### PR TITLE
Replaced redirectToRoute for old symfony versions

### DIFF
--- a/Controller/ProfileFOSUser1Controller.php
+++ b/Controller/ProfileFOSUser1Controller.php
@@ -61,7 +61,7 @@ class ProfileFOSUser1Controller extends Controller
         if ($process) {
             $this->setFlash('sonata_user_success', 'profile.flash.updated');
 
-            return $this->redirectToRoute('sonata_user_profile_show');
+            return $this->redirect($this->generateUrl('sonata_user_profile_show'));
         }
 
         return $this->render('SonataUserBundle:Profile:edit_authentication.html.twig', array(
@@ -88,7 +88,7 @@ class ProfileFOSUser1Controller extends Controller
         if ($process) {
             $this->setFlash('sonata_user_success', 'profile.flash.updated');
 
-            return $this->redirectToRoute('sonata_user_profile_show');
+            return $this->redirect($this->generateUrl('sonata_user_profile_show'));
         }
 
         return $this->render('SonataUserBundle:Profile:edit_profile.html.twig', array(

--- a/Controller/RegistrationFOSUser1Controller.php
+++ b/Controller/RegistrationFOSUser1Controller.php
@@ -39,7 +39,7 @@ class RegistrationFOSUser1Controller extends Controller
         if ($user instanceof UserInterface) {
             $this->get('session')->getFlashBag()->set('sonata_user_error', 'sonata_user_already_authenticated');
 
-            return $this->redirectToRoute('sonata_user_profile_show');
+            return $this->redirect($this->generateUrl('sonata_user_profile_show'));
         }
 
         $form = $this->get('sonata.user.registration.form');
@@ -133,9 +133,9 @@ class RegistrationFOSUser1Controller extends Controller
 
         $this->get('fos_user.user_manager')->updateUser($user);
         if ($redirectRoute = $this->container->getParameter('sonata.user.register.confirm.redirect_route')) {
-            $response = $this->redirectToRoute($redirectRoute, $this->container->getParameter('sonata.user.register.confirm.redirect_route_params'));
+            $response = $this->redirect($this->generateUrl($redirectRoute, $this->container->getParameter('sonata.user.register.confirm.redirect_route_params')));
         } else {
-            $response = $this->redirectToRoute('fos_user_registration_confirmed');
+            $response = $this->redirect($this->generateUrl('fos_user_registration_confirmed'));
         }
 
         $this->authenticateUser($user, $response);


### PR DESCRIPTION
Fixed error, introduced by https://github.com/sonata-project/SonataUserBundle/pull/641

The method ``redirectToRoute`` exists since symfony 2.6.