### PR TITLE
Fix bad method and cyclic dependency (BC 2.1)

### DIFF
--- a/Form/Type/SecurityRolesType.php
+++ b/Form/Type/SecurityRolesType.php
@@ -53,7 +53,7 @@ class SecurityRolesType extends ChoiceType
             $attr['class'] = 'sonata-medium';
         }
 
-        $view->setVars(array(
+        $view->addVars(array(
             'attr' => $attr,
             'read_only_choices' => $options['read_only_choices']
         ));
@@ -109,8 +109,8 @@ class SecurityRolesType extends ChoiceType
         }
         
         $resolver->setDefaults(array(
-            'choices' => function (Options $options) use ($roles) {
-                return empty($options['choices']) ? $roles : array();
+            'choices' => function (Options $options, $parentChoices) use ($roles) {
+                return empty($parentChoices) ? $roles : array();
             },
               
             'read_only_choices' => function (Options $options) use ($rolesReadOnly) {


### PR DESCRIPTION
Fixes for issues noted by @lopsided in #93 and #92. I have one question: why does the setDefaultOptions function set 'choices' and 'read_only_choices' to array() if the parent type has and default 'choices' set? I just don't really understand why this is done, but the attached code mirrors the functionality from the 2.0 branch, so this PR maintains the intended (and in my opinion, suspect) behaviour.
