### PR TITLE
[FOS2] Fix renamed service fos_user.entity_manager

### DIFF
--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -9,7 +9,7 @@
             <argument type="service" id="security.encoder_factory" />
             <argument type="service" id="fos_user.util.username_canonicalizer" />
             <argument type="service" id="fos_user.util.email_canonicalizer" />
-            <argument type="service" id="fos_user.entity_manager" />
+            <argument type="service" id="fos_user.object_manager" />
             <argument>%fos_user.model.user.class%</argument>
         </service>
 


### PR DESCRIPTION
Like mentioned in https://github.com/sonata-project/SonataUserBundle/issues/322#issuecomment-186171692 this service has been renamed in fos 2, and therefore I suppose it should be changed.

Or do we need to support both fos versions?