### PR TITLE
Fixing hidden roles support in SecurityRolesType

### DIFF
--- a/Form/Transformer/RestoreRolesTransformer.php
+++ b/Form/Transformer/RestoreRolesTransformer.php
@@ -64,7 +64,7 @@ class RestoreRolesTransformer implements DataTransformerInterface
 
         list($availableRoles, ) = $this->rolesBuilder->getRoles();
 
-        $hiddenRoles = array_diff($this->originalRoles, $availableRoles);
+        $hiddenRoles = array_diff($this->originalRoles, array_keys($availableRoles));
 
         return array_merge($selectedRoles, $hiddenRoles);
     }

--- a/Form/Type/SecurityRolesType.php
+++ b/Form/Type/SecurityRolesType.php
@@ -58,7 +58,7 @@ class SecurityRolesType extends AbstractType
 
         // POST METHOD
         $formBuilder->addEventListener(FormEvents::PRE_BIND, function(FormEvent $event) use ($transformer) {
-            $transformer->setOriginalRoles($event->getData());
+            $transformer->setOriginalRoles($event->getForm()->getData());
         });
 
         $formBuilder->addModelTransformer($transformer);

--- a/Tests/Form/Transformer/RestoreRolesTransformerTest.php
+++ b/Tests/Form/Transformer/RestoreRolesTransformerTest.php
@@ -100,4 +100,57 @@ class RestoreRolesTransformerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(array('ROLE_FOO'), $transformer->reverseTransform($data));
     }
+
+    public function testReverseTransformRevokedHierarchicalRole()
+    {
+        $roleBuilder = $this->getMockBuilder('Sonata\UserBundle\Security\EditableRolesBuilder')
+                            ->disableOriginalConstructor()
+                            ->getMock();
+
+        $availableRoles = array(
+            'ROLE_SONATA_ADMIN'  => 'ROLE_SONATA_ADMIN',
+            'ROLE_COMPANY_PERSONAL_MODERATOR' => 'ROLE_COMPANY_PERSONAL_MODERATOR: ROLE_COMPANY_USER',
+            'ROLE_COMPANY_NEWS_MODERATOR' => 'ROLE_COMPANY_NEWS_MODERATOR: ROLE_COMPANY_USER',
+            'ROLE_COMPANY_BOOKKEEPER' => 'ROLE_COMPANY_BOOKKEEPER: ROLE_COMPANY_USER',
+            'ROLE_USER' => 'ROLE_USER',
+        );
+        $roleBuilder->expects($this->once())->method('getRoles')->will($this->returnValue(array($availableRoles, array())));
+
+        // user roles
+        $userRoles = array('ROLE_COMPANY_PERSONAL_MODERATOR', 'ROLE_COMPANY_NEWS_MODERATOR', 'ROLE_COMPANY_BOOKKEEPER');
+        $transformer = new RestoreRolesTransformer($roleBuilder);
+        $transformer->setOriginalRoles($userRoles);
+
+        // now we want to revoke role ROLE_COMPANY_PERSONAL_MODERATOR
+        $revokedRole = array_shift($userRoles);
+        $processedRoles = $transformer->reverseTransform($userRoles);
+
+        $this->assertNotContains($revokedRole, $processedRoles);
+    }
+
+    public function testReverseTransformHiddenRole()
+    {
+        $roleBuilder = $this->getMockBuilder('Sonata\UserBundle\Security\EditableRolesBuilder')
+                            ->disableOriginalConstructor()
+                            ->getMock();
+
+        $availableRoles = array(
+            'ROLE_SONATA_ADMIN'  => 'ROLE_SONATA_ADMIN',
+            'ROLE_ADMIN' => 'ROLE_ADMIN: ROLE_USER ROLE_COMPANY_ADMIN',
+        );
+        $roleBuilder->expects($this->once())->method('getRoles')->will($this->returnValue(array($availableRoles, array())));
+
+        // user roles
+        $userRoles = array('ROLE_USER', 'ROLE_SUPER_ADMIN');
+        $transformer = new RestoreRolesTransformer($roleBuilder);
+        $transformer->setOriginalRoles($userRoles);
+
+        // add a new role
+        array_push($userRoles, 'ROLE_SONATA_ADMIN');
+        // remove existing user role that is not availableRoles
+        unset($userRoles[array_search('ROLE_SUPER_ADMIN', $userRoles)]);
+        $processedRoles = $transformer->reverseTransform($userRoles);
+
+        $this->assertContains('ROLE_SUPER_ADMIN', $processedRoles);
+    }
 }

--- a/Tests/Form/Type/SecurityRolesTypeTest.php
+++ b/Tests/Form/Type/SecurityRolesTypeTest.php
@@ -99,4 +99,22 @@ class SecurityRolesTypeTest extends TypeTestCase
         $this->assertFalse($form->isSynchronized());
         $this->assertNull($form->getData());
     }
+
+    public function testSubmitWithHiddenRoleData()
+    {
+        $originalRoles = array('ROLE_SUPER_ADMIN', 'ROLE_USER');
+
+        $form = $this->factory->create('sonata_security_roles', $originalRoles, array(
+            'multiple' => true,
+            'expanded' => true,
+            'required' => false
+        ));
+
+        // we keep hidden ROLE_SUPER_ADMIN and delete available ROLE_USER
+        $form->submit(array(0 => 'ROLE_ADMIN'));
+
+        $this->assertTrue($form->isSynchronized());
+        $this->assertCount(2, $form->getData());
+        $this->assertContains('ROLE_SUPER_ADMIN', $form->getData());
+    }
 }


### PR DESCRIPTION
As mentioned in #499 there is a problem with keeping hidden roles.

Example:
User 'admin' with roles: ROLE_ADMIN, ROLE_USER is editing user 'superadmin' with ROLE_SUPER_ADMIN.

Currently Sonata would delete ROLE_SUPER_ADMIN from superadmin user. Expected behavior is to keep this role.

I reverted the change from #452 and added changes from #470. I didn't delete tests from both PR's and added one additional tests to cover the error from #499.

