### PR TITLE
Update GroupAdmin.php

### DIFF
--- a/Admin/Model/GroupAdmin.php
+++ b/Admin/Model/GroupAdmin.php
@@ -65,7 +65,7 @@ class GroupAdmin extends Admin
                 ->end()
             ->end()
             ->tab('Security')
-                ->with()
+                ->with('Roles')
                 ->add('roles', 'sonata_security_roles', array(
                     'expanded' => true,
                     'multiple' => true,


### PR DESCRIPTION
Without the text in the 'with' method the symfony was throwing:

ContextErrorException: Warning: Missing argument 1 for Sonata\AdminBundle\Mapper\BaseGroupedMapper::with(), called in /var/www/html/muva/vendor/sonata-project/user-bundle/Admin/Model/GroupAdmin.php on line 68 and defined in /var/www/html/muva/app/cache/dev/classes.php line 12165