### PR TITLE
add SonataEasyExtendsBundle to AppKernel.php

### DIFF
--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -41,6 +41,7 @@ Next, be sure to enable the bundles in your and ``AppKernel.php`` file:
         return array(
             new Sonata\CoreBundle\SonataCoreBundle(),
             new Sonata\BlockBundle\SonataBlockBundle(),
+            new Sonata\EasyExtendsBundle\SonataEasyExtendsBundle(),
             // ...
             // You have 2 options to initialize the SonataUserBundle in your AppKernel,
             // you can select which bundle SonataUserBundle extends


### PR DESCRIPTION
the bundle seems to be needed to run the php app/console sonata:easy-extends:generate command used later in this tutorial