### PR TITLE
Add Admin password resetting

### DIFF
--- a/Controller/AdminResettingController.php
+++ b/Controller/AdminResettingController.php
@@ -1,0 +1,138 @@
+<?php
+
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Controller;
+
+use FOS\UserBundle\Controller\ResettingController;
+use FOS\UserBundle\Model\UserInterface;
+use FOS\UserBundle\Util\TokenGeneratorInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * @author Márk Sági-Kazár <mark.sagikazar@gmail.com>
+ */
+class AdminResettingController extends ResettingController
+{
+    /**
+     * Request reset user password: show form.
+     */
+    public function requestAction()
+    {
+        if ($this->container->get('security.context')->isGranted('IS_AUTHENTICATED_FULLY')) {
+            return new RedirectResponse($this->container->get('router')->generate('sonata_admin_dashboard'));
+        }
+
+        return $this->container->get('templating')->renderResponse('SonataUserBundle:Admin:Security/Resetting/request.html.'.$this->getEngine(), array(
+            'base_template' => $this->container->get('sonata.admin.pool')->getTemplate('layout'),
+            'admin_pool'    => $this->container->get('sonata.admin.pool'),
+        ));
+    }
+
+    /**
+     * Request reset user password: submit form and send email.
+     */
+    public function sendEmailAction()
+    {
+        $username = $this->container->get('request')->request->get('username');
+
+        /** @var $user UserInterface */
+        $user = $this->container->get('fos_user.user_manager')->findUserByUsernameOrEmail($username);
+
+        if (null === $user) {
+            return $this->container->get('templating')->renderResponse('SonataUserBundle:Admin:Security/Resetting/request.html.'.$this->getEngine(), array(
+                'invalid_username' => $username,
+                'base_template'    => $this->container->get('sonata.admin.pool')->getTemplate('layout'),
+                'admin_pool'       => $this->container->get('sonata.admin.pool'),
+            ));
+        }
+
+        if ($user->isPasswordRequestNonExpired($this->container->getParameter('fos_user.resetting.token_ttl'))) {
+            return $this->container->get('templating')->renderResponse('SonataUserBundle:Admin:Security/Resetting/passwordAlreadyRequested.html.'.$this->getEngine(), array(
+                'base_template'    => $this->container->get('sonata.admin.pool')->getTemplate('layout'),
+                'admin_pool'       => $this->container->get('sonata.admin.pool'),
+            ));
+        }
+
+        if (null === $user->getConfirmationToken()) {
+            /** @var $tokenGenerator TokenGeneratorInterface */
+            $tokenGenerator = $this->container->get('fos_user.util.token_generator');
+            $user->setConfirmationToken($tokenGenerator->generateToken());
+        }
+
+        $this->container->get('session')->set(static::SESSION_EMAIL, $this->getObfuscatedEmail($user));
+        $this->container->get('fos_user.mailer')->sendResettingEmailMessage($user);
+        $user->setPasswordRequestedAt(new \DateTime());
+        $this->container->get('fos_user.user_manager')->updateUser($user);
+
+        return new RedirectResponse($this->container->get('router')->generate('sonata_user_admin_resetting_check_email'));
+    }
+
+    /**
+     * Tell the user to check his email provider.
+     */
+    public function checkEmailAction()
+    {
+        $session = $this->container->get('session');
+        $email = $session->get(static::SESSION_EMAIL);
+        $session->remove(static::SESSION_EMAIL);
+
+        if (empty($email)) {
+            // the user does not come from the sendEmail action
+            return new RedirectResponse($this->container->get('router')->generate('sonata_user_admin_resetting_check_email'));
+        }
+
+        return $this->container->get('templating')->renderResponse('SonataUserBundle:Admin:Security/Resetting/checkEmail.html.'.$this->getEngine(), array(
+            'email'         => $email,
+            'base_template' => $this->container->get('sonata.admin.pool')->getTemplate('layout'),
+            'admin_pool'    => $this->container->get('sonata.admin.pool'),
+        ));
+    }
+
+    /**
+     * Reset user password.
+     */
+    public function resetAction($token)
+    {
+        if ($this->container->get('security.context')->isGranted('IS_AUTHENTICATED_FULLY')) {
+            return new RedirectResponse($this->container->get('router')->generate('sonata_admin_dashboard'));
+        }
+
+        $user = $this->container->get('fos_user.user_manager')->findUserByConfirmationToken($token);
+
+        if (null === $user) {
+            throw new NotFoundHttpException(sprintf('The user with "confirmation token" does not exist for value "%s"', $token));
+        }
+
+        if (!$user->isPasswordRequestNonExpired($this->container->getParameter('fos_user.resetting.token_ttl'))) {
+            return new RedirectResponse($this->container->get('router')->generate('sonata_user_admin_resetting_request'));
+        }
+
+        $form = $this->container->get('fos_user.resetting.form');
+        $formHandler = $this->container->get('fos_user.resetting.form.handler');
+        $process = $formHandler->process($user);
+
+        if ($process) {
+            $this->setFlash('fos_user_success', 'resetting.flash.success');
+            $response = new RedirectResponse($this->container->get('router')->generate('sonata_admin_dashboard'));
+            $this->authenticateUser($user, $response);
+
+            return $response;
+        }
+
+        return $this->container->get('templating')->renderResponse('SonataUserBundle:Admin:Security/Resetting/reset.html.'.$this->getEngine(), array(
+            'token'         => $token,
+            'form'          => $form->createView(),
+            'base_template' => $this->container->get('sonata.admin.pool')->getTemplate('layout'),
+            'admin_pool'    => $this->container->get('sonata.admin.pool'),
+        ));
+    }
+}

--- a/Resources/config/routing/admin_resetting.xml
+++ b/Resources/config/routing/admin_resetting.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<routes xmlns="http://symfony.com/schema/routing"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
+
+    <route id="sonata_user_admin_resetting_request" path="/request" methods="GET">
+        <default key="_controller">SonataUserBundle:AdminResetting:request</default>
+    </route>
+
+    <route id="sonata_user_admin_resetting_send_email" path="/send-email" methods="POST">
+        <default key="_controller">SonataUserBundle:AdminResetting:sendEmail</default>
+    </route>
+
+    <route id="sonata_user_admin_resetting_check_email" path="/check-email" methods="GET">
+        <default key="_controller">SonataUserBundle:AdminResetting:checkEmail</default>
+    </route>
+
+    <route id="sonata_user_admin_resetting_reset" path="/reset/{token}" methods="GET POST">
+        <default key="_controller">SonataUserBundle:AdminResetting:reset</default>
+    </route>
+
+</routes>

--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -192,6 +192,10 @@ Add the related security routing information:
         resource: '@SonataUserBundle/Resources/config/routing/admin_security.xml'
         prefix: /admin
 
+    sonata_user_admin_resetting:
+        resource: '@SonataUserBundle/Resources/config/routing/admin_resetting.xml'
+        prefix: /admin/resetting
+
 Then, add a new custom firewall handlers for the admin:
 
 .. code-block:: yaml
@@ -264,6 +268,7 @@ The last part is to define 3 new access control rules:
             - { path: ^/admin/login$, role: IS_AUTHENTICATED_ANONYMOUSLY }
             - { path: ^/admin/logout$, role: IS_AUTHENTICATED_ANONYMOUSLY }
             - { path: ^/admin/login_check$, role: IS_AUTHENTICATED_ANONYMOUSLY }
+            - { path: ^/admin/resetting, role: IS_AUTHENTICATED_ANONYMOUSLY }
 
             # Secured part of the site
             # This config requires being logged for the whole site and having the admin role for the admin part.

--- a/Resources/views/Admin/Security/Resetting/checkEmail.html.twig
+++ b/Resources/views/Admin/Security/Resetting/checkEmail.html.twig
@@ -1,0 +1,30 @@
+{% extends base_template %}
+
+{% block sonata_nav %}
+{% endblock sonata_nav %}
+
+{% block logo %}
+{% endblock logo %}
+
+{% block sonata_left_side %}
+{% endblock sonata_left_side %}
+
+{% block body_attributes %}class="sonata-bc login-page"{% endblock %}
+
+{% block sonata_wrapper %}
+
+    <div class="login-box">
+        <div class="login-logo">
+            <a href="{{ path('sonata_admin_dashboard') }}">
+                {% if 'single_text' == admin_pool.getOption('title_mode') or 'both' == admin_pool.getOption('title_mode') %}
+                    <span>{{ admin_pool.title }}</span>
+                {% endif %}
+            </a>
+        </div>
+        <div class="login-box-body">
+            <p>{{ 'resetting.check_email'|trans({'%email%': email}, 'FOSUserBundle') }}</p>
+            <a href="{{ path('sonata_user_admin_security_login') }}">{{ 'title_user_authentication'|trans({}, 'SonataUserBundle') }}</a>
+        </div>
+    </div>
+
+{% endblock sonata_wrapper %}

--- a/Resources/views/Admin/Security/Resetting/passwordAlreadyRequested.html.twig
+++ b/Resources/views/Admin/Security/Resetting/passwordAlreadyRequested.html.twig
@@ -1,0 +1,30 @@
+{% extends base_template %}
+
+{% block sonata_nav %}
+{% endblock sonata_nav %}
+
+{% block logo %}
+{% endblock logo %}
+
+{% block sonata_left_side %}
+{% endblock sonata_left_side %}
+
+{% block body_attributes %}class="sonata-bc login-page"{% endblock %}
+
+{% block sonata_wrapper %}
+
+    <div class="login-box">
+        <div class="login-logo">
+            <a href="{{ path('sonata_admin_dashboard') }}">
+                {% if 'single_text' == admin_pool.getOption('title_mode') or 'both' == admin_pool.getOption('title_mode') %}
+                    <span>{{ admin_pool.title }}</span>
+                {% endif %}
+            </a>
+        </div>
+        <div class="login-box-body">
+            <p>{{ 'resetting.password_already_requested'|trans({}, 'FOSUserBundle') }}</p>
+            <a href="{{ path('sonata_user_admin_security_login') }}">{{ 'title_user_authentication'|trans({}, 'SonataUserBundle') }}</a>
+        </div>
+    </div>
+
+{% endblock sonata_wrapper %}

--- a/Resources/views/Admin/Security/Resetting/request.html.twig
+++ b/Resources/views/Admin/Security/Resetting/request.html.twig
@@ -1,0 +1,50 @@
+{% extends base_template %}
+
+{% block sonata_nav %}
+{% endblock sonata_nav %}
+
+{% block logo %}
+{% endblock logo %}
+
+{% block sonata_left_side %}
+{% endblock sonata_left_side %}
+
+{% block body_attributes %}class="sonata-bc login-page"{% endblock %}
+
+{% block sonata_wrapper %}
+
+    <div class="login-box">
+        <div class="login-logo">
+            <a href="{{ path('sonata_admin_dashboard') }}">
+                {% if 'single_text' == admin_pool.getOption('title_mode') or 'both' == admin_pool.getOption('title_mode') %}
+                    <span>{{ admin_pool.title }}</span>
+                {% endif %}
+            </a>
+        </div>
+        <div class="login-box-body">
+            {% block sonata_user_reset_request_form %}
+                {% block sonata_user_reset_request_error %}
+                    {% if invalid_username is defined %}
+                        <div class="alert alert-danger">{{ 'resetting.request.invalid_username'|trans({'%username%': invalid_username}, 'FOSUserBundle') }}</div>
+                    {% endif %}
+                {% endblock %}
+                <p class="login-box-msg">{{ 'resetting.request.submit'|trans({}, 'FOSUserBundle') }}</p>
+                <form action="{{ path('sonata_user_admin_resetting_send_email') }}" method="post" role="form">
+                    <div class="form-group has-feedback">
+                        <input type="text" class="form-control" id="username"  name="username" required="required" placeholder="{{ 'resetting.request.username'|trans({}, 'FOSUserBundle')|replace({':': ''}) }}"/>
+                        <span class="glyphicon glyphicon-user form-control-feedback"></span>
+                    </div>
+
+                    <div class="row">
+                        <div class="col-xs-12">
+                            <button type="submit" class="btn btn-primary btn-block btn-flat">{{ 'resetting.request.submit'|trans({}, 'FOSUserBundle') }}</button>
+                        </div>
+                    </div>
+                </form>
+
+                <a href="{{ path('sonata_user_admin_security_login') }}">{{ 'title_user_authentication'|trans({}, 'SonataUserBundle') }}</a>
+            {% endblock %}
+        </div>
+    </div>
+
+{% endblock sonata_wrapper %}

--- a/Resources/views/Admin/Security/Resetting/reset.html.twig
+++ b/Resources/views/Admin/Security/Resetting/reset.html.twig
@@ -1,0 +1,46 @@
+{% extends base_template %}
+
+{% block sonata_nav %}
+{% endblock sonata_nav %}
+
+{% block logo %}
+{% endblock logo %}
+
+{% block sonata_left_side %}
+{% endblock sonata_left_side %}
+
+{% block body_attributes %}class="sonata-bc login-page"{% endblock %}
+
+{% block sonata_wrapper %}
+
+    <div class="login-box">
+        <div class="login-logo">
+            <a href="{{ path('sonata_admin_dashboard') }}">
+                {% if 'single_text' == admin_pool.getOption('title_mode') or 'both' == admin_pool.getOption('title_mode') %}
+                    <span>{{ admin_pool.title }}</span>
+                {% endif %}
+            </a>
+        </div>
+        <div class="login-box-body">
+            {% block sonata_user_reset_form %}
+                <p class="login-box-msg">{{ 'resetting.reset.submit'|trans({}, 'FOSUserBundle') }}</p>
+                <form action="{{ path('sonata_user_admin_resetting_reset', {'token': token}) }}" method="post" role="form">
+                    <div class="form-group">
+                        <input type="password" class="form-control" id="fos_user_resetting_form_new_first"  name="fos_user_resetting_form[new][first]" required="required" placeholder="{{ 'form.new_password'|trans({}, 'FOSUserBundle')|replace({':': ''}) }}"/>
+                    </div>
+                    <div class="form-group">
+                        <input type="password" class="form-control" id="fos_user_resetting_form_new_second"  name="fos_user_resetting_form[new][second]" required="required" placeholder="{{ 'form.new_password_confirmation'|trans({}, 'FOSUserBundle')|replace({':': ''}) }}"/>
+                    </div>
+                    {{ form_widget(form._token) }}
+
+                    <div class="row">
+                        <div class="col-xs-12">
+                            <button type="submit" class="btn btn-primary btn-block btn-flat">{{ 'resetting.reset.submit'|trans({}, 'FOSUserBundle') }}</button>
+                        </div>
+                    </div>
+                </form>
+            {% endblock %}
+        </div>
+    </div>
+
+{% endblock sonata_wrapper %}

--- a/Resources/views/Admin/Security/login.html.twig
+++ b/Resources/views/Admin/Security/login.html.twig
@@ -13,53 +13,53 @@
 
 {% block sonata_wrapper %}
 
-<div class="login-box">
-    <div class="login-logo">
-        <a href="{{ path('sonata_admin_dashboard') }}">
-            {% if 'single_text' == admin_pool.getOption('title_mode') or 'both' == admin_pool.getOption('title_mode') %}
-                <span>{{ admin_pool.title }}</span>
-            {% endif %}
-        </a>
-    </div><!-- /.login-logo -->
-    <div class="login-box-body">
-        {% block sonata_user_login_form %}
-            {% block sonata_user_login_error %}
-                {% if error %}
-                    <div class="alert alert-danger">{{ error|trans({}, 'FOSUserBundle') }}</div>
+    <div class="login-box">
+        <div class="login-logo">
+            <a href="{{ path('sonata_admin_dashboard') }}">
+                {% if 'single_text' == admin_pool.getOption('title_mode') or 'both' == admin_pool.getOption('title_mode') %}
+                    <span>{{ admin_pool.title }}</span>
                 {% endif %}
-            {% endblock %}
-            <p class="login-box-msg">{{ 'title_user_authentication'|trans({}, 'SonataUserBundle') }}</p>
-            <form action="{{ path("sonata_user_admin_security_check") }}" method="post" role="form">
-                <input type="hidden" name="_csrf_token" value="{{ csrf_token }}"/>
+            </a>
+        </div>
+        <div class="login-box-body">
+            {% block sonata_user_login_form %}
+                {% block sonata_user_login_error %}
+                    {% if error %}
+                        <div class="alert alert-danger">{{ error|trans({}, 'FOSUserBundle') }}</div>
+                    {% endif %}
+                {% endblock %}
+                <p class="login-box-msg">{{ 'title_user_authentication'|trans({}, 'SonataUserBundle') }}</p>
+                <form action="{{ path("sonata_user_admin_security_check") }}" method="post" role="form">
+                    <input type="hidden" name="_csrf_token" value="{{ csrf_token }}"/>
 
-                <div class="form-group has-feedback">
-                    <input type="text" class="form-control" id="username"  name="_username" value="{{ last_username }}" required="required" placeholder="{{ 'security.login.username'|trans({}, 'SonataUserBundle') }}"/>
-                    <span class="glyphicon glyphicon-user form-control-feedback"></span>
-                </div>
+                    <div class="form-group has-feedback">
+                        <input type="text" class="form-control" id="username"  name="_username" value="{{ last_username }}" required="required" placeholder="{{ 'security.login.username'|trans({}, 'SonataUserBundle') }}"/>
+                        <span class="glyphicon glyphicon-user form-control-feedback"></span>
+                    </div>
 
-                <div class="form-group has-feedback">
-                    <input type="password" class="form-control" id="password" name="_password" required="required" placeholder="{{ 'security.login.password'|trans({}, 'SonataUserBundle') }}"/>
-                    <span class="glyphicon glyphicon-lock form-control-feedback"></span>
-                </div>
+                    <div class="form-group has-feedback">
+                        <input type="password" class="form-control" id="password" name="_password" required="required" placeholder="{{ 'security.login.password'|trans({}, 'SonataUserBundle') }}"/>
+                        <span class="glyphicon glyphicon-lock form-control-feedback"></span>
+                    </div>
 
-                <div class="row">
-                    <div class="col-xs-8">
-                        <div class="checkbox icheck">
-                            <label>
-                                <input type="checkbox" id="remember_me" name="_remember_me" value="on"/>
-                                {{ 'security.login.remember_me'|trans({}, 'FOSUserBundle') }}
-                            </label>
+                    <div class="row">
+                        <div class="col-xs-8">
+                            <div class="checkbox icheck">
+                                <label>
+                                    <input type="checkbox" id="remember_me" name="_remember_me" value="on"/>
+                                    {{ 'security.login.remember_me'|trans({}, 'FOSUserBundle') }}
+                                </label>
+                            </div>
+                        </div>
+                        <div class="col-xs-4">
+                            <button type="submit" class="btn btn-primary btn-block btn-flat">{{ 'security.login.submit'|trans({}, 'FOSUserBundle') }}</button>
                         </div>
                     </div>
-                    <div class="col-xs-4">
-                        <button type="submit" class="btn btn-primary btn-block btn-flat">{{ 'security.login.submit'|trans({}, 'FOSUserBundle') }}</button>
-                    </div>
-                </div>
-            </form>
+                </form>
 
-            <a href="{{ path('fos_user_resetting_request') }}">{{ 'forgotten_password'|trans({}, 'SonataUserBundle') }}</a>
-        {% endblock %}
+                <a href="{{ path('sonata_user_admin_resetting_request') }}">{{ 'forgotten_password'|trans({}, 'SonataUserBundle') }}</a>
+            {% endblock %}
+        </div>
     </div>
-</div>
 
 {% endblock sonata_wrapper %}


### PR DESCRIPTION
This PR fixes #618

## Instructions for sandbox

0 Until this gets merged, add this repository manually and install `dev-admin_reset`

### 1. Add routes

Make sure to prefix it with `/admin` or put in a resource file which is loaded with that prefix (like in the sandbox):

``` yaml
sonata_user_resetting:
    resource: '@SonataUserBundle/Resources/config/routing/admin_resetting.xml'
    prefix: /resetting
```

### 2. Add access control

The `/admin/resetting` route must be accessed as anonymus.

In `security.yml`
``` yaml
    access_control:
        - { path: ^/admin/resetting, role: IS_AUTHENTICATED_ANONYMOUSLY }
```

## Notes

- Accessing any of the reset pages as authenticated user redirects to the dashboard. Unlike the AdminSecurity controller, only authentication validity is checked instead of the token, as mentioned in #619
- FOSUserBundle provides a registered form for password reset, however the form is manually created in `SonataUserBundle:Admin:Security/Resetting/reset.html.twig` (mainly because theme reasons). CSRF token is used.
- Translations are used from the FOSUserBundle, however there are ":" after field names. Those are manually trimmed in twig templates, because field names are used as placeholders instead of labels.