### PR TITLE
Fixes a bug when trying to export a user

### DIFF
--- a/Entity/BaseUser.php
+++ b/Entity/BaseUser.php
@@ -63,6 +63,16 @@ class BaseUser extends AbstractedUser implements UserInterface
     {
         return $this->updatedAt;
     }
+    
+    /**
+     * Get ExpiresAt
+     * 
+     * @return \DateTime|null
+     */
+    public function getExpiresAt()
+    {
+        return $this->expiresAt;
+    }
 
     /**
      * @return void


### PR DESCRIPTION
In reference to PR 35 of SonataSandbox : there was a bug in the exporter, preventing it from working as a getter for the èxpiresAt` field was absent.

Note, you should also merge it into 2.0.
