### PR TITLE
Move form code to external templates

### DIFF
--- a/Resources/views/Profile/edit_authentication.html.twig
+++ b/Resources/views/Profile/edit_authentication.html.twig
@@ -18,11 +18,7 @@ file that was distributed with this source code.
                 <h3 class="panel-title">{{ 'title_user_edit_authentication'|trans({}, 'SonataUserBundle') }}</h3>
             </div>
             <div class="panel-body">
-                <form action="{{ path('sonata_user_profile_edit_authentication') }}" method="POST" class="form-horizontal">
-                    {{ form_widget(form) }}
-
-                    <button type="submit" name="submit" class="btn btn-primary pull-right">{{ 'sonata_user_submit'|trans({}, 'SonataUserBundle') }}</button>
-                </form>
+                {% include "SonataUserBundle:Profile:edit_authentication_content.html.twig" %}
             </div>
         </div>
     </div>

--- a/Resources/views/Profile/edit_authentication_content.html.twig
+++ b/Resources/views/Profile/edit_authentication_content.html.twig
@@ -1,0 +1,5 @@
+<form action="{{ path('sonata_user_profile_edit_authentication') }}" method="POST" class="form-horizontal">
+    {{ form_widget(form) }}
+
+    <button type="submit" name="submit" class="btn btn-primary pull-right">{{ 'sonata_user_submit'|trans({}, 'SonataUserBundle') }}</button>
+</form>

--- a/Resources/views/Profile/edit_profile.html.twig
+++ b/Resources/views/Profile/edit_profile.html.twig
@@ -27,12 +27,7 @@ file that was distributed with this source code.
             <h3 class="panel-title">{{ "title_user_account" | trans({}, 'SonataUserBundle')}}</h3>
         </div>
         <div class="panel-body">
-            <form action="{{ path('sonata_user_profile_edit') }}" method="POST" class="form-horizontal">
-                {{ form_widget(form) }}
-                <div class="form-actions">
-                    <button type="submit" name="submit"  class="btn btn-primary pull-right">{{ 'sonata_user_submit'|trans({}, 'SonataUserBundle') }}</button>
-                </div>
-            </form>
+            {% include "SonataUserBundle:Profile:edit_profile_content.html.twig" %}
         </div>
     </div>
 

--- a/Resources/views/Profile/edit_profile_content.html.twig
+++ b/Resources/views/Profile/edit_profile_content.html.twig
@@ -1,0 +1,6 @@
+<form action="{{ path('sonata_user_profile_edit') }}" method="POST" class="form-horizontal">
+    {{ form_widget(form) }}
+    <div class="form-actions">
+        <button type="submit" name="submit"  class="btn btn-primary pull-right">{{ 'sonata_user_submit'|trans({}, 'SonataUserBundle') }}</button>
+    </div>
+</form>


### PR DESCRIPTION
Use the same structure for templates like in the FOSUserBundle

* https://github.com/FriendsOfSymfony/FOSUserBundle/tree/master/Resources/views/Profile
* https://github.com/FriendsOfSymfony/FOSUserBundle/tree/master/Resources/views/ChangePassword
* ...