### PR TITLE
added preupdate hook for user admin

### DIFF
--- a/Admin/Entity/UserAdmin.php
+++ b/Admin/Entity/UserAdmin.php
@@ -17,6 +17,8 @@ use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Route\RouteCollection;
 
+use FOS\UserBundle\Model\UserManagerInterface;
+
 class UserAdmin extends Admin
 {
 
@@ -69,5 +71,21 @@ class UserAdmin extends Admin
         ), array(
             'type' => 'choice'
         ));
+    }
+    
+    public function preUpdate($user)
+    {
+        $this->getUserManager()->updateCanonicalFields($user);
+        $this->getUserManager()->updatePassword($user);
+    }
+    
+    public function setUserManager(UserManagerInterface $userManager)
+    {
+        $this->userManager = $userManager;
+    }
+    
+    public function getUserManager()
+    {
+        return $this->userManager;
     }
 }

--- a/Resources/config/admin_orm.xml
+++ b/Resources/config/admin_orm.xml
@@ -21,6 +21,9 @@
             <argument />
             <argument>%sonata.user.admin.user.entity%</argument>
             <argument />
+            <call method="setUserManager">
+                <argument type="service" id="fos_user.user_manager" />
+            </call>
         </service>
 
         <service id="sonata.user.admin.group" class="%sonata.user.admin.group.class%">


### PR DESCRIPTION
Without this hook, modifications of username and password are not effective : `updateCanonicalFields()` and `updatePassword()` have to be called after modifications.
