### PR TITLE
delete duplicate translation keys

### DIFF
--- a/Resources/translations/SonataUserBundle.ru.xliff
+++ b/Resources/translations/SonataUserBundle.ru.xliff
@@ -362,14 +362,6 @@
                 <source>form.label_date_of_birth</source>
                 <target>Дата рождения</target>
             </trans-unit>
-            <trans-unit id="form.label_firstname">
-                <source>form.label_firstname</source>
-                <target>Имя</target>
-            </trans-unit>
-            <trans-unit id="form.label_lastname">
-                <source>form.label_lastname</source>
-                <target>Фамилия</target>
-            </trans-unit>
             <trans-unit id="field.label_roles_editable">
                 <source>field.label_roles_editable</source>
                 <target>Роли</target>


### PR DESCRIPTION
Remove duplicate Russian translations

before the following error: 
An exception has been thrown during the rendering of a template ("[ERROR 94] Validation failed: no DTD found ! (in n/a - line 2, column 21)
[ERROR 1877] Element '{urn:oasis:names:tc:xliff:document:1.2}trans-unit': Duplicate key-sequence ['form.label_firstname'] in key identity-constraint '{urn:oasis:names:tc:xliff:document:1.2}K_unit_id'. (in /private/var/www/history/web/ - line 365, column 0)
[ERROR 1877] Element '{urn:oasis:names:tc:xliff:document:1.2}trans-unit': Duplicate key-sequence ['form.label_lastname'] in key identity-constraint '{urn:oasis:names:tc:xliff:document:1.2}K_unit_id'. (in /private/var/www/history/web/ - line 369, column 0)") in ArmdEventBundle:Event:tapeTime.html.twig at line 4.
