### PR TITLE
Removing deprecated method

### DIFF
--- a/Block/ProfileMenuBlockService.php
+++ b/Block/ProfileMenuBlockService.php
@@ -87,6 +87,10 @@ class ProfileMenuBlockService extends MenuBlockService
             if (method_exists($menu, 'setCurrentUri')) {
                 $menu->setCurrentUri($settings['current_uri']);
             }
+
+	    if (method_exists($menu, 'setUri')) {
+                $menu->setUri($settings['current_uri']);
+            }
         }
 
         return $menu;


### PR DESCRIPTION
The setCurrentUri method has been removed a long time ago.
https://github.com/KnpLabs/KnpMenu/commit/e7ef14a9469545423276e8516196496664429b81

Right now If your follow the install instruction it breaks when you try to go on the profile page because it use that method.