### PR TITLE
Update composer.json - FOSUser master branch is in 2.0 version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "symfony/console": "~2.2",
         "sonata-project/core-bundle": "~2.2",
         "sonata-project/admin-bundle": "~2.2,>=2.2.9",
-        "friendsofsymfony/user-bundle": "~1.3",
+        "friendsofsymfony/user-bundle": "~2.0",
         "sonata-project/doctrine-extensions": "~1.0",
         "sonata-project/easy-extends-bundle": "~2.1",
         "sonata-project/google-authenticator": "~1.0"


### PR DESCRIPTION
Last modifications are dependants of the master fos user bundle which is the 2.0 version, not the 1.3 any more.

By example :

https://github.com/sonata-project/SonataUserBundle/blob/master/Controller/RegistrationController.php#L46

Not compatible with 1.3 : 
https://github.com/FriendsOfSymfony/FOSUserBundle/blob/v1.3.3/Controller/RegistrationController.php#L30

Compatible with master (2.0) : 
https://github.com/FriendsOfSymfony/FOSUserBundle/blob/master/Controller/RegistrationController.php#L34
