### PR TITLE
Fixing problem with RestoreRolesTransformer #469

### DIFF
--- a/Form/Transformer/RestoreRolesTransformer.php
+++ b/Form/Transformer/RestoreRolesTransformer.php
@@ -64,7 +64,7 @@ class RestoreRolesTransformer implements DataTransformerInterface
 
         list($availableRoles, ) = $this->rolesBuilder->getRoles();
 
-        $hiddenRoles = array_diff($this->originalRoles, $availableRoles);
+        $hiddenRoles = array_diff($this->originalRoles, array_keys($availableRoles));
 
         return array_merge($selectedRoles, $hiddenRoles);
     }


### PR DESCRIPTION
I've made changes by first way of my suggestion
"So I propose to use array_key instead values (if this transformer used only for form type sonata_security_roles) or merge array_keys of the $avaliableRoles array with its values in another case."