### PR TITLE
fixed composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,14 +21,14 @@
         "symfony/form": ">=2.1,<2.3-dev",
         "symfony/security": ">=2.1,<2.3-dev",
         "symfony/console": ">=2.1,<2.3-dev",
-        "sonata-project/admin-bundle": ">=2.1.*@dev,<2.3-dev",
+        "sonata-project/admin-bundle": ">=2.1@dev,<2.3-dev",
         "friendsofsymfony/user-bundle": "1.3.*",
         "sonata-project/doctrine-extensions": "1.*",
         "sonata-project/easy-extends-bundle": "2.1.*",
         "sonata-project/google-authenticator": "1.*"
     },
     "suggest": {
-        "sonata-project/doctrine-orm-admin-bundle": ">=2.1.*@dev,<2.3-dev"
+        "sonata-project/doctrine-orm-admin-bundle": ">=2.1@dev,<2.3-dev"
     },
     "autoload": {
         "psr-0": { "Sonata\\UserBundle": "" }


### PR DESCRIPTION
Wildcards are not valid with comparisons

http://getcomposer.org/doc/faqs/why-are-version-constraints-combining-comparisons-and-wildcards-a-bad-idea.md
