### PR TITLE
Update translation for some form labels in russian

### DIFF
--- a/Resources/translations/SonataUserBundle.ru.xliff
+++ b/Resources/translations/SonataUserBundle.ru.xliff
@@ -100,7 +100,7 @@
             </trans-unit>
             <trans-unit id="form.label_firstname">
                 <source>form.label_firstname</source>
-    		<target>Имя</target>
+                <target>Имя</target>
             </trans-unit>
             <trans-unit id="form.label_lastname">
                 <source>form.label_lastname</source>


### PR DESCRIPTION
Also, it looks that some translation units like "label_two_step_verification_code" are splitted into "form.label_two_step_verification_code" and "show.label_two_step_verification_code". I did not remove such keys in the translation file.
