### PR TITLE
Added support for MongoDB with EasyExtends

### DIFF
--- a/Resources/config/doctrine/Group.mongodb.xml.skeleton
+++ b/Resources/config/doctrine/Group.mongodb.xml.skeleton
@@ -4,7 +4,7 @@
       xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
                     http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
 
-    <document name="Application\Sonata\UserBundle\Entity\Group" collection="fos_user_group">
+    <document name="Application\Sonata\UserBundle\Document\Group" collection="fos_user_group">
 
 		<field fieldName="id" id="true" strategy="INCREMENT" />
         

--- a/Resources/config/doctrine/User.mongodb.xml.skeleton
+++ b/Resources/config/doctrine/User.mongodb.xml.skeleton
@@ -4,7 +4,7 @@
       xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
                     http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
 
-    <document name="Application\Sonata\UserBundle\Entity\User" collection="fos_user_user" customId="true">
+    <document name="Application\Sonata\UserBundle\Document\User" collection="fos_user_user" customId="true">
 
         <field fieldName="id" id="true" strategy="INCREMENT" />
 


### PR DESCRIPTION
Users will have to delete either the entity directory and mapping for ODM or document directory and mapping for ORM. Couldn't think of an easier way of doing this but at least the documents are now actually created!
