### PR TITLE
This would solve the problem when using the current FOSUserBundle 2.x

### DIFF
--- a/DependencyInjection/SonataUserExtension.php
+++ b/DependencyInjection/SonataUserExtension.php
@@ -247,8 +247,8 @@ class SonataUserExtension extends Extension
      */
     public function configureShortcut(ContainerBuilder $container)
     {
-        $container->setAlias('sonata.user.authentication.form', 'fos_user.profile.form');
-        $container->setAlias('sonata.user.authentication.form_handler', 'fos_user.profile.form.handler');
+        $container->setAlias('sonata.user.authentication.form', 'fos_user.profile.form.factory');
+        $container->setAlias('sonata.user.authentication.form_handler', 'fos_user.profile.form.type');
     }
 
     /**


### PR DESCRIPTION
Using SonataUserBundle with FOSUserBundle 2.x causes

[Symfony\Component\DependencyInjection\Exception\InvalidArgumentException]
  Unable to replace alias "fos_user.profile.form" with "sonata.user.authentic
  ation.form".

This naive adjustment seems to solve the problem.

I cannot use the approach to alias FUB 1.3 as dev-master in my composer.json file, since I want to use it with the SecurityHandler Support.

Are there any consideration to provide a version that supports FOSUserBundle 2.x?
