### PR TITLE
Moved FOSUserBundle from "required" to "suggest"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,12 +20,12 @@
         "php": ">=5.3.2",
         "symfony/framework-bundle": "2.1.*",
         "sonata-project/admin-bundle": "dev-master",
-        "friendsofsymfony/user-bundle": "dev-master",
         "sonata-project/doctrine-extensions": "dev-master",
         "sonata-project/easy-extends-bundle": "dev-master"
     },
     "suggest": {
-        "sonata-project/doctrine-orm-admin-bundle": "dev-master"
+        "sonata-project/doctrine-orm-admin-bundle": "dev-master",
+        "friendsofsymfony/user-bundle": "If you want to use the FOSUserBundle"
     },
     "autoload": {
         "psr-0": { "Sonata\\UserBundle": "" }


### PR DESCRIPTION
Since using the FOSUserBundle is not mandatory, it is a little bit strange it is required when using Composer. Furthermore when using a custom fork of FOSUserBundle in your project, SonataUserBundle can't be installed because of dependency errors. If you're planning to use the SonataUserBundle seperate from FOSUserBundle this doesn't make sense.
