### PR TITLE
Fixes the padding issue after merging PR #3672

### DIFF
--- a/Resources/views/Admin/Security/login.html.twig
+++ b/Resources/views/Admin/Security/login.html.twig
@@ -44,7 +44,7 @@
 
                     <div class="row">
                         <div class="col-xs-8">
-                            <div class="checkbox icheck">
+                            <div class="checkbox">
                                 <label>
                                     <input type="checkbox" id="remember_me" name="_remember_me" value="on"/>
                                     {{ 'security.login.remember_me'|trans({}, 'FOSUserBundle') }}


### PR DESCRIPTION
Removes the `.icheck` class on the "Remember me" checkbox of the login form.
See [SonataAdminBundle#3672](https://github.com/sonata-project/SonataAdminBundle/pull/3672)