### PR TITLE
two_step_code fatal error fix

### DIFF
--- a/Resources/config/doctrine/BaseUser.orm.xml
+++ b/Resources/config/doctrine/BaseUser.orm.xml
@@ -7,7 +7,7 @@
     <mapped-superclass name="Sonata\UserBundle\Entity\BaseUser">
         <field name="createdAt"    type="datetime"   column="created_at" />
         <field name="updatedAt"    type="datetime"   column="updated_at" />
-        <field name="twoStepVerificationCode" type="string" length="255" column="two_step_code" />
+        <field name="twoStepVerificationCode" type="string" length="255" column="two_step_code" nullable="true" />
 
         <lifecycle-callbacks>
             <lifecycle-callback type="prePersist" method="prePersist" />


### PR DESCRIPTION
When creating a new user with the FosUserBundles `fos:user:create` command, a fatal error was thrown:

```
SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'two_step_code' cannot be null
```

This PR allows `two_step_code` to be `null`.
