### PR TITLE
Security token can be null in login form on 404

### DIFF
--- a/Controller/SecurityFOSUser1Controller.php
+++ b/Controller/SecurityFOSUser1Controller.php
@@ -25,9 +25,9 @@ class SecurityFOSUser1Controller extends SecurityController
 {
     public function loginAction()
     {
-        $user = $this->container->get('security.context')->getToken()->getUser();
+        $token = $this->container->get('security.context')->getToken();
 
-        if ($user instanceof UserInterface) {
+        if ($token && $token->getUser() instanceof UserInterface) {
             $this->container->get('session')->getFlashBag()->set('sonata_user_error', 'sonata_user_already_authenticated');
             $url = $this->container->get('router')->generate('sonata_user_profile_show');
 


### PR DESCRIPTION
If you show the sonata login form in a 404 page, the token would be null and an error would show up.
Using the fos user action FOSUserBundle:Security:login doesn't throw an error.

It adds a check on the token.