### PR TITLE
removing setCurrentUri call from getMenu-Method

### DIFF
--- a/Block/ProfileMenuBlockService.php
+++ b/Block/ProfileMenuBlockService.php
@@ -88,7 +88,6 @@ class ProfileMenuBlockService extends MenuBlockService
                     'attributes'         => array('class' => $settings['children_class']),
                 )
             );
-            $menu->setCurrentUri($settings['current_uri']);
         }
 
         return $menu;


### PR DESCRIPTION
since [this commit](https://github.com/KnpLabs/KnpMenu/commit/e7ef14a9469545423276e8516196496664429b81), setCurrentUri is gone (and if i get it right, url-matching is now done outside of the menu object)