### PR TITLE
Fix typo in SonataUserBundle.fr.xliff

### DIFF
--- a/Resources/translations/SonataUserBundle.fr.xliff
+++ b/Resources/translations/SonataUserBundle.fr.xliff
@@ -532,7 +532,7 @@
             </trans-unit>
             <trans-unit id="form.email">
                 <source>form.email</source>
-                <target>Addresse e-mail</target>
+                <target>Adresse e-mail</target>
             </trans-unit>
             <trans-unit id="form.password">
                 <source>form.password</source>


### PR DESCRIPTION
The word 'Adresse' has only one 'd' in french
