### PR TITLE
Better route name for sonata admin security

### DIFF
--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -188,7 +188,7 @@ Add the related security routing information:
 
     # app/config/routing.yml
 
-    sonata_user:
+    sonata_user_admin_security:
         resource: '@SonataUserBundle/Resources/config/routing/admin_security.xml'
         prefix: /admin
 


### PR DESCRIPTION
I didn't find any reference to this route name, so I don't think it is actually a BC break.