### PR TITLE
Fix deprecated "factory-*" service definition

### DIFF
--- a/Resources/config/form.xml
+++ b/Resources/config/form.xml
@@ -5,7 +5,8 @@
 
     <services>
         <!-- profile form -->
-        <service id="sonata.user.profile.form" factory-method="createNamed" factory-service="form.factory" class="Symfony\Component\Form\Form">
+        <service id="sonata.user.profile.form" class="Symfony\Component\Form\Form">
+            <factory service="form.factory" method="createNamed"/>
             <argument>%sonata.user.profile.form.name%</argument>
             <argument>%sonata.user.profile.form.type%</argument>
             <argument>null</argument>
@@ -34,7 +35,8 @@
             <tag name="form.type" alias="sonata_user_gender" />
         </service>
 
-        <service id="sonata.user.registration.form" factory-method="createNamed" factory-service="form.factory" class="Symfony\Component\Form\Form">
+        <service id="sonata.user.registration.form" class="Symfony\Component\Form\Form">
+            <factory service="form.factory" method="createNamed"/>
             <argument>%sonata.user.registration.form.name%</argument>
             <argument>%sonata.user.registration.form.type%</argument>
             <argument>null</argument>


### PR DESCRIPTION
As of Symfony 2.7, "factory-method" and "factory-service" are deprecated in favor of "factory".