### PR TITLE
Makes user expiresAt nullable

### DIFF
--- a/Model/User.php
+++ b/Model/User.php
@@ -180,6 +180,20 @@ abstract class User extends AbstractedUser implements UserInterface
     }
 
     /**
+     * Set expiration date
+     *
+     * @param \DateTime|null $date
+     *
+     * @return User
+     */
+    public function setExpiresAt(\DateTime $date = null)
+    {
+        $this->expiresAt = $date;
+
+        return $this;
+    }
+
+    /**
      * Returns the credentials expiration date
      *
      * @return \DateTime


### PR DESCRIPTION
After adding the user expiration date to the admin, the field becomes mandatory.

This is an alternative to https://github.com/FriendsOfSymfony/FOSUserBundle/pull/1812