### PR TITLE
Fixed Issue #430

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "sonata-project/doctrine-extensions": "~1.0",
         "sonata-project/easy-extends-bundle": "~2.1",
         "sonata-project/google-authenticator": "~1.0",
-        "sonata-project/datagrid-bundle": "~2.2@dev",
+        "sonata-project/datagrid-bundle": "dev-master",
 
         "friendsofsymfony/rest-bundle": "~1.1",
         "jms/serializer-bundle": "~0.11",


### PR DESCRIPTION
SonataUserBundle depends on 2.2@dev tag of SonataDatagridBundle that
now has no tags at all. Someone need to add a tag or use this temporary
fix (It’s not a good idea to rely on dev-master branch).
https://github.com/sonata-project/SonataUserBundle/issues/430