### PR TITLE
profile.xml name changed to match with the code

### DIFF
--- a/Resources/doc/reference/profile_edition.rst
+++ b/Resources/doc/reference/profile_edition.rst
@@ -72,7 +72,7 @@ to define to make it work.
 
     # by those lines :
     sonata_user_profile:
-        resource: "@SonataUserBundle/Resources/config/routing/profile.xml"
+        resource: "@SonataUserBundle/Resources/config/routing/sonata_profile_1.xml"
         prefix: /profile
 
 Actions


### PR DESCRIPTION
The files in the routing directory of SonataUserBundle have a different file name than their equivalent in the FOSUserBundle (don't know why, maybe the code should change instead of the doc).
