### PR TITLE
SONATA-323 - Enable modal for user enabled & locked fields

### DIFF
--- a/Admin/Model/UserAdmin.php
+++ b/Admin/Model/UserAdmin.php
@@ -60,8 +60,14 @@ class UserAdmin extends Admin
             ->addIdentifier('username')
             ->add('email')
             ->add('groups')
-            ->add('enabled', null, array('editable' => true))
-            ->add('locked', null, array('editable' => true))
+            ->add('enabled', null, array(
+                'editable'     => true,
+                'confirmation' => true,
+            ))
+            ->add('locked', null, array(
+                'editable'     => true,
+                'confirmation' => true,
+            ))
             ->add('createdAt')
         ;
 


### PR DESCRIPTION
Added confirmation modal for user `enabled` & `locked` fields in administration list template.

Merge or the following PR is needed before: sonata-project/SonataAdminBundle#1873
