### PR TITLE
Add flash message for /login and /register pages

### DIFF
--- a/Controller/AdminSecurityController.php
+++ b/Controller/AdminSecurityController.php
@@ -14,6 +14,7 @@ namespace Sonata\UserBundle\Controller;
 use Symfony\Component\DependencyInjection\ContainerAware;
 use Symfony\Component\Security\Core\SecurityContext;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use FOS\UserBundle\Model\UserInterface;
 
 class AdminSecurityController extends ContainerAware
 {
@@ -22,6 +23,15 @@ class AdminSecurityController extends ContainerAware
      */
     public function loginAction()
     {
+        $user = $this->container->get('security.context')->getToken()->getUser();
+
+        if ($user instanceof UserInterface) {
+            $this->container->get('session')->getFlashBag()->set('sonata_user_error', 'sonata_user_already_authenticated');
+            $url = $this->container->get('router')->generate('sonata_user_profile_show');
+
+            return new RedirectResponse($url);
+        }
+
         $request = $this->container->get('request');
         /* @var $request \Symfony\Component\HttpFoundation\Request */
         $session = $request->getSession();

--- a/Controller/RegistrationFOSUser1Controller.php
+++ b/Controller/RegistrationFOSUser1Controller.php
@@ -33,6 +33,15 @@ class RegistrationFOSUser1Controller extends ContainerAware
 {
     public function registerAction()
     {
+        $user = $this->container->get('security.context')->getToken()->getUser();
+
+        if ($user instanceof UserInterface) {
+            $this->container->get('session')->getFlashBag()->set('sonata_user_error', 'sonata_user_already_authenticated');
+            $url = $this->container->get('router')->generate('sonata_user_profile_show');
+
+            return new RedirectResponse($url);
+        }
+
         $form = $this->container->get('fos_user.registration.form');
         $formHandler = $this->container->get('fos_user.registration.form.handler');
         $confirmationEnabled = $this->container->getParameter('fos_user.registration.confirmation.enabled');

--- a/Controller/SecurityFOSUser1Controller.php
+++ b/Controller/SecurityFOSUser1Controller.php
@@ -12,7 +12,8 @@
 namespace Sonata\UserBundle\Controller;
 
 use FOS\UserBundle\Controller\SecurityController;
-
+use Sonata\UserBundle\Model\UserInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 
 /**
  * Class SecurityFOSUser1Controller
@@ -23,5 +24,17 @@ use FOS\UserBundle\Controller\SecurityController;
  */
 class SecurityFOSUser1Controller extends SecurityController
 {
+    public function loginAction()
+    {
+        $user = $this->container->get('security.context')->getToken()->getUser();
 
+        if ($user instanceof UserInterface) {
+            $this->container->get('session')->getFlashBag()->set('sonata_user_error', 'sonata_user_already_authenticated');
+            $url = $this->container->get('router')->generate('sonata_user_profile_show');
+
+            return new RedirectResponse($url);
+        }
+
+        return parent::loginAction();
+    }
 }

--- a/Resources/translations/SonataUserBundle.bg.xliff
+++ b/Resources/translations/SonataUserBundle.bg.xliff
@@ -278,6 +278,10 @@
                 <source>sonata_user_profile_breadcrumb_edit</source>
                 <target>sonata_user_profile_breadcrumb_edit</target>
             </trans-unit>
+            <trans-unit id="sonata_user_already_authenticated">
+                <source>sonata_user_already_authenticated</source>
+                <target>You are already logged in</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataUserBundle.ca.xliff
+++ b/Resources/translations/SonataUserBundle.ca.xliff
@@ -470,6 +470,10 @@
                 <source>sonata_user_profile_breadcrumb_edit</source>
                 <target>sonata_user_profile_breadcrumb_edit</target>
             </trans-unit>
+            <trans-unit id="sonata_user_already_authenticated">
+                <source>sonata_user_already_authenticated</source>
+                <target>You are already logged in</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataUserBundle.cs.xliff
+++ b/Resources/translations/SonataUserBundle.cs.xliff
@@ -426,6 +426,10 @@
                 <source>sonata_user_profile_breadcrumb_edit</source>
                 <target>sonata_user_profile_breadcrumb_edit</target>
             </trans-unit>
+            <trans-unit id="sonata_user_already_authenticated">
+                <source>sonata_user_already_authenticated</source>
+                <target>You are already logged in</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataUserBundle.de.xliff
+++ b/Resources/translations/SonataUserBundle.de.xliff
@@ -567,6 +567,10 @@
                 <source>sonata_user_profile_breadcrumb_edit</source>
                 <target>sonata_user_profile_breadcrumb_edit</target>
             </trans-unit>
+            <trans-unit id="sonata_user_already_authenticated">
+                <source>sonata_user_already_authenticated</source>
+                <target>You are already logged in</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataUserBundle.en.xliff
+++ b/Resources/translations/SonataUserBundle.en.xliff
@@ -502,6 +502,10 @@
                 <source>sonata_user_profile_breadcrumb_edit</source>
                 <target>Edit profile</target>
             </trans-unit>
+            <trans-unit id="sonata_user_already_authenticated">
+                <source>sonata_user_already_authenticated</source>
+                <target>You are already logged in</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataUserBundle.es.xliff
+++ b/Resources/translations/SonataUserBundle.es.xliff
@@ -474,6 +474,10 @@
                 <source>sonata_user_profile_breadcrumb_edit</source>
                 <target>sonata_user_profile_breadcrumb_edit</target>
             </trans-unit>
+            <trans-unit id="sonata_user_already_authenticated">
+                <source>sonata_user_already_authenticated</source>
+                <target>You are already logged in</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataUserBundle.fa.xliff
+++ b/Resources/translations/SonataUserBundle.fa.xliff
@@ -474,6 +474,10 @@
                 <source>sonata_user_profile_breadcrumb_edit</source>
                 <target>sonata_user_profile_breadcrumb_edit</target>
             </trans-unit>
+            <trans-unit id="sonata_user_already_authenticated">
+                <source>sonata_user_already_authenticated</source>
+                <target>You are already logged in</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataUserBundle.fr.xliff
+++ b/Resources/translations/SonataUserBundle.fr.xliff
@@ -514,6 +514,10 @@
                 <source>sonata_user_profile_breadcrumb_edit</source>
                 <target>Editer votre profil</target>
             </trans-unit>
+            <trans-unit id="sonata_user_already_authenticated">
+                <source>sonata_user_already_authenticated</source>
+                <target>Vous êtes déjà identifiés</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataUserBundle.it.xliff
+++ b/Resources/translations/SonataUserBundle.it.xliff
@@ -426,6 +426,10 @@
                 <source>sonata_user_profile_breadcrumb_edit</source>
                 <target>sonata_user_profile_breadcrumb_edit</target>
             </trans-unit>
+            <trans-unit id="sonata_user_already_authenticated">
+                <source>sonata_user_already_authenticated</source>
+                <target>You are already logged in</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataUserBundle.lt.xliff
+++ b/Resources/translations/SonataUserBundle.lt.xliff
@@ -502,6 +502,10 @@
                 <source>sonata_user_profile_breadcrumb_edit</source>
                 <target>sonata_user_profile_breadcrumb_edit</target>
             </trans-unit>
+            <trans-unit id="sonata_user_already_authenticated">
+                <source>sonata_user_already_authenticated</source>
+                <target>You are already logged in</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataUserBundle.nl.xliff
+++ b/Resources/translations/SonataUserBundle.nl.xliff
@@ -526,6 +526,10 @@
                 <source>sonata_user_profile_breadcrumb_edit</source>
                 <target>sonata_user_profile_breadcrumb_edit</target>
             </trans-unit>
+            <trans-unit id="sonata_user_already_authenticated">
+                <source>sonata_user_already_authenticated</source>
+                <target>You are already logged in</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataUserBundle.pl.xliff
+++ b/Resources/translations/SonataUserBundle.pl.xliff
@@ -474,6 +474,10 @@
                 <source>sonata_user_profile_breadcrumb_edit</source>
                 <target>sonata_user_profile_breadcrumb_edit</target>
             </trans-unit>
+            <trans-unit id="sonata_user_already_authenticated">
+                <source>sonata_user_already_authenticated</source>
+                <target>You are already logged in</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataUserBundle.pt.xliff
+++ b/Resources/translations/SonataUserBundle.pt.xliff
@@ -426,6 +426,10 @@
                 <source>sonata_user_profile_breadcrumb_edit</source>
                 <target>sonata_user_profile_breadcrumb_edit</target>
             </trans-unit>
+            <trans-unit id="sonata_user_already_authenticated">
+                <source>sonata_user_already_authenticated</source>
+                <target>You are already logged in</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataUserBundle.pt_BR.xliff
+++ b/Resources/translations/SonataUserBundle.pt_BR.xliff
@@ -502,6 +502,10 @@
                 <source>sonata_user_profile_breadcrumb_edit</source>
                 <target>sonata_user_profile_breadcrumb_edit</target>
             </trans-unit>
+            <trans-unit id="sonata_user_already_authenticated">
+                <source>sonata_user_already_authenticated</source>
+                <target>You are already logged in</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataUserBundle.ru.xliff
+++ b/Resources/translations/SonataUserBundle.ru.xliff
@@ -478,6 +478,10 @@
                 <source>sonata_user_profile_breadcrumb_edit</source>
                 <target>sonata_user_profile_breadcrumb_edit</target>
             </trans-unit>
+            <trans-unit id="sonata_user_already_authenticated">
+                <source>sonata_user_already_authenticated</source>
+                <target>You are already logged in</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataUserBundle.sk.xliff
+++ b/Resources/translations/SonataUserBundle.sk.xliff
@@ -426,6 +426,10 @@
                 <source>sonata_user_profile_breadcrumb_edit</source>
                 <target>sonata_user_profile_breadcrumb_edit</target>
             </trans-unit>
+            <trans-unit id="sonata_user_already_authenticated">
+                <source>sonata_user_already_authenticated</source>
+                <target>You are already logged in</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataUserBundle.sl.xliff
+++ b/Resources/translations/SonataUserBundle.sl.xliff
@@ -502,6 +502,10 @@
                 <source>sonata_user_profile_breadcrumb_edit</source>
                 <target>sonata_user_profile_breadcrumb_edit</target>
             </trans-unit>
+            <trans-unit id="sonata_user_already_authenticated">
+                <source>sonata_user_already_authenticated</source>
+                <target>You are already logged in</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataUserBundle.zh_TW.xliff
+++ b/Resources/translations/SonataUserBundle.zh_TW.xliff
@@ -314,6 +314,10 @@
                 <source>sonata_user_profile_breadcrumb_edit</source>
                 <target>sonata_user_profile_breadcrumb_edit</target>
             </trans-unit>
+            <trans-unit id="sonata_user_already_authenticated">
+                <source>sonata_user_already_authenticated</source>
+                <target>You are already logged in</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/views/Profile/action.html.twig
+++ b/Resources/views/Profile/action.html.twig
@@ -29,19 +29,9 @@ file that was distributed with this source code.
     </div>
 
     <div class="span10 col-lg-10">
-        {% for message in app.session.flashbag.get('fos_user_success') %}
-            <div class="alert alert-success">
-                {{ message|trans({}, "FOSUserBundle") }}
-            </div>
-        {% endfor %}
-        {% for message in app.session.flashbag.get('sonata_user_success') %}
-            <div class="alert alert-success">
-                {{ message|trans({}, "SonataUserBundle") }}
-            </div>
-        {% endfor %}
+        {% include 'SonataCoreBundle:FlashMessage:render.html.twig' %}
 
-        {% block sonata_profile_content %}
-        {% endblock %}
+        {% block sonata_profile_content '' %}
     </div>
 
 </div>


### PR DESCRIPTION
When user is already authenticated, I've added a redirection on the profile page with the following flash message:

![capture decran 2014-01-23 a 14 16 53](https://f.cloud.github.com/assets/103900/1984663/b4dd6078-8430-11e3-9670-473f1f02f153.png)
