### PR TITLE
Remember-me checkbox with a proper label

### DIFF
--- a/Resources/views/Admin/Security/login.html.twig
+++ b/Resources/views/Admin/Security/login.html.twig
@@ -34,9 +34,11 @@
                         <input type="password" class="form-control" id="password" name="_password" required="required" placeholder="{{ 'security.login.password'|trans({}, 'SonataUserBundle') }}"/>
                     </div>
 
-                    <div class="form-group">
-                        <input type="checkbox" id="remember_me" name="_remember_me" value="on"/>
-                        {{ 'security.login.remember_me'|trans({}, 'FOSUserBundle') }}
+                    <div class="checkbox">
+                        <label>
+                            <input type="checkbox" id="remember_me" name="_remember_me" value="on"/>
+                            {{ 'security.login.remember_me'|trans({}, 'FOSUserBundle') }}
+                        </label>
                     </div>
 
                 </div>


### PR DESCRIPTION
As defined in [bootstrap examples](http://getbootstrap.com/css/#forms-example), the remember-me checkbox now has a working label