### PR TITLE
General, Management - polish translation

### DIFF
--- a/Resources/translations/SonataUserBundle.pl.xliff
+++ b/Resources/translations/SonataUserBundle.pl.xliff
@@ -162,6 +162,22 @@
                 <source>sonata_user</source>
                 <target>Użytkownicy</target>
             </trans-unit>
+            <trans-unit id="form_general">
+                <source>General</source>
+                <target>Ogólne</target>
+            </trans-unit>
+            <trans-unit id="form_groups">
+                <source>Groups</source>
+                <target>Grupy</target>
+            </trans-unit>
+            <trans-unit id="form_management">
+                <source>Management</source>
+                <target>Uprawnienia</target>
+            </trans-unit>
+            <trans-unit id="field.label_roles_editable">
+                <source>field.label_roles_editable</source>
+                <target>Zaznacz uprawnienia użytkownika</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
Is there any special reason why fr, pt, ru etc. translations do not include General & Management labels?

Anyway, here is polish translation for them.
