### PR TITLE
Remove invalid birthday type from show

### DIFF
--- a/Admin/Model/UserAdmin.php
+++ b/Admin/Model/UserAdmin.php
@@ -75,7 +75,7 @@ class UserAdmin extends Admin
                 ->add('groups')
             ->end()
             ->with('Profile')
-                ->add('dateOfBirth', 'birthday')
+                ->add('dateOfBirth')
                 ->add('firstname')
                 ->add('lastname')
                 ->add('website')


### PR DESCRIPTION
This type throws an exception and is useless as a datetime will be guessed by default.
