### PR TITLE
fixed bug in role list

### DIFF
--- a/Form/Type/SecurityRolesType.php
+++ b/Form/Type/SecurityRolesType.php
@@ -47,12 +47,14 @@ class SecurityRolesType extends ChoiceType
 
             // get roles from the service container
             foreach ($this->pool->getContainer()->getParameter('security.role_hierarchy.roles') as $name => $rolesHierarchy) {
-                $roles[$name] = $name;
+                $roles[$name] = $name . ': ' . implode(', ', $rolesHierarchy);
+                
                 foreach ($rolesHierarchy as $role) {
                     if (!isset($roles[$role])) {
-                        $roles[$role] = ' -- '.$role;
+                        $roles[$role] = $role;
                     }
                 }
+                
             }
 
             $options['choices'] = $roles;


### PR DESCRIPTION
For role hierarchy like this one :

```
role_hierarchy:
    ROLE_A: [ROLE_1, ROLE_2]
    ROLE_B: [ROLE_1, ROLE_3]
```

the current code is displaying :

```
ROLE_A
-- ROLE_1
-- ROLE_2
ROLE_B
-- ROLE_3
```

This is not clear in that list that `ROLE_B` has `ROLE_3` **and** `ROLE_1`. The proposed change displays one line per role and showing all the sub-roles of a role :

```
ROLE_A: ROLE_1, ROLE_2
ROLE_1
ROLE_2
ROLE_B: ROLE_1, ROLE_3
ROLE_3
```
