### PR TITLE
Fixed MopaBootstrap dependency (now optional)

### DIFF
--- a/Resources/views/ChangePassword/changePassword_content.html.twig
+++ b/Resources/views/ChangePassword/changePassword_content.html.twig
@@ -1,4 +1,3 @@
-{% form_theme form "MopaBootstrapBundle:Form:fields.html.twig" %}
 <form action="{{ path('sonata_user_change_password') }}" {{ form_enctype(form) }} method="POST" class="fos_user_change_password form-horizontal">
     {{ form_widget(form) }}
     <button type="submit" class="btn btn-danger pull-right"><i class="icon-lock icon-white glyphicon glyphicon-lock"></i>&nbsp;{{ 'change_password.submit'|trans({}, 'FOSUserBundle') }}</button>


### PR DESCRIPTION
Unable to find template "MopaBootstrapBundle:Form:fields.html.twig" in SonataUserBundle:ChangePassword:changePassword_content.html.twig at line 2.
