### PR TITLE
added parameters for labels and groups fields of admin services

### DIFF
--- a/Resources/config/admin_orm.xml
+++ b/Resources/config/admin_orm.xml
@@ -8,23 +8,30 @@
         <parameter key="sonata.user.admin.user.class">Sonata\UserBundle\Admin\Entity\UserAdmin</parameter>
         <parameter key="sonata.user.admin.user.controller"></parameter>
         <parameter key="sonata.user.admin.user.entity">Application\Sonata\UserBundle\Entity\User</parameter>
-
+        <parameter key="sonata.user.admin.user.label">Users</parameter>
+    
         <!-- GROUP -->
         <parameter key="sonata.user.admin.group.class">Sonata\UserBundle\Admin\Entity\GroupAdmin</parameter>
         <parameter key="sonata.user.admin.group.controller"></parameter>
         <parameter key="sonata.user.admin.group.entity">Application\Sonata\UserBundle\Entity\Group</parameter>
+        <parameter key="sonata.user.admin.group.label">Groups</parameter>
+
+        <parameter key="sonata.user.admin.groupname">FOS User</parameter>
     </parameters>
 
     <services>
         <service id="sonata.user.admin.user" class="%sonata.user.admin.user.class%">
-            <tag name="sonata.admin" manager_type="orm" group="fos_user" />
+            <tag name="sonata.admin" manager_type="orm" group="%sonata.user.admin.groupname%" label="%sonata.user.admin.user.label%" />
             <argument />
             <argument>%sonata.user.admin.user.entity%</argument>
             <argument />
+            <call method="setUserManager">
+                <argument type="service" id="fos_user.user_manager" />
+            </call>
         </service>
 
         <service id="sonata.user.admin.group" class="%sonata.user.admin.group.class%">
-            <tag name="sonata.admin" manager_type="orm" group="fos_user"/>
+            <tag name="sonata.admin" manager_type="orm" group="%sonata.user.admin.groupname%" label="%sonata.user.admin.group.label%" />
             <argument />
             <argument>%sonata.user.admin.group.entity%</argument>
             <argument />


### PR DESCRIPTION
To make labels and groups name easily changeable in project configuration. By default, labels are `-`, which is not very descriptive.
