### PR TITLE
Replace url() with path() for logout uri

### DIFF
--- a/Resources/views/Admin/Core/user_block.html.twig
+++ b/Resources/views/Admin/Core/user_block.html.twig
@@ -1,7 +1,7 @@
 {% block user_block %}
     {% if app.user %}
         {% set _bg_class          = "bg-light-blue" %}
-        {% set _logout_uri        = url('sonata_user_admin_security_logout') %}
+        {% set _logout_uri        = path('sonata_user_admin_security_logout') %}
         {% set _logout_text       = 'user_block_logout'|trans({}, 'SonataUserBundle') %}
         {% set _profile_uri       = sonata_user.userAdmin.isGranted('EDIT', app.user) ? sonata_user.userAdmin.generateUrl('edit', {id: sonata_user.userAdmin.id(app.user)}) : sonata_user.userAdmin.generateUrl('show', {id: sonata_user.userAdmin.id(app.user)}) %}
         {% set _profile_text      = 'user_block_profile'|trans({}, 'SonataUserBundle') %}


### PR DESCRIPTION
It's not better to use the relative logout url generated with the path() twig function, instead of the absolute url using the url() function?

I noticed in a project of mine (the hosting server have some special settings regarding the public hostname) that the logout url is wrong generated using url(), with path() it is perfect.