### PR TITLE
Fixes "implement the remaining methods"

### DIFF
--- a/Document/UserManager.php
+++ b/Document/UserManager.php
@@ -30,4 +30,11 @@ class UserManager extends BaseUserManager implements UserManagerInterface
     {
         return $this->repository->findBy($criteria, $orderBy, $limit, $offset);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPager(array $criteria, $page, $limit = 10, array $sort = array()){
+        throw new \RuntimeException("Not Implemented yet");
+    }
 }


### PR DESCRIPTION
This fixes #463 for the moment.

Fatal error: Class Sonata\UserBundle\Document\UserManager contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (Sonata\CoreBundle\Model\PageableManagerInterface::getPager) in .../vendor/sonata-project/user-bundle/Document/UserManager.php on line 33
