### PR TITLE
Add a real roles method because of FOSUserBundle

### DIFF
--- a/Admin/Model/UserAdmin.php
+++ b/Admin/Model/UserAdmin.php
@@ -137,7 +137,7 @@ class UserAdmin extends Admin
         if (!$this->getSubject()->hasRole('ROLE_SUPER_ADMIN')) {
             $formMapper
                 ->with('Management')
-                    ->add('roles', 'sonata_security_roles', array(
+                    ->add('realRoles', 'sonata_security_roles', array(
                         'expanded' => true,
                         'multiple' => true,
                         'required' => false

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,16 @@
 CHANGELOG
 =========
 
+### [BC BREAK] 2013-05-06
+
+* User's groups roles are not merged anymore when editing `User` entity. A `getRealRoles()` method has been
+  added in `Sonata\UserBundle\Model\User` and is now used in `Sonata\UserBundle\Admin\UserAdmin`.
+
+  If you still want to merge user's groups roles, you can:
+
+     * add a `getRealRoles()` in your entity by overriding `Sonata\UserBundle\Model\User` method and
+       referencing `getRoles()` parent method
+
 ### 2012-09-24
 
 * changed service parameters into options that come through the configuration with the old values as the new defaults.

--- a/Model/User.php
+++ b/Model/User.php
@@ -552,4 +552,20 @@ abstract class User extends AbstractedUser implements UserInterface
     {
         return sprintf("%s %s", $this->getFirstname(), $this->getLastname());
     }
+
+    /**
+     * @return array
+     */
+    public function getRealRoles()
+    {
+        return $this->roles;
+    }
+
+    /**
+     * @param array $roles
+     */
+    public function setRealRoles(array $roles)
+    {
+        $this->setRoles($roles);
+    }
 }


### PR DESCRIPTION
### Reason:

`FOS\UserBundle\Model\User` model is merging user's groups roles in `getRoles()` method:

``` php
    /**
     * Returns the user roles
     *
     * @return array The roles
     */
    public function getRoles()
    {
        $roles = $this->roles;

        foreach ($this->getGroups() as $group) {
            $roles = array_merge($roles, $group->getRoles());
        }

        // we need to make sure to have at least one role
        $roles[] = static::ROLE_DEFAULT;

        return array_unique($roles);
    }
```

So when `UserAdmin` calls `getRoles()` method to display admin form (when editing a user), user's groups roles are checked too.
### Solution:

A `getRealRoles()` method has been added to `Sonata\UserBundle\Model\User` model and is now used into `UserAdmin` class.
