### PR TITLE
FOSUserBundle 2.x: Show exception message instead of dumping exception on login page

### DIFF
--- a/Controller/AdminSecurityController.php
+++ b/Controller/AdminSecurityController.php
@@ -54,6 +54,7 @@ class AdminSecurityController extends SecurityController
             'base_template' => $this->get('sonata.admin.pool')->getTemplate('layout'),
             'admin_pool'    => $this->get('sonata.admin.pool'),
             'reset_route'   => $this->generateUrl('sonata_user_admin_resetting_request'),
+            'error'         => $data['error'] instanceof \Exception ? $data['error']->getMessage() : $data['error'],
         )));
     }
 }


### PR DESCRIPTION
Show exception message like 'Bad credentials' instead of dumping the entire exception object BadCredentialsException when trying to log in with wrong credentials.