### PR TITLE
Prevent authorized user from opening register page

### DIFF
--- a/Controller/RegistrationFOSUser1Controller.php
+++ b/Controller/RegistrationFOSUser1Controller.php
@@ -35,7 +35,7 @@ class RegistrationFOSUser1Controller extends ContainerAware
     {
         $user = $this->container->get('security.context')->getToken()->getUser();
 
-        if ($user instanceof UserInterface && 'POST' === $this->container->get('request')->getMethod()) {
+        if ($user instanceof UserInterface) {
             $this->container->get('session')->getFlashBag()->set('sonata_user_error', 'sonata_user_already_authenticated');
             $url = $this->container->get('router')->generate('sonata_user_profile_show');
 


### PR DESCRIPTION
There is an odd check of http method.
When authorized user opens the registration page he should be redirected out of it immediately because his next actions would be obviously in vain (based on code) but user himself cannot be sure of its result... will the new user be actually created or won't, and even will form be submitted or won't.
