### PR TITLE
Fix API DoctrineORMSerializationType to be loaded only when using ORM

### DIFF
--- a/DependencyInjection/SonataUserExtension.php
+++ b/DependencyInjection/SonataUserExtension.php
@@ -55,11 +55,11 @@ class SonataUserExtension extends Extension
         $loader->load('form.xml');
         $loader->load('google_authenticator.xml');
         $loader->load('twig.xml');
+        $loader->load('serializer.xml');
 
-        if (isset($bundles['FOSRestBundle']) && isset($bundles['NelmioApiDocBundle'])) {
+        if ('orm' === $config['manager_type'] && isset($bundles['FOSRestBundle']) && isset($bundles['NelmioApiDocBundle'])) {
             $loader->load('api_form.xml');
             $loader->load('api_controllers.xml');
-            $loader->load('serializer.xml');
         }
 
         if (isset($bundles['SonataSeoBundle'])) {


### PR DESCRIPTION
I've moved `api_form.xml` that only contains form types definitions for API using `DoctrineORMSerializationType` when using the Doctrine ORM context.

This is to avoid the following issue when using ODM context:

`ParameterNotFoundException: The service "sonata.user.api.form.type.group" has a dependency on a non-existent parameter "sonata.user.admin.group.entity".`

This PR is related to the following comment: https://github.com/sonata-project/SonataUserBundle/commit/9027604673cec6b67b5edfb47cba3ae55fd772e7#commitcomment-5705945

I've also made `serializer.xml` available outside of the API bundles.
