### PR TITLE
Fix SF 2.1 Form compatibility

### DIFF
--- a/Form/Type/SecurityRolesType.php
+++ b/Form/Type/SecurityRolesType.php
@@ -30,7 +30,7 @@ class SecurityRolesType extends ChoiceType
     /**
      * {@inheritdoc}
      */
-    public function buildForm(FormBuilder $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options)
     {
         parent::buildForm($builder, $options);
 


### PR DESCRIPTION
Incompatibility on the buildForm method (Need to use `FormBuilderInterface` instead of `FormBuilder` in the argument list)
