### PR TITLE
Add ext-intl dependency to the composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "sonata-project/doctrine-extensions": "dev-master",
         "sonata-project/easy-extends-bundle": "dev-master",
         "sonata-project/google-authenticator": "dev-master",
-    	"ext-intl": "*"
+        "ext-intl": "*"
     },
 
     "suggest": {


### PR DESCRIPTION
If I open the user entity to edit in admin panel, I get error "Fatal error: Class 'ResourceBundle' not found ...". It looks like missed php-intl extension on my local PC. So, I included it to composer.json as required package.

I did not found any references to "SonataIntlBundle" in the source code, which depends on ext-int. Otherwise, I would include it instead of "ext-intl".
