### PR TITLE
Added missing translation for DE

### DIFF
--- a/Resources/translations/SonataUserBundle.de.xliff
+++ b/Resources/translations/SonataUserBundle.de.xliff
@@ -130,6 +130,10 @@
                 <source>list.label_email</source>
                 <target>E-Mail-Adresse</target>
             </trans-unit>
+            <trans-unit id="list.label_groups">
+                <source>list.label_groups</source>
+                <target>Gruppen</target>
+            </trans-unit>
             <trans-unit id="list.label_locked">
                 <source>list.label_locked</source>
                 <target>Gesperrt</target>


### PR DESCRIPTION
Translation for `list.label_groups` has been missing.
