### PR TITLE
Documentation for MongoDB is incomplete and out of date

### DIFF
--- a/Resources/doc/reference/advanced_configuration.rst
+++ b/Resources/doc/reference/advanced_configuration.rst
@@ -6,7 +6,7 @@ Full configuration options:
 .. code-block:: yaml
 
     fos_user:
-        db_driver:        orm # can be orm or odm
+        db_driver:        orm # can be orm or mongodb (support is also available within FOSUser for couchdb, propel but none is given for SonataUserBundle)
         firewall_name:    main
         user_class:       Application\Sonata\UserBundle\Entity\User
 
@@ -21,6 +21,8 @@ Full configuration options:
 
     sonata_user:
         security_acl:           false
+
+		manager_type: orm # Can be orm for mongodb
 
         table:
             user_group: "my_custom_user_group_association_table_name"

--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -62,6 +62,7 @@ of ``super-admin`` users, to enable this add to the configuration:
     # app/config/config.yml
     sonata_user:
         security_acl: true
+		manager_type: orm # can be orm or mongodb
 
 
     # app/config/security.yml


### PR DESCRIPTION
Have added documentation for MongoDB and updated the options for FOSUser as it no longer supports the ODM option.
