### PR TITLE
SONATA-421 - Add profile form type labels to allow translation

### DIFF
--- a/Form/Type/ProfileType.php
+++ b/Form/Type/ProfileType.php
@@ -37,6 +37,7 @@ class ProfileType extends AbstractType
     {
         $builder
             ->add('gender', 'sonata_user_gender', array(
+                'label'    => 'form.label_gender',
                 'required' => true,
                 'translation_domain' => 'SonataUserBundle',
                 'choices' => array(
@@ -44,14 +45,39 @@ class ProfileType extends AbstractType
                     UserInterface::GENDER_MALE   => 'gender_male',
                 )
             ))
-            ->add('firstname', null, array('required' => false))
-            ->add('lastname', null, array('required' => false))
-            ->add('dateOfBirth', 'birthday', array('required' => false, 'widget' => 'single_text'))
-            ->add('website', 'url', array('required' => false))
-            ->add('biography', 'textarea', array('required' => false))
-            ->add('locale', 'locale', array('required' => false))
-            ->add('timezone', 'timezone', array('required' => false))
-            ->add('phone', null, array('required' => false))
+            ->add('firstname', null, array(
+                'label'    => 'form.label_firstname',
+                'required' => false
+            ))
+            ->add('lastname', null, array(
+                'label'    => 'form.label_lastname',
+                'required' => false
+            ))
+            ->add('dateOfBirth', 'birthday', array(
+                'label'    => 'form.label_date_of_birth',
+                'required' => false,
+                'widget'   => 'single_text'
+            ))
+            ->add('website', 'url', array(
+                'label'    => 'form.label_website',
+                'required' => false,
+            ))
+            ->add('biography', 'textarea', array(
+                'label'    => 'form.label_biography',
+                'required' => false
+            ))
+            ->add('locale', 'locale', array(
+                'label'    => 'form.label_locale',
+                'required' => false
+            ))
+            ->add('timezone', 'timezone', array(
+                'label'    => 'form.label_timezone',
+                'required' => false
+            ))
+            ->add('phone', null, array(
+                'label'    => 'form.label_phone',
+                'required' => false
+            ))
         ;
     }
 


### PR DESCRIPTION
I've added form type labels in order to allow them to be translated on frontend edit profile form.
