### PR TITLE
Fix: Empty route after registration

### DIFF
--- a/Controller/RegistrationFOSUser1Controller.php
+++ b/Controller/RegistrationFOSUser1Controller.php
@@ -64,6 +64,10 @@ class RegistrationFOSUser1Controller extends Controller
                 } else {
                     $url = $this->get('session')->get('sonata_user_redirect_url');
                 }
+
+                if (null === $route) {
+                    $url = $this->generateUrl('sonata_user_profile_show');
+                }
             }
 
             $this->setFlash('fos_user_success', 'registration.flash.user_created');


### PR DESCRIPTION
Sometimes the route could be empty after registration. This could happen when no "sonata_user_redirect_url" value exists in the user session.