### PR TITLE
Can't remove user/group (FOREIGN KEY Constraints)

### DIFF
--- a/DependencyInjection/SonataUserExtension.php
+++ b/DependencyInjection/SonataUserExtension.php
@@ -229,11 +229,13 @@ class SonataUserExtension extends Extension
                     array(
                         'name' => 'user_id',
                         'referencedColumnName' => 'id',
+                        'onDelete' => 'CASCADE'
                     ),
                 ),
                 'inverseJoinColumns' => array( array(
                     'name' => 'group_id',
                     'referencedColumnName' => 'id',
+                    'onDelete' => 'CASCADE'
                 )),
             )
         ));


### PR DESCRIPTION
Added : onDelete CASCADE on both sides of the user/group relation, in order to be able to delete a user having a group or a group having users.
