### PR TITLE
Travis: Only run supported php versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
       env: SYMFONY_VERSION=2.8.*
     - php: 5.6
       env: SYMFONY_VERSION=2.8.* CS_FIXER=run
-    - php: 5.3
+    - php: 5.5
       env: COMPOSER_FLAGS="--prefer-lowest"
     - php: 5.6
       env: SYMFONY_VERSION=2.3.*
@@ -42,6 +42,10 @@ matrix:
 
   allow_failures:
     - php: hhvm
+    - php: 5.3
+      env: SYMFONY_VERSION=2.8.*
+    - php: 5.4
+      env: SYMFONY_VERSION=2.8.*
 
 before_script:
   - (phpenv config-rm xdebug.ini || exit 0)


### PR DESCRIPTION
Drop support for outdated php versions: https://secure.php.net/supported-versions.php