### PR TITLE
Remove duplicate fos_user_xxx routes

### DIFF
--- a/Controller/RegistrationFOSUser1Controller.php
+++ b/Controller/RegistrationFOSUser1Controller.php
@@ -53,7 +53,7 @@ class RegistrationFOSUser1Controller extends ContainerAware
             $authUser = false;
             if ($confirmationEnabled) {
                 $this->container->get('session')->set('fos_user_send_confirmation_email/email', $user->getEmail());
-                $url = $this->container->get('router')->generate('fos_user_registration_check_email');
+                $url = $this->container->get('router')->generate('sonata_user_registration_check_email');
             } else {
                 $authUser = true;
                 $route = $this->container->get('session')->get('sonata_basket_delivery_redirect');
@@ -121,7 +121,7 @@ class RegistrationFOSUser1Controller extends ContainerAware
         if ($redirectRoute = $this->container->getParameter('sonata.user.register.confirm.redirect_route')) {
             $response = new RedirectResponse($this->container->get('router')->generate($redirectRoute, $this->container->getParameter('sonata.user.register.confirm.redirect_route_params')));
         } else {
-            $response = new RedirectResponse($this->container->get('router')->generate('fos_user_registration_confirmed'));
+            $response = new RedirectResponse($this->container->get('router')->generate('sonata_user_registration_confirmed'));
         }
 
         $this->authenticateUser($user, $response);

--- a/Resources/config/routing/sonata_change_password_1.xml
+++ b/Resources/config/routing/sonata_change_password_1.xml
@@ -4,11 +4,6 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="fos_user_change_password" pattern="/change-password">
-        <default key="_controller">SonataUserBundle:ChangePasswordFOSUser1:changePassword</default>
-        <requirement key="_method">GET|POST</requirement>
-    </route>
-
     <route id="sonata_user_change_password" pattern="/change-password">
         <default key="_controller">SonataUserBundle:ChangePasswordFOSUser1:changePassword</default>
         <requirement key="_method">GET|POST</requirement>

--- a/Resources/config/routing/sonata_profile_1.xml
+++ b/Resources/config/routing/sonata_profile_1.xml
@@ -4,19 +4,6 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="fos_user_profile_show" pattern="/">
-        <default key="_controller">SonataUserBundle:ProfileFOSUser1:show</default>
-        <requirement key="_method">GET</requirement>
-    </route>
-
-    <route id="fos_user_profile_edit_authentication" pattern="/edit-authentication">
-        <default key="_controller">SonataUserBundle:ProfileFOSUser1:editAuthentication</default>
-    </route>
-
-    <route id="fos_user_profile_edit" pattern="/edit-profile">
-        <default key="_controller">SonataUserBundle:ProfileFOSUser1:editProfile</default>
-    </route>
-
     <route id="sonata_user_profile_show" pattern="/">
         <default key="_controller">SonataUserBundle:ProfileFOSUser1:show</default>
         <requirement key="_method">GET</requirement>

--- a/Resources/config/routing/sonata_registration_1.xml
+++ b/Resources/config/routing/sonata_registration_1.xml
@@ -4,25 +4,6 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="fos_user_registration_register" pattern="/">
-        <default key="_controller">SonataUserBundle:RegistrationFOSUser1:register</default>
-    </route>
-
-    <route id="fos_user_registration_check_email" pattern="/check-email">
-        <default key="_controller">SonataUserBundle:RegistrationFOSUser1:checkEmail</default>
-        <requirement key="_method">GET</requirement>
-    </route>
-
-    <route id="fos_user_registration_confirm" pattern="/confirm/{token}">
-        <default key="_controller">SonataUserBundle:RegistrationFOSUser1:confirm</default>
-        <requirement key="_method">GET</requirement>
-    </route>
-
-    <route id="fos_user_registration_confirmed" pattern="/confirmed">
-        <default key="_controller">SonataUserBundle:RegistrationFOSUser1:confirmed</default>
-        <requirement key="_method">GET</requirement>
-    </route>
-
     <route id="sonata_user_registration_register" pattern="/">
         <default key="_controller">SonataUserBundle:RegistrationFOSUser1:register</default>
     </route>

--- a/Resources/config/routing/sonata_resetting_1.xml
+++ b/Resources/config/routing/sonata_resetting_1.xml
@@ -4,26 +4,6 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="fos_user_resetting_request" pattern="/request">
-        <default key="_controller">SonataUserBundle:ResettingFOSUser1:request</default>
-        <requirement key="_method">GET</requirement>
-    </route>
-
-    <route id="fos_user_resetting_send_email" pattern="/send-email">
-        <default key="_controller">SonataUserBundle:ResettingFOSUser1:sendEmail</default>
-        <requirement key="_method">POST</requirement>
-    </route>
-
-    <route id="fos_user_resetting_check_email" pattern="/check-email">
-        <default key="_controller">SonataUserBundle:ResettingFOSUser1:checkEmail</default>
-        <requirement key="_method">GET</requirement>
-    </route>
-
-    <route id="fos_user_resetting_reset" pattern="/reset/{token}">
-        <default key="_controller">SonataUserBundle:ResettingFOSUser1:reset</default>
-        <requirement key="_method">GET|POST</requirement>
-    </route>
-
     <route id="sonata_user_resetting_request" pattern="/request">
         <default key="_controller">SonataUserBundle:ResettingFOSUser1:request</default>
         <requirement key="_method">GET</requirement>

--- a/Resources/config/routing/sonata_security_1.xml
+++ b/Resources/config/routing/sonata_security_1.xml
@@ -4,19 +4,6 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="fos_user_security_login" pattern="/login">
-        <default key="_controller">SonataUserBundle:SecurityFOSUser1:login</default>
-    </route>
-
-    <route id="fos_user_security_check" pattern="/login_check">
-        <default key="_controller">SonataUserBundle:SecurityFOSUser1:check</default>
-        <requirement key="_method">POST</requirement>
-    </route>
-
-    <route id="fos_user_security_logout" pattern="/logout">
-        <default key="_controller">SonataUserBundle:SecurityFOSUser1:logout</default>
-    </route>
-
     <route id="sonata_user_security_login" pattern="/login">
         <default key="_controller">SonataUserBundle:SecurityFOSUser1:login</default>
     </route>

--- a/Resources/views/Admin/Security/login.html.twig
+++ b/Resources/views/Admin/Security/login.html.twig
@@ -43,7 +43,7 @@
 
                 <div class="footer">
                     <button type="submit" id="_submit" name="_submit" class="btn bg-olive btn-block">{{ 'security.login.submit'|trans({}, 'FOSUserBundle') }}</button>
-                    <p><a href="{{ path('fos_user_resetting_request') }}" class="text-center">{{ 'forgotten_password'|trans({}, 'SonataUserBundle') }}</a></p>
+                    <p><a href="{{ path('sonata_user_resetting_request') }}" class="text-center">{{ 'forgotten_password'|trans({}, 'SonataUserBundle') }}</a></p>
                 </div>
             </form>
         {% endblock %}

--- a/Resources/views/Block/account.html.twig
+++ b/Resources/views/Block/account.html.twig
@@ -15,9 +15,9 @@ file that was distributed with this source code.
     <div style="display:inline;">
         {% if user %}
             <a href="{{ path('sonata_user_profile_show') }}">{{ user.username }}</a> |
-            <a href="{{ path('fos_user_security_logout') }}">{{ 'link_logout' | trans({}, "SonataUserBundle") }}</a>
+            <a href="{{ path('sonata_user_security_logout') }}">{{ 'link_logout' | trans({}, "SonataUserBundle") }}</a>
         {% else %}
-            <a href="{{ path('fos_user_security_login') }}">{{ 'link_login'|trans({}, 'SonataUserBundle') }} / {{ 'link_register'|trans({}, 'SonataUserBundle') }}</a>
+            <a href="{{ path('sonata_user_security_login') }}">{{ 'link_login'|trans({}, 'SonataUserBundle') }} / {{ 'link_register'|trans({}, 'SonataUserBundle') }}</a>
         {% endif %}
     </div>
 {% endblock %}

--- a/Resources/views/Registration/register_content.html.twig
+++ b/Resources/views/Registration/register_content.html.twig
@@ -3,7 +3,7 @@
         <h2 class="panel-title">{{ 'title_user_registration'|trans({}, 'SonataUserBundle') }}</h2>
     </div>
     <div class="panel-body">
-        <form action="{{ path('fos_user_registration_register') }}" {{ form_enctype(form) }} method="POST" class="fos_user_registration_register form-horizontal">
+        <form action="{{ path('sonata_user_registration_register') }}" {{ form_enctype(form) }} method="POST" class="fos_user_registration_register form-horizontal">
 
             {{ form_widget(form) }}
 

--- a/Resources/views/Security/base_login.html.twig
+++ b/Resources/views/Security/base_login.html.twig
@@ -30,7 +30,7 @@ file that was distributed with this source code.
                     {% endblock %}
 
                     {% block sonata_user_login_form %}
-                        <form action="{{ path("fos_user_security_check") }}" method="post" role="form"
+                        <form action="{{ path("sonata_user_security_check") }}" method="post" role="form"
                               class="form-horizontal">
                             <input type="hidden" name="_csrf_token" value="{{ csrf_token }}"/>
 
@@ -65,7 +65,7 @@ file that was distributed with this source code.
 
                             <div class="form-group control-group">
                                 <div class="controls col-sm-offset-4 col-sm-8">
-                                    <a href="{{ path('fos_user_resetting_request') }}">{{ 'forgotten_password'|trans({}, 'SonataUserBundle') }}</a>
+                                    <a href="{{ path('sonata_user_resetting_request') }}">{{ 'forgotten_password'|trans({}, 'SonataUserBundle') }}</a>
                                 </div>
                             </div>
 


### PR DESCRIPTION
Kristian B reported the following problem to sonata-users group:
There are both fos_user_xxx and sonata_user_xxx routes with the same paths.
UPDATE  fos_user_security_login                         /login
UPDATE  sonata_user_security_login                   /login
When trying to edit one of these pages, the following error happen: The URL '/login' is already associated with another page.

I removed duplicate routes in Resources/config/routing/*.xml files and changed references to fos_user_xxx routes to use sonata_user_xxx routes.