### PR TITLE
fixed PHP Strict standards:  Declaration error.

### DIFF
--- a/Controller/RegistrationController.php
+++ b/Controller/RegistrationController.php
@@ -15,6 +15,7 @@ use FOS\UserBundle\Controller\RegistrationController as BaseController;
 use FOS\UserBundle\Model\UserInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Class RegistrationController
@@ -42,9 +43,9 @@ class RegistrationController extends BaseController
     /**
      * {@inheritdoc}
      */
-    public function registerAction()
+    public function registerAction(Request $request)
     {
-        $response = parent::registerAction();
+        $response = parent::registerAction($request);
 
         if ($response instanceof RedirectResponse && ($url = $this->container->get('session')->get('sonata_user_redirect_url'))) {
             // Form has been submitted and we're redirected...


### PR DESCRIPTION
Patch for error:

Declaration of Sonata\UserBundle\Controller\RegistrationController::registerAction() should be compatible with FOS\UserBundle\Controller\RegistrationController::registerAction(Symfony\Component\HttpFoundation\Request $request) 
