### PR TITLE
Fix error new group originalRoles null condition

### DIFF
--- a/Form/Type/SecurityRolesType.php
+++ b/Form/Type/SecurityRolesType.php
@@ -53,12 +53,12 @@ class SecurityRolesType extends AbstractType
 
         // GET METHOD
         $formBuilder->addEventListener(FormEvents::PRE_SET_DATA, function(FormEvent $event) use ($tranformer) {
-            $tranformer->setOriginalRoles($event->getData());
+            $tranformer->setOriginalRoles($event->getData() ? $event->getData() : array());
         });
 
         // POST METHOD
         $formBuilder->addEventListener(FormEvents::PRE_BIND, function(FormEvent $event) use ($tranformer) {
-            $tranformer->setOriginalRoles($event->getForm()->getData());
+            $tranformer->setOriginalRoles($event->getData() ? $event->getData() : array());
         });
 
         $formBuilder->addModelTransformer($tranformer);


### PR DESCRIPTION
I'm not sure if this should be fixed here or in the RestoreRolesTransformer but new Groups have no roles associated with them (and its also perfectly valid for existing groups to have no roles associated with them) so the treatment of null as an exception in RestoreRolesTransformer seems incorrect and it causes an exception. Specifically when you use the 'Add Group' button when administering a user you cannot ever create new groups because of this behavior (the group is created but the user sees an error).
