### PR TITLE
Deprecate factory-* methods for Symfony >2.6 

### DIFF
--- a/DependencyInjection/SonataUserExtension.php
+++ b/DependencyInjection/SonataUserExtension.php
@@ -49,6 +49,22 @@ class SonataUserExtension extends Extension
         $loader->load('block.xml');
         $loader->load('menu.xml');
         $loader->load('form.xml');
+
+        $defProfileForm = $container->getDefinition('sonata.user.profile.form');
+        $defRegistrationForm = $container->getDefinition('sonata.user.registration.form');
+
+        if (method_exists($defProfileForm, 'setFactory')) {
+            // to be inlined in form.xml when dependency on Symfony DependencyInjection is bumped to 2.6
+            $defProfileForm->setFactory(array(new Reference('form.factory'), 'createNamed'));
+            $defRegistrationForm->setFactory(array(new Reference('form.factory'), 'createNamed'));
+        } else {
+            // to be removed when dependency on Symfony DependencyInjection is bumped to 2.6
+            $defProfileForm->setFactoryService('form.factory');
+            $defProfileForm->setFactoryMethod('createNamed');
+            $defRegistrationForm->setFactoryService('form.factory');
+            $defRegistrationForm->setFactoryMethod('createNamed');
+        }
+
         $loader->load('google_authenticator.xml');
         $loader->load('twig.xml');
 

--- a/Resources/config/form.xml
+++ b/Resources/config/form.xml
@@ -5,7 +5,7 @@
 
     <services>
         <!-- profile form -->
-        <service id="sonata.user.profile.form" factory-method="createNamed" factory-service="form.factory" class="Symfony\Component\Form\Form">
+        <service id="sonata.user.profile.form" class="Symfony\Component\Form\Form">
             <argument>%sonata.user.profile.form.name%</argument>
             <argument>%sonata.user.profile.form.type%</argument>
             <argument>null</argument>
@@ -34,7 +34,7 @@
             <tag name="form.type" alias="sonata_user_gender" />
         </service>
 
-        <service id="sonata.user.registration.form" factory-method="createNamed" factory-service="form.factory" class="Symfony\Component\Form\Form">
+        <service id="sonata.user.registration.form" class="Symfony\Component\Form\Form">
             <argument>%sonata.user.registration.form.name%</argument>
             <argument>%sonata.user.registration.form.type%</argument>
             <argument>null</argument>


### PR DESCRIPTION
Maintain compatibility with Symfony <2.6

in favor of #561
close #563