### PR TITLE
Replace translation domain fixes #478

### DIFF
--- a/Resources/views/Security/base_login.html.twig
+++ b/Resources/views/Security/base_login.html.twig
@@ -36,7 +36,7 @@ file that was distributed with this source code.
 
                             <div class="form-group">
                                 <label for="username"
-                                       class="col-sm-4 control-label">{{ 'security.login.username'|trans({}, 'SonataUserBundle') }}</label>
+                                       class="col-sm-4 control-label">{{ 'security.login.username'|trans({}, 'FOSUserBundle') }}</label>
 
                                 <div class="col-sm-8"><input type="text" class="form-control" id="username"
                                                                       name="_username" value="{{ last_username }}"
@@ -46,7 +46,7 @@ file that was distributed with this source code.
 
                             <div class="form-group control-group">
                                 <label for="password"
-                                       class="col-sm-4 control-label">{{ 'security.login.password'|trans({}, 'SonataUserBundle') }}</label>
+                                       class="col-sm-4 control-label">{{ 'security.login.password'|trans({}, 'FOSUserBundle') }}</label>
 
                                 <div class="col-sm-8"><input type="password" class="form-control" id="password"
                                                                       name="_password" required="required"/></div>


### PR DESCRIPTION
Replaced `SonataUserBundle` with `FOSUserBundle` domain see:
https://github.com/sonata-project/SonataUserBundle/issues/478