### PR TITLE
Update AdminSecurityController.php

### DIFF
--- a/Controller/AdminSecurityController.php
+++ b/Controller/AdminSecurityController.php
@@ -11,17 +11,17 @@
 
 namespace Sonata\UserBundle\Controller;
 
-use Symfony\Component\DependencyInjection\ContainerAware;
-use Symfony\Component\Security\Core\SecurityContext;
-use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\Security\Core\SecurityContextInterface;
+use Symfony\Component\HttpFoundation\Request;
 use FOS\UserBundle\Model\UserInterface;
 
-class AdminSecurityController extends ContainerAware
+class AdminSecurityController extends Controller
 {
     /**
      * {@inheritdoc}
      */
-    public function loginAction()
+    public function loginAction(Request $request)
     {
         $user = $this->container->get('security.context')->getToken()->getUser();
 
@@ -29,20 +29,18 @@ class AdminSecurityController extends ContainerAware
             $this->container->get('session')->getFlashBag()->set('sonata_user_error', 'sonata_user_already_authenticated');
             $url = $this->container->get('router')->generate('sonata_user_profile_show');
 
-            return new RedirectResponse($url);
+            return $this->redirect($url);
         }
 
-        $request = $this->container->get('request');
-        /* @var $request \Symfony\Component\HttpFoundation\Request */
         $session = $request->getSession();
         /* @var $session \Symfony\Component\HttpFoundation\Session */
 
         // get the error if any (works with forward and redirect -- see below)
-        if ($request->attributes->has(SecurityContext::AUTHENTICATION_ERROR)) {
-            $error = $request->attributes->get(SecurityContext::AUTHENTICATION_ERROR);
-        } elseif (null !== $session && $session->has(SecurityContext::AUTHENTICATION_ERROR)) {
-            $error = $session->get(SecurityContext::AUTHENTICATION_ERROR);
-            $session->remove(SecurityContext::AUTHENTICATION_ERROR);
+        if ($request->attributes->has(SecurityContextInterface::AUTHENTICATION_ERROR)) {
+            $error = $request->attributes->get(SecurityContextInterface::AUTHENTICATION_ERROR);
+        } elseif (null !== $session && $session->has(SecurityContextInterface::AUTHENTICATION_ERROR)) {
+            $error = $session->get(SecurityContextInterface::AUTHENTICATION_ERROR);
+            $session->remove(SecurityContextInterface::AUTHENTICATION_ERROR);
         } else {
             $error = '';
         }
@@ -52,7 +50,7 @@ class AdminSecurityController extends ContainerAware
             $error = $error->getMessage();
         }
         // last username entered by the user
-        $lastUsername = (null === $session) ? '' : $session->get(SecurityContext::LAST_USERNAME);
+        $lastUsername = (null === $session) ? '' : $session->get(SecurityContextInterface::LAST_USERNAME);
 
         $csrfToken = $this->container->has('form.csrf_provider')
             ? $this->container->get('form.csrf_provider')->generateCsrfToken('authenticate')
@@ -60,11 +58,11 @@ class AdminSecurityController extends ContainerAware
 
         if ($this->container->get('security.context')->isGranted('ROLE_ADMIN')) {
             $refererUri = $request->server->get('HTTP_REFERER');
-
-            return new RedirectResponse($refererUri && $refererUri != $request->getUri() ? $refererUri : $this->container->get('router')->generate('sonata_admin_dashboard'));
+            
+            return $this->redirect($refererUri && $refererUri != $request->getUri() ? $refererUri : $this->container->get('router')->generate('sonata_admin_dashboard'));
         }
 
-        return $this->container->get('templating')->renderResponse('SonataUserBundle:Admin:Security/login.html.'.$this->container->getParameter('fos_user.template.engine'), array(
+        return $this->render('SonataUserBundle:Admin:Security/login.html.twig', array(
                 'last_username' => $lastUsername,
                 'error'         => $error,
                 'csrf_token'    => $csrfToken,
@@ -72,22 +70,7 @@ class AdminSecurityController extends ContainerAware
                 'admin_pool'    => $this->container->get('sonata.admin.pool')
             ));
     }
-
-    /**
-     * Renders the login template with the given parameters. Overwrite this function in
-     * an extended controller to provide additional data for the login template.
-     *
-     * @param array $data
-     *
-     * @return \Symfony\Component\HttpFoundation\Response
-     */
-    protected function renderLogin(array $data)
-    {
-        $template = sprintf('FOSUserBundle:Security:login.html.%s', $this->container->getParameter('fos_user.template.engine'));
-
-        return $this->container->get('templating')->renderResponse($template, $data);
-    }
-
+    
     public function checkAction()
     {
         throw new \RuntimeException('You must configure the check path to be handled by the firewall using form_login in your security firewall configuration.');


### PR DESCRIPTION
@rande Hello,

1) I was working on a custom login page and came to compare this login Controller with the latest of FOSUserBundle. This one could be updated to follow those FOSUserBundle commits?
https://github.com/FriendsOfSymfony/FOSUserBundle/commit/20b97f61ede32b37266cb3febf2372f82647b617
https://github.com/FriendsOfSymfony/FOSUserBundle/commit/63e308cad922185fc1dedc9f95e92b23fd1c94b1

2) I removed renderLogin because it seems to no longer have any use to split between 2 methods (correct me if I am wrong ^^) https://github.com/FriendsOfSymfony/FOSUserBundle/blob/master/Controller/SecurityController.php

3) As per the contributing guidelines I would have liked to provide a test but I didn't find an example in the Tests/Controller folder.