### PR TITLE
Adding event dispatcher in request listener

### DIFF
--- a/GoogleAuthenticator/RendererEvents.php
+++ b/GoogleAuthenticator/RendererEvents.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Sonata project.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\GoogleAuthenticator;
+
+final class RendererEvents
+{
+    const DISPLAY_FORM = 'google.authenticator.display_form';
+}

--- a/GoogleAuthenticator/RendererListener.php
+++ b/GoogleAuthenticator/RendererListener.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Sonata project.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\GoogleAuthenticator;
+
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+
+class RendererListener
+{
+    protected $templating;
+
+    protected $view;
+
+    /**
+     * Constructor.
+     *
+     * @param EngineInterface $templating Template engine
+     * @param string          $view       The view name
+     */
+    public function __construct(EngineInterface $templating, $view)
+    {
+        $this->templating = $templating;
+        $this->view = $view;
+    }
+
+    /**
+     * Sets render google step in response.
+     *
+     * @param RequestEvent $event
+     */
+    public function onRender(RequestEvent $event)
+    {
+        $event->setResponse($this->templating->renderResponse($this->view,
+            array('state' => $event->getState())
+        ));
+    }
+}

--- a/GoogleAuthenticator/RequestEvent.php
+++ b/GoogleAuthenticator/RequestEvent.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Sonata project.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\GoogleAuthenticator;
+
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * RequestEvent
+ */
+class RequestEvent extends Event
+{
+    protected $state;
+
+    protected $response;
+
+    /**
+     * Constructor.
+     *
+     * @param string $state Request result
+     */
+    public function __construct($state)
+    {
+        $this->state = $state;
+    }
+
+    /**
+     * @return string
+     */
+    public function getState()
+    {
+        return $this->state;
+    }
+
+    /**
+     * @param Response $response
+     */
+    public function setResponse(Response $response)
+    {
+        $this->response = $response;
+    }
+
+    /**
+     * @return Response
+     */
+    public function getResponse()
+    {
+        return $this->response;
+    }
+}

--- a/GoogleAuthenticator/RequestListener.php
+++ b/GoogleAuthenticator/RequestListener.php
@@ -14,7 +14,6 @@ namespace Sonata\UserBundle\GoogleAuthenticator;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\Security\Core\SecurityContextInterface;
-use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 
 class RequestListener
 {
@@ -22,18 +21,14 @@ class RequestListener
 
     protected $securityContext;
 
-    protected $templating;
-
     /**
      * @param Helper                                                     $helper
      * @param \Symfony\Component\Security\Core\SecurityContextInterface  $securityContext
-     * @param \Symfony\Bundle\FrameworkBundle\Templating\EngineInterface $templating
      */
-    public function __construct(Helper $helper, SecurityContextInterface $securityContext, EngineInterface $templating)
+    public function __construct(Helper $helper, SecurityContextInterface $securityContext)
     {
         $this->helper = $helper;
         $this->securityContext = $securityContext;
-        $this->templating = $templating;
     }
 
     /**
@@ -76,8 +71,10 @@ class RequestListener
             $state = 'error';
         }
 
-        $event->setResponse($this->templating->renderResponse('SonataUserBundle:Admin:Security/two_step_form.html.twig', array(
-            'state' => $state
-         )));
+        $requestEvent = new RequestEvent($state);
+
+        $event->getDispatcher()->dispatch(RendererEvents::DISPLAY_FORM, $requestEvent);
+
+        $event->setResponse($requestEvent->getResponse());
     }
 }

--- a/Resources/config/google_authenticator.xml
+++ b/Resources/config/google_authenticator.xml
@@ -4,6 +4,10 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
+    <parameters>
+        <parameter key="sonata.user.security.two_step_form.view">SonataUserBundle:Admin:Security/two_step_form.html.twig</parameter>
+    </parameters>
+
     <services>
         <service id="sonata.user.google.authenticator" class="Google\Authenticator\GoogleAuthenticator">
 
@@ -25,7 +29,13 @@
 
             <argument type="service" id="sonata.user.google.authenticator.provider" />
             <argument type="service" id="security.context" />
+        </service>
+
+        <service id="sonata.user.google.authenticator.renderer_event" class="Sonata\UserBundle\GoogleAuthenticator\RendererListener">
+            <tag name="kernel.event_listener" event="google.authenticator.display_form" method="onRender" />
+
             <argument type="service" id="templating" />
+            <argument>%sonata.user.security.two_step_form.view%</argument>
         </service>
 
     </services>


### PR DESCRIPTION
Is fixed backward.

With new event, request listener no longer depends directly templating.

Thereby it is compatible with template manager of sonata page.
