### PR TITLE
Update installation.rst

### DIFF
--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -46,6 +46,7 @@ Next, be sure to enable the bundles in your and ``AppKernel.php`` file:
             // you can select which bundle SonataUserBundle extends
             // Most of the cases, you'll want to extend FOSUserBundle though ;)
             // extend the ``FOSUserBundle``
+            new FOS\UserBundle\FOSUserBundle(),
             new Sonata\UserBundle\SonataUserBundle('FOSUserBundle'),
             // OR
             // the bundle will NOT extend ``FOSUserBundle``
@@ -107,6 +108,7 @@ Then, add these bundles in the config mapping definition (or enable `auto_mappin
                     mappings:
                         ApplicationSonataUserBundle: ~
                         SonataUserBundle: ~
+                        FOSUserBundle: ~                                    # If SonataUserBundle extends it
 
         dbal:
             types:


### PR DESCRIPTION
Need to declare FOSUserBundle & the related mapping, if SonataUserBundle extends it.
(this prevents a "Unrecognized field: usernameCanonical" error encountered while logging in)
