### PR TITLE
Bump jms/serializer-bundle requirement to include ~1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "sonata-project/datagrid-bundle": "~2.2",
 
         "friendsofsymfony/rest-bundle": "~1.1",
-        "jms/serializer-bundle": "~0.11",
+        "jms/serializer-bundle": "~0.11|~1.0",
         "nelmio/api-doc-bundle": "~2.4"
     },
     "require-dev": {


### PR DESCRIPTION
Closes #590.