### PR TITLE
Replaced routing deprecated arguments

### DIFF
--- a/Resources/config/routing/admin_security.xml
+++ b/Resources/config/routing/admin_security.xml
@@ -4,15 +4,15 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="sonata_user_admin_security_login" pattern="/login">
+    <route id="sonata_user_admin_security_login" path="/login">
         <default key="_controller">SonataUserBundle:AdminSecurity:login</default>
     </route>
 
-    <route id="sonata_user_admin_security_check" pattern="/login_check">
+    <route id="sonata_user_admin_security_check" path="/login_check">
         <default key="_controller">SonataUserBundle:AdminSecurity:check</default>
     </route>
 
-    <route id="sonata_user_admin_security_logout" pattern="/logout">
+    <route id="sonata_user_admin_security_logout" path="/logout">
         <default key="_controller">SonataUserBundle:AdminSecurity:logout</default>
     </route>
 </routes>

--- a/Resources/config/routing/sonata_change_password_1.xml
+++ b/Resources/config/routing/sonata_change_password_1.xml
@@ -4,14 +4,12 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="fos_user_change_password" pattern="/change-password">
+    <route id="fos_user_change_password" path="/change-password" methods="GET POST">
         <default key="_controller">SonataUserBundle:ChangePasswordFOSUser1:changePassword</default>
-        <requirement key="_method">GET|POST</requirement>
     </route>
 
-    <route id="sonata_user_change_password" pattern="/change-password">
+    <route id="sonata_user_change_password" path="/change-password" methods="GET POST">
         <default key="_controller">SonataUserBundle:ChangePasswordFOSUser1:changePassword</default>
-        <requirement key="_method">GET|POST</requirement>
     </route>
 
 </routes>

--- a/Resources/config/routing/sonata_profile_1.xml
+++ b/Resources/config/routing/sonata_profile_1.xml
@@ -4,29 +4,27 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="fos_user_profile_show" pattern="/">
+    <route id="fos_user_profile_show" path="/" methods="GET">
         <default key="_controller">SonataUserBundle:ProfileFOSUser1:show</default>
-        <requirement key="_method">GET</requirement>
     </route>
 
-    <route id="fos_user_profile_edit_authentication" pattern="/edit-authentication">
+    <route id="fos_user_profile_edit_authentication" path="/edit-authentication">
         <default key="_controller">SonataUserBundle:ProfileFOSUser1:editAuthentication</default>
     </route>
 
-    <route id="fos_user_profile_edit" pattern="/edit-profile">
+    <route id="fos_user_profile_edit" path="/edit-profile">
         <default key="_controller">SonataUserBundle:ProfileFOSUser1:editProfile</default>
     </route>
 
-    <route id="sonata_user_profile_show" pattern="/">
+    <route id="sonata_user_profile_show" path="/" methods="GET">
         <default key="_controller">SonataUserBundle:ProfileFOSUser1:show</default>
-        <requirement key="_method">GET</requirement>
     </route>
 
-    <route id="sonata_user_profile_edit_authentication" pattern="/edit-authentication">
+    <route id="sonata_user_profile_edit_authentication" path="/edit-authentication">
         <default key="_controller">SonataUserBundle:ProfileFOSUser1:editAuthentication</default>
     </route>
 
-    <route id="sonata_user_profile_edit" pattern="/edit-profile">
+    <route id="sonata_user_profile_edit" path="/edit-profile">
         <default key="_controller">SonataUserBundle:ProfileFOSUser1:editProfile</default>
     </route>
 

--- a/Resources/config/routing/sonata_registration_1.xml
+++ b/Resources/config/routing/sonata_registration_1.xml
@@ -4,42 +4,36 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="fos_user_registration_register" pattern="/">
+    <route id="fos_user_registration_register" path="/">
         <default key="_controller">SonataUserBundle:RegistrationFOSUser1:register</default>
     </route>
 
-    <route id="fos_user_registration_check_email" pattern="/check-email">
+    <route id="fos_user_registration_check_email" path="/check-email" methods="GET">
         <default key="_controller">SonataUserBundle:RegistrationFOSUser1:checkEmail</default>
-        <requirement key="_method">GET</requirement>
     </route>
 
-    <route id="fos_user_registration_confirm" pattern="/confirm/{token}">
+    <route id="fos_user_registration_confirm" path="/confirm/{token}" methods="GET">
         <default key="_controller">SonataUserBundle:RegistrationFOSUser1:confirm</default>
-        <requirement key="_method">GET</requirement>
     </route>
 
-    <route id="fos_user_registration_confirmed" pattern="/confirmed">
+    <route id="fos_user_registration_confirmed" path="/confirmed" methods="GET">
         <default key="_controller">SonataUserBundle:RegistrationFOSUser1:confirmed</default>
-        <requirement key="_method">GET</requirement>
     </route>
 
-    <route id="sonata_user_registration_register" pattern="/">
+    <route id="sonata_user_registration_register" path="/">
         <default key="_controller">SonataUserBundle:RegistrationFOSUser1:register</default>
     </route>
 
-    <route id="sonata_user_registration_check_email" pattern="/check-email">
+    <route id="sonata_user_registration_check_email" path="/check-email" methods="GET">
         <default key="_controller">SonataUserBundle:RegistrationFOSUser1:checkEmail</default>
-        <requirement key="_method">GET</requirement>
     </route>
 
-    <route id="sonata_user_registration_confirm" pattern="/confirm/{token}">
+    <route id="sonata_user_registration_confirm" path="/confirm/{token}" methods="GET">
         <default key="_controller">SonataUserBundle:RegistrationFOSUser1:confirm</default>
-        <requirement key="_method">GET</requirement>
     </route>
 
-    <route id="sonata_user_registration_confirmed" pattern="/confirmed">
+    <route id="sonata_user_registration_confirmed" path="/confirmed" methods="GET">
         <default key="_controller">SonataUserBundle:RegistrationFOSUser1:confirmed</default>
-        <requirement key="_method">GET</requirement>
     </route>
 
 </routes>

--- a/Resources/config/routing/sonata_resetting_1.xml
+++ b/Resources/config/routing/sonata_resetting_1.xml
@@ -4,44 +4,36 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="fos_user_resetting_request" pattern="/request">
+    <route id="fos_user_resetting_request" path="/request" methods="GET">
         <default key="_controller">SonataUserBundle:ResettingFOSUser1:request</default>
-        <requirement key="_method">GET</requirement>
     </route>
 
-    <route id="fos_user_resetting_send_email" pattern="/send-email">
+    <route id="fos_user_resetting_send_email" path="/send-email" methods="POST">
         <default key="_controller">SonataUserBundle:ResettingFOSUser1:sendEmail</default>
-        <requirement key="_method">POST</requirement>
     </route>
 
-    <route id="fos_user_resetting_check_email" pattern="/check-email">
+    <route id="fos_user_resetting_check_email" path="/check-email" methods="GET">
         <default key="_controller">SonataUserBundle:ResettingFOSUser1:checkEmail</default>
-        <requirement key="_method">GET</requirement>
     </route>
 
-    <route id="fos_user_resetting_reset" pattern="/reset/{token}">
+    <route id="fos_user_resetting_reset" path="/reset/{token}" methods="GET POST">
         <default key="_controller">SonataUserBundle:ResettingFOSUser1:reset</default>
-        <requirement key="_method">GET|POST</requirement>
     </route>
 
-    <route id="sonata_user_resetting_request" pattern="/request">
+    <route id="sonata_user_resetting_request" path="/request" methods="GET">
         <default key="_controller">SonataUserBundle:ResettingFOSUser1:request</default>
-        <requirement key="_method">GET</requirement>
     </route>
 
-    <route id="sonata_user_resetting_send_email" pattern="/send-email">
+    <route id="sonata_user_resetting_send_email" path="/send-email" methods="POST">
         <default key="_controller">SonataUserBundle:ResettingFOSUser1:sendEmail</default>
-        <requirement key="_method">POST</requirement>
     </route>
 
-    <route id="sonata_user_resetting_check_email" pattern="/check-email">
+    <route id="sonata_user_resetting_check_email" path="/check-email" methods="GET">
         <default key="_controller">SonataUserBundle:ResettingFOSUser1:checkEmail</default>
-        <requirement key="_method">GET</requirement>
     </route>
 
-    <route id="sonata_user_resetting_reset" pattern="/reset/{token}">
+    <route id="sonata_user_resetting_reset" path="/reset/{token}" methods="GET POST">
         <default key="_controller">SonataUserBundle:ResettingFOSUser1:reset</default>
-        <requirement key="_method">GET|POST</requirement>
     </route>
 
 </routes>

--- a/Resources/config/routing/sonata_security_1.xml
+++ b/Resources/config/routing/sonata_security_1.xml
@@ -4,29 +4,29 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="fos_user_security_login" pattern="/login">
+    <route id="fos_user_security_login" path="/login">
         <default key="_controller">SonataUserBundle:SecurityFOSUser1:login</default>
     </route>
 
-    <route id="fos_user_security_check" pattern="/login_check">
+    <route id="fos_user_security_check" path="/login_check">
         <default key="_controller">SonataUserBundle:SecurityFOSUser1:check</default>
         <requirement key="_method">POST</requirement>
     </route>
 
-    <route id="fos_user_security_logout" pattern="/logout">
+    <route id="fos_user_security_logout" path="/logout">
         <default key="_controller">SonataUserBundle:SecurityFOSUser1:logout</default>
     </route>
 
-    <route id="sonata_user_security_login" pattern="/login">
+    <route id="sonata_user_security_login" path="/login">
         <default key="_controller">SonataUserBundle:SecurityFOSUser1:login</default>
     </route>
 
-    <route id="sonata_user_security_check" pattern="/login_check">
+    <route id="sonata_user_security_check" path="/login_check">
         <default key="_controller">SonataUserBundle:SecurityFOSUser1:check</default>
         <requirement key="_method">POST</requirement>
     </route>
 
-    <route id="sonata_user_security_logout" pattern="/logout">
+    <route id="sonata_user_security_logout" path="/logout">
         <default key="_controller">SonataUserBundle:SecurityFOSUser1:logout</default>
     </route>
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

Replaces arguments that are deprecated from Symfony 2.2:

Before:
```xml
<route id="fos_user_resetting_reset" pattern="/reset/{token}">
    <default key="_controller">SonataUserBundle:ResettingFOSUser1:reset</default>
    <requirement key="_method">GET|POST</requirement>
</route>
```

After:
```xml
<route id="fos_user_resetting_reset" path="/reset/{token}" methods="GET POST">
    <default key="_controller">SonataUserBundle:ResettingFOSUser1:reset</default>
</route>
```