### PR TITLE
Comment for mongodb usage case of fos_user section

### DIFF
--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -95,10 +95,10 @@ Then, add these bundles in the config mapping definition (or enable `auto_mappin
 
         group:
             group_class:   Application\Sonata\UserBundle\Entity\Group
-            group_manager: sonata.user.orm.group_manager                    # If you're using doctrine orm
+            group_manager: sonata.user.orm.group_manager                    # If you're using doctrine orm (use sonata.user.mongodb.user_manager for mongodb)
 
         service:
-            user_manager: sonata.user.orm.user_manager                      # If you're using doctrine orm
+            user_manager: sonata.user.orm.user_manager                      # If you're using doctrine orm (use sonata.user.mongodb.group_manager for mongodb)
 
     doctrine:
         orm:


### PR DESCRIPTION
That's not so obvious you should use sonata.user.**mongodb**.user_manager but not sonata.user.**odm**.user_manager
Same with group manager.
So added comment to docs
