### PR TITLE
Fix login_check route to prevent code 500 error on GET-request.

### DIFF
--- a/Resources/config/routing/sonata_security_1.xml
+++ b/Resources/config/routing/sonata_security_1.xml
@@ -10,6 +10,7 @@
 
     <route id="fos_user_security_check" pattern="/login_check">
         <default key="_controller">SonataUserBundle:SecurityFOSUser1:check</default>
+        <requirement key="_method">POST</requirement>
     </route>
 
     <route id="fos_user_security_logout" pattern="/logout">
@@ -22,6 +23,7 @@
 
     <route id="sonata_user_security_check" pattern="/login_check">
         <default key="_controller">SonataUserBundle:SecurityFOSUser1:check</default>
+        <requirement key="_method">POST</requirement>
     </route>
 
     <route id="sonata_user_security_logout" pattern="/logout">


### PR DESCRIPTION
Since firewall's check_path handles only POST request the exception 

```
throw new \RuntimeException('You must configure the check path to be handled by the firewall using form_login in your security firewall configuration.');
```

should be thrown only in case of POST request, and just 404 should be returned on GET. Otherwise we have 2 problems: 
- An error appears when all configured properly.
- On production environment each response with code 500 often configured to be logged and sent to admin, to fix the problem. So we have a route which is always lead to an error.
