### PR TITLE
fixing build - step 1 - adjusting composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "symfony/form": "~2.3",
         "symfony/security": "~2.3",
         "symfony/console": "~2.3",
-        "sonata-project/core-bundle": "~2.2",
+        "sonata-project/core-bundle": "2.2.*@dev",
         "sonata-project/admin-bundle": "~2.3@dev",
         "friendsofsymfony/user-bundle": "~1.3",
         "sonata-project/doctrine-extensions": "~1.0",

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "symfony/form": "~2.3",
         "symfony/security": "~2.3",
         "symfony/console": "~2.3",
+        "doctrine/orm": "~2.2,>=2.2.3",
         "sonata-project/core-bundle": "2.2.*@dev",
         "sonata-project/admin-bundle": "~2.3@dev",
         "friendsofsymfony/user-bundle": "~1.3",


### PR DESCRIPTION
Since [87f2072](https://github.com/sonata-project/SonataUserBundle/commit/87f2072) we require PageableManagerInterface, but the interface was added in core-bundle [4f48318](https://github.com/sonata-project/SonataCoreBundle/commit/4f48318), which is beyond what we get with 
>"sonata-project/core-bundle": "~2.2"

(composer will checkout 2.2.5)
So to green the build, we need to checkout dev version :/