### PR TITLE
Replace url() with path() for logout url

### DIFF
--- a/Resources/views/Admin/Core/user_block.html.twig
+++ b/Resources/views/Admin/Core/user_block.html.twig
@@ -2,7 +2,7 @@
     {% if app.user %}
 
         {% set _bg_class    = "bg-light-blue" %}
-        {% set _logout_uri  = url('sonata_user_admin_security_logout') %}
+        {% set _logout_uri  = path('sonata_user_admin_security_logout') %}
         {% set _logout_text = 'user_block_logout'|trans({}, 'SonataUserBundle') %}
         {% set _user_image  = asset(sonata_user.defaultAvatar) %}
         {# Customize this with your profile picture implementation, see below for example #}


### PR DESCRIPTION
It's not better to use the relative logout url generated with the path() twig function, instead of the absolute url using the url() function?

I noticed in a project of mine (the hosting server have some special settings regarding the public hostname) that the logout url is wrong generated using url(), with path() it is perfect.