### PR TITLE
UI: Updated frontend user templates

### DIFF
--- a/Resources/translations/SonataUserBundle.bg.xliff
+++ b/Resources/translations/SonataUserBundle.bg.xliff
@@ -350,6 +350,18 @@
                 <source>sonata_user</source>
                 <target>Потребители</target>
             </trans-unit>
+            <trans-unit id="title_user_edit_password">
+                <source>title_user_edit_password</source>
+                <target>title_user_edit_password</target>
+            </trans-unit>
+            <trans-unit id="title_user_resetting">
+                <source>title_user_resetting</source>
+                <target>title_user_resetting</target>
+            </trans-unit>
+            <trans-unit id="title_user_resetting_reset">
+                <source>title_user_resetting_reset</source>
+                <target>title_user_resetting_reset</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataUserBundle.ca.xliff
+++ b/Resources/translations/SonataUserBundle.ca.xliff
@@ -510,6 +510,18 @@
                 <source>form.password_confirmation</source>
                 <target>form.password_confifmation</target>
             </trans-unit>
+            <trans-unit id="title_user_edit_password">
+                <source>title_user_edit_password</source>
+                <target>title_user_edit_password</target>
+            </trans-unit>
+            <trans-unit id="title_user_resetting">
+                <source>title_user_resetting</source>
+                <target>title_user_resetting</target>
+            </trans-unit>
+            <trans-unit id="title_user_resetting_reset">
+                <source>title_user_resetting_reset</source>
+                <target>title_user_resetting_reset</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataUserBundle.cs.xliff
+++ b/Resources/translations/SonataUserBundle.cs.xliff
@@ -458,6 +458,18 @@
                 <source>form.password_confirmation</source>
                 <target>Ověření</target>
             </trans-unit>
+            <trans-unit id="title_user_edit_password">
+                <source>title_user_edit_password</source>
+                <target>title_user_edit_password</target>
+            </trans-unit>
+            <trans-unit id="title_user_resetting">
+                <source>title_user_resetting</source>
+                <target>title_user_resetting</target>
+            </trans-unit>
+            <trans-unit id="title_user_resetting_reset">
+                <source>title_user_resetting_reset</source>
+                <target>title_user_resetting_reset</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataUserBundle.de.xliff
+++ b/Resources/translations/SonataUserBundle.de.xliff
@@ -618,6 +618,18 @@
                 <source>form.password_confirmation</source>
                 <target>Passwort bestätigen</target>
             </trans-unit>
+            <trans-unit id="title_user_edit_password">
+                <source>title_user_edit_password</source>
+                <target>Passwort ändern</target>
+            </trans-unit>
+            <trans-unit id="title_user_resetting">
+                <source>title_user_resetting</source>
+                <target>Password vergessen</target>
+            </trans-unit>
+            <trans-unit id="title_user_resetting_reset">
+                <source>title_user_resetting_reset</source>
+                <target>Password zurücksetzen</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataUserBundle.en.xliff
+++ b/Resources/translations/SonataUserBundle.en.xliff
@@ -542,6 +542,18 @@
                 <source>form.password_confirmation</source>
                 <target>Verification</target>
             </trans-unit>
+            <trans-unit id="title_user_edit_password">
+                <source>title_user_edit_password</source>
+                <target>Change password</target>
+            </trans-unit>
+            <trans-unit id="title_user_resetting">
+                <source>title_user_resetting</source>
+                <target>Request password</target>
+            </trans-unit>
+            <trans-unit id="title_user_resetting_reset">
+                <source>title_user_resetting_reset</source>
+                <target>Reset password</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataUserBundle.es.xliff
+++ b/Resources/translations/SonataUserBundle.es.xliff
@@ -510,6 +510,18 @@
                 <source>form.password_confirmation</source>
                 <target>Confirmar contraseña</target>
             </trans-unit>
+            <trans-unit id="title_user_edit_password">
+                <source>title_user_edit_password</source>
+                <target>title_user_edit_password</target>
+            </trans-unit>
+            <trans-unit id="title_user_resetting">
+                <source>title_user_resetting</source>
+                <target>title_user_resetting</target>
+            </trans-unit>
+            <trans-unit id="title_user_resetting_reset">
+                <source>title_user_resetting_reset</source>
+                <target>title_user_resetting_reset</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataUserBundle.fa.xliff
+++ b/Resources/translations/SonataUserBundle.fa.xliff
@@ -506,6 +506,18 @@
                 <source>form.password_confirmation</source>
                 <target>تایید کلمه عبور</target>
             </trans-unit>
+            <trans-unit id="title_user_edit_password">
+                <source>title_user_edit_password</source>
+                <target>title_user_edit_password</target>
+            </trans-unit>
+            <trans-unit id="title_user_resetting">
+                <source>title_user_resetting</source>
+                <target>title_user_resetting</target>
+            </trans-unit>
+            <trans-unit id="title_user_resetting_reset">
+                <source>title_user_resetting_reset</source>
+                <target>title_user_resetting_reset</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataUserBundle.fi.xliff
+++ b/Resources/translations/SonataUserBundle.fi.xliff
@@ -538,6 +538,18 @@
                 <source>form.password_confirmation</source>
                 <target>Vahvistus</target>
             </trans-unit>
+            <trans-unit id="title_user_edit_password">
+                <source>title_user_edit_password</source>
+                <target>title_user_edit_password</target>
+            </trans-unit>
+            <trans-unit id="title_user_resetting">
+                <source>title_user_resetting</source>
+                <target>title_user_resetting</target>
+            </trans-unit>
+            <trans-unit id="title_user_resetting_reset">
+                <source>title_user_resetting_reset</source>
+                <target>title_user_resetting_reset</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataUserBundle.fr.xliff
+++ b/Resources/translations/SonataUserBundle.fr.xliff
@@ -546,6 +546,18 @@
                 <source>form.password_confirmation</source>
                 <target>Vérification</target>
             </trans-unit>
+            <trans-unit id="title_user_edit_password">
+                <source>title_user_edit_password</source>
+                <target>title_user_edit_password</target>
+            </trans-unit>
+            <trans-unit id="title_user_resetting">
+                <source>title_user_resetting</source>
+                <target>title_user_resetting</target>
+            </trans-unit>
+            <trans-unit id="title_user_resetting_reset">
+                <source>title_user_resetting_reset</source>
+                <target>title_user_resetting_reset</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataUserBundle.hr.xliff
+++ b/Resources/translations/SonataUserBundle.hr.xliff
@@ -534,6 +534,18 @@
                 <source>form.password_confirmation</source>
                 <target>Ponovi lozinku</target>
             </trans-unit>
+            <trans-unit id="title_user_edit_password">
+                <source>title_user_edit_password</source>
+                <target>title_user_edit_password</target>
+            </trans-unit>
+            <trans-unit id="title_user_resetting">
+                <source>title_user_resetting</source>
+                <target>title_user_resetting</target>
+            </trans-unit>
+            <trans-unit id="title_user_resetting_reset">
+                <source>title_user_resetting_reset</source>
+                <target>title_user_resetting_reset</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataUserBundle.hu.xliff
+++ b/Resources/translations/SonataUserBundle.hu.xliff
@@ -534,6 +534,18 @@
                 <source>form.password_confirmation</source>
                 <target>Jelszó megismétlése</target>
             </trans-unit>
+            <trans-unit id="title_user_edit_password">
+                <source>title_user_edit_password</source>
+                <target>title_user_edit_password</target>
+            </trans-unit>
+            <trans-unit id="title_user_resetting">
+                <source>title_user_resetting</source>
+                <target>title_user_resetting</target>
+            </trans-unit>
+            <trans-unit id="title_user_resetting_reset">
+                <source>title_user_resetting_reset</source>
+                <target>title_user_resetting_reset</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataUserBundle.it.xliff
+++ b/Resources/translations/SonataUserBundle.it.xliff
@@ -458,6 +458,18 @@
                 <source>form.password_confirmation</source>
                 <target>Conferma password</target>
             </trans-unit>
+            <trans-unit id="title_user_edit_password">
+                <source>title_user_edit_password</source>
+                <target>title_user_edit_password</target>
+            </trans-unit>
+            <trans-unit id="title_user_resetting">
+                <source>title_user_resetting</source>
+                <target>title_user_resetting</target>
+            </trans-unit>
+            <trans-unit id="title_user_resetting_reset">
+                <source>title_user_resetting_reset</source>
+                <target>title_user_resetting_reset</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataUserBundle.ja.xliff
+++ b/Resources/translations/SonataUserBundle.ja.xliff
@@ -486,6 +486,18 @@
                 <source>forgotten_password</source>
                 <target>パスワードをお忘れですか？</target>
             </trans-unit>
+            <trans-unit id="title_user_edit_password">
+                <source>title_user_edit_password</source>
+                <target>title_user_edit_password</target>
+            </trans-unit>
+            <trans-unit id="title_user_resetting">
+                <source>title_user_resetting</source>
+                <target>title_user_resetting</target>
+            </trans-unit>
+            <trans-unit id="title_user_resetting_reset">
+                <source>title_user_resetting_reset</source>
+                <target>title_user_resetting_reset</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataUserBundle.lt.xliff
+++ b/Resources/translations/SonataUserBundle.lt.xliff
@@ -534,6 +534,18 @@
                 <source>form.password_confirmation</source>
                 <target>form.password_erification</target>
             </trans-unit>
+            <trans-unit id="title_user_edit_password">
+                <source>title_user_edit_password</source>
+                <target>title_user_edit_password</target>
+            </trans-unit>
+            <trans-unit id="title_user_resetting">
+                <source>title_user_resetting</source>
+                <target>title_user_resetting</target>
+            </trans-unit>
+            <trans-unit id="title_user_resetting_reset">
+                <source>title_user_resetting_reset</source>
+                <target>title_user_resetting_reset</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataUserBundle.nl.xliff
+++ b/Resources/translations/SonataUserBundle.nl.xliff
@@ -558,6 +558,18 @@
                 <source>form.password_confirmation</source>
                 <target>Wachtwoord bevestigen</target>
             </trans-unit>
+            <trans-unit id="title_user_edit_password">
+                <source>title_user_edit_password</source>
+                <target>title_user_edit_password</target>
+            </trans-unit>
+            <trans-unit id="title_user_resetting">
+                <source>title_user_resetting</source>
+                <target>title_user_resetting</target>
+            </trans-unit>
+            <trans-unit id="title_user_resetting_reset">
+                <source>title_user_resetting_reset</source>
+                <target>title_user_resetting_reset</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataUserBundle.pl.xliff
+++ b/Resources/translations/SonataUserBundle.pl.xliff
@@ -510,6 +510,18 @@
                 <source>form.password_confirmation</source>
                 <target>Weryfikacja</target>
             </trans-unit>
+            <trans-unit id="title_user_edit_password">
+                <source>title_user_edit_password</source>
+                <target>title_user_edit_password</target>
+            </trans-unit>
+            <trans-unit id="title_user_resetting">
+                <source>title_user_resetting</source>
+                <target>title_user_resetting</target>
+            </trans-unit>
+            <trans-unit id="title_user_resetting_reset">
+                <source>title_user_resetting_reset</source>
+                <target>title_user_resetting_reset</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataUserBundle.pt.xliff
+++ b/Resources/translations/SonataUserBundle.pt.xliff
@@ -542,6 +542,18 @@
                 <source>form.password_confirmation</source>
                 <target>Confirmação</target>
             </trans-unit>
+            <trans-unit id="title_user_edit_password">
+                <source>title_user_edit_password</source>
+                <target>title_user_edit_password</target>
+            </trans-unit>
+            <trans-unit id="title_user_resetting">
+                <source>title_user_resetting</source>
+                <target>title_user_resetting</target>
+            </trans-unit>
+            <trans-unit id="title_user_resetting_reset">
+                <source>title_user_resetting_reset</source>
+                <target>title_user_resetting_reset</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataUserBundle.pt_BR.xliff
+++ b/Resources/translations/SonataUserBundle.pt_BR.xliff
@@ -542,6 +542,18 @@
                 <source>Security</source>
                 <target>Segurança</target>
             </trans-unit>
+            <trans-unit id="title_user_edit_password">
+                <source>title_user_edit_password</source>
+                <target>title_user_edit_password</target>
+            </trans-unit>
+            <trans-unit id="title_user_resetting">
+                <source>title_user_resetting</source>
+                <target>title_user_resetting</target>
+            </trans-unit>
+            <trans-unit id="title_user_resetting_reset">
+                <source>title_user_resetting_reset</source>
+                <target>title_user_resetting_reset</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataUserBundle.ro.xliff
+++ b/Resources/translations/SonataUserBundle.ro.xliff
@@ -534,6 +534,18 @@
                 <source>form.password_confirmation</source>
                 <target>Parola repetat</target>
             </trans-unit>
+            <trans-unit id="title_user_edit_password">
+                <source>title_user_edit_password</source>
+                <target>title_user_edit_password</target>
+            </trans-unit>
+            <trans-unit id="title_user_resetting">
+                <source>title_user_resetting</source>
+                <target>title_user_resetting</target>
+            </trans-unit>
+            <trans-unit id="title_user_resetting_reset">
+                <source>title_user_resetting_reset</source>
+                <target>title_user_resetting_reset</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataUserBundle.ru.xliff
+++ b/Resources/translations/SonataUserBundle.ru.xliff
@@ -514,6 +514,18 @@
                 <source>form.password_confirmation</source>
                 <target>Подтверждение пароля</target>
             </trans-unit>
+            <trans-unit id="title_user_edit_password">
+                <source>title_user_edit_password</source>
+                <target>title_user_edit_password</target>
+            </trans-unit>
+            <trans-unit id="title_user_resetting">
+                <source>title_user_resetting</source>
+                <target>title_user_resetting</target>
+            </trans-unit>
+            <trans-unit id="title_user_resetting_reset">
+                <source>title_user_resetting_reset</source>
+                <target>title_user_resetting_reset</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataUserBundle.sk.xliff
+++ b/Resources/translations/SonataUserBundle.sk.xliff
@@ -458,6 +458,18 @@
                 <source>form.password_confirmation</source>
                 <target>Heslo znovu</target>
             </trans-unit>
+            <trans-unit id="title_user_edit_password">
+                <source>title_user_edit_password</source>
+                <target>title_user_edit_password</target>
+            </trans-unit>
+            <trans-unit id="title_user_resetting">
+                <source>title_user_resetting</source>
+                <target>title_user_resetting</target>
+            </trans-unit>
+            <trans-unit id="title_user_resetting_reset">
+                <source>title_user_resetting_reset</source>
+                <target>title_user_resetting_reset</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataUserBundle.sl.xliff
+++ b/Resources/translations/SonataUserBundle.sl.xliff
@@ -534,6 +534,18 @@
                 <source>form.password_confirmation</source>
                 <target>form.password_erification</target>
             </trans-unit>
+            <trans-unit id="title_user_edit_password">
+                <source>title_user_edit_password</source>
+                <target>title_user_edit_password</target>
+            </trans-unit>
+            <trans-unit id="title_user_resetting">
+                <source>title_user_resetting</source>
+                <target>title_user_resetting</target>
+            </trans-unit>
+            <trans-unit id="title_user_resetting_reset">
+                <source>title_user_resetting_reset</source>
+                <target>title_user_resetting_reset</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataUserBundle.uk.xliff
+++ b/Resources/translations/SonataUserBundle.uk.xliff
@@ -514,6 +514,18 @@
                 <source>form.password_confirmation</source>
                 <target>Підтвердження пароля</target>
             </trans-unit>
+            <trans-unit id="title_user_edit_password">
+                <source>title_user_edit_password</source>
+                <target>title_user_edit_password</target>
+            </trans-unit>
+            <trans-unit id="title_user_resetting">
+                <source>title_user_resetting</source>
+                <target>title_user_resetting</target>
+            </trans-unit>
+            <trans-unit id="title_user_resetting_reset">
+                <source>title_user_resetting_reset</source>
+                <target>title_user_resetting_reset</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/SonataUserBundle.zh_TW.xliff
+++ b/Resources/translations/SonataUserBundle.zh_TW.xliff
@@ -346,6 +346,18 @@
                 <source>form.password_confirmation</source>
                 <target>form.password_erification</target>
             </trans-unit>
+            <trans-unit id="title_user_edit_password">
+                <source>title_user_edit_password</source>
+                <target>title_user_edit_password</target>
+            </trans-unit>
+            <trans-unit id="title_user_resetting">
+                <source>title_user_resetting</source>
+                <target>title_user_resetting</target>
+            </trans-unit>
+            <trans-unit id="title_user_resetting_reset">
+                <source>title_user_resetting_reset</source>
+                <target>title_user_resetting_reset</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/views/ChangePassword/changePassword.html.twig
+++ b/Resources/views/ChangePassword/changePassword.html.twig
@@ -1,5 +1,16 @@
-{% extends "FOSUserBundle::layout.html.twig" %}
+{% extends "SonataUserBundle:Profile:action.html.twig" %}
 
-{% block fos_user_content %}
-{% include "SonataUserBundle:ChangePassword:changePassword_content.html.twig" %}
-{% endblock fos_user_content %}
+{% block sonata_profile_content %}
+    {{ form_errors(form) }}
+
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">{{ "title_user_edit_password" | trans({}, 'SonataUserBundle') }}</h3>
+        </div>
+        <div class="panel-body">
+            {% block fos_user_content %}
+                {% include "SonataUserBundle:ChangePassword:changePassword_content.html.twig" %}
+            {% endblock fos_user_content %}
+        </div>
+    </div>
+{% endblock sonata_profile_content %}

--- a/Resources/views/ChangePassword/changePassword_content.html.twig
+++ b/Resources/views/ChangePassword/changePassword_content.html.twig
@@ -1,4 +1,9 @@
-<form action="{{ path('sonata_user_change_password') }}" {{ form_enctype(form) }} method="POST" class="fos_user_change_password form-horizontal">
-    {{ form_widget(form) }}
-    <button type="submit" class="btn btn-danger pull-right"><i class="icon-lock icon-white glyphicon glyphicon-lock"></i>&nbsp;{{ 'change_password.submit'|trans({}, 'FOSUserBundle') }}</button>
-</form>
+{{ form_start(form, {'action': path('sonata_user_change_password')  }) }}
+{{ form_widget(form) }}
+
+<div class="form-actions form-group">
+    <div class="col-sm-offset-3 col-sm-9">
+        <button type="submit" class="btn btn-danger">{{ 'change_password.submit'|trans({}, 'FOSUserBundle') }}</button>
+    </div>
+</div>
+{{ form_end(form) }}

--- a/Resources/views/Resetting/request.html.twig
+++ b/Resources/views/Resetting/request.html.twig
@@ -1,0 +1,12 @@
+{% extends "SonataUserBundle::layout.html.twig" %}
+
+{% block fos_user_content %}
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">{{ "title_user_resetting" | trans({}, 'SonataUserBundle') }}</h3>
+        </div>
+        <div class="panel-body">
+            {% include "FOSUserBundle:Resetting:request_content.html.twig" %}
+        </div>
+    </div>
+{% endblock fos_user_content %}

--- a/Resources/views/Resetting/request_content.html.twig
+++ b/Resources/views/Resetting/request_content.html.twig
@@ -1,0 +1,16 @@
+<form action="{{ path('sonata_user_resetting_send_email') }}" method="POST" class="fos_user_resetting_request">
+    {% if invalid_username is defined %}
+        <div class="alert alert-danger">{{ 'resetting.request.invalid_username'|trans({'%username%': invalid_username}, 'FOSUserBundle') }}</div>
+    {% endif %}
+
+    <div class="form-group">
+        <label for="username" class="control-label required">{{ 'resetting.request.username'|trans({}, 'FOSUserBundle') }} * </label>
+        <input type="text" id="username" name="username" required="required" />
+    </div>
+
+    <div class="form-actions form-group">
+        <div class="col-sm-offset-3 col-sm-9">
+            <input type="submit" value="{{ 'resetting.request.submit'|trans({}, 'FOSUserBundle') }}" class="btn btn-primary" />
+        </div>
+    </div>
+</form>

--- a/Resources/views/Resetting/reset.html.twig
+++ b/Resources/views/Resetting/reset.html.twig
@@ -1,0 +1,14 @@
+{% extends "SonataUserBundle::layout.html.twig" %}
+
+{% block fos_user_content %}
+    {{ form_errors(form) }}
+
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">{{ "title_user_resetting_reset" | trans({}, 'SonataUserBundle') }}</h3>
+        </div>
+        <div class="panel-body">
+            {% include "FOSUserBundle:Resetting:reset_content.html.twig" %}
+        </div>
+    </div>
+{% endblock fos_user_content %}

--- a/Resources/views/Resetting/reset_content.html.twig
+++ b/Resources/views/Resetting/reset_content.html.twig
@@ -1,0 +1,9 @@
+{{ form_start(form, {'action': path('sonata_user_resetting_reset', {'token': token } ) }) }}
+{{ form_widget(form) }}
+
+<div class="form-actions form-group">
+    <div class="col-sm-offset-3 col-sm-9">
+        <input type="submit" value="{{ 'resetting.reset.submit'|trans({}, 'FOSUserBundle') }}" class="btn btn-primary" />
+    </div>
+</div>
+{{ form_end(form) }}


### PR DESCRIPTION
This will change the frontend templates to show a panel around the forms.

**Change password**
Before
![bildschirmfoto 2016-01-16 um 20 20 40](https://cloud.githubusercontent.com/assets/3440437/12374107/0836a16c-bc92-11e5-8f02-3c3795b03e9c.PNG)
After
![bildschirmfoto 2016-01-16 um 20 20 04](https://cloud.githubusercontent.com/assets/3440437/12374106/08216ab8-bc92-11e5-808b-2a6551730a4d.PNG)

**Request password**
Before
![bildschirmfoto 2016-01-16 um 20 26 35](https://cloud.githubusercontent.com/assets/3440437/12374109/084b8050-bc92-11e5-84c4-0854cfdd5a0e.PNG)
After
![bildschirmfoto 2016-01-16 um 20 27 13](https://cloud.githubusercontent.com/assets/3440437/12374108/0849311a-bc92-11e5-98cb-2584863e206a.PNG)

**Reset password**
Before
![bildschirmfoto 2016-01-16 um 20 30 59](https://cloud.githubusercontent.com/assets/3440437/12374110/084cefa8-bc92-11e5-994d-5d7cde1c3763.PNG)
After
![bildschirmfoto 2016-01-16 um 20 31 41](https://cloud.githubusercontent.com/assets/3440437/12374111/084ef2d0-bc92-11e5-84b5-12eee3dde145.PNG)
