### PR TITLE
Added check for Master Request

### DIFF
--- a/GoogleAuthenticator/RequestListener.php
+++ b/GoogleAuthenticator/RequestListener.php
@@ -43,7 +43,7 @@ class RequestListener
      */
     public function onCoreRequest(GetResponseEvent $event)
     {
-		if (HttpKernel::MASTER_REQUEST != $event->getRequestType()) {
+        if (HttpKernel::MASTER_REQUEST != $event->getRequestType()) {
             return;
         }
     


### PR DESCRIPTION
Added Symfony2's example check to prevent loops of nesting when using templates with multiple calls to the Request service
@rande 
