### PR TITLE
Fixed the 'Bad Credentials' translation problem

### DIFF
--- a/Controller/AdminSecurityController.php
+++ b/Controller/AdminSecurityController.php
@@ -42,19 +42,19 @@ class AdminSecurityController extends Controller
         $session = $request->getSession();
 
         // get the error if any (works with forward and redirect -- see below)
-        if ($request->attributes->has(SecurityContext::AUTHENTICATION_ERROR)) {
-            $error = $request->attributes->get(SecurityContext::AUTHENTICATION_ERROR);
-        } elseif (null !== $session && $session->has(SecurityContext::AUTHENTICATION_ERROR)) {
-            $error = $session->get(SecurityContext::AUTHENTICATION_ERROR);
-            $session->remove(SecurityContext::AUTHENTICATION_ERROR);
+        if ($request->attributes->has(SecurityContextInterface::AUTHENTICATION_ERROR)) {
+            $error = $request->attributes->get(SecurityContextInterface::AUTHENTICATION_ERROR);
+        } elseif (null !== $session && $session->has(SecurityContextInterface::AUTHENTICATION_ERROR)) {
+            $error = $session->get(SecurityContextInterface::AUTHENTICATION_ERROR);
+            $session->remove(SecurityContextInterface::AUTHENTICATION_ERROR);
         } else {
-            $error = '';
+            $error = null;
         }
 
-        if ($error) {
-            // TODO: this is a potential security risk (see http://trac.symfony-project.org/ticket/9523)
-            $error = $error->getMessage();
+        if (!$error instanceof AuthenticationException) {
+            $error = null; // The value does not come from the security component.
         }
+
         // last username entered by the user
         $lastUsername = (null === $session) ? '' : $session->get(SecurityContext::LAST_USERNAME);
 

--- a/Resources/translations/SonataUserBundle.de.xliff
+++ b/Resources/translations/SonataUserBundle.de.xliff
@@ -494,10 +494,6 @@
                 <source>Gender</source>
                 <target>Geschlecht</target>
             </trans-unit>
-            <trans-unit id="Bad credentials">
-                <source>Bad credentials</source>
-                <target>Benutzername oder Passwort ungültig</target>
-            </trans-unit>
             <trans-unit id="sonata_profile_title">
                 <source>sonata_profile_title</source>
                 <target>Profil</target>

--- a/Resources/views/Admin/Security/login.html.twig
+++ b/Resources/views/Admin/Security/login.html.twig
@@ -30,7 +30,9 @@
             {% block sonata_user_login_form %}
                 {% block sonata_user_login_error %}
                     {% if error %}
-                        <div class="alert alert-danger">{{ error|trans({}, 'FOSUserBundle') }}</div>
+                        <div class="alert alert-danger alert-error">
+                            {{ error.messageKey|trans(error.messageData, 'security') }}
+                        </div>
                     {% endif %}
                 {% endblock %}
                 <p class="login-box-msg">{{ 'title_user_authentication'|trans({}, 'SonataUserBundle') }}</p>

--- a/Resources/views/Security/base_login.html.twig
+++ b/Resources/views/Security/base_login.html.twig
@@ -25,7 +25,9 @@ file that was distributed with this source code.
 
                     {% block sonata_user_login_error %}
                         {% if error %}
-                            <div class="alert alert-danger alert-error">{{ error|trans({}, 'FOSUserBundle') }}</div>
+                            <div class="alert alert-danger alert-error">
+                                {{ error.messageKey|trans(error.messageData, 'security') }}
+                            </div>
                         {% endif %}
                     {% endblock %}
 


### PR DESCRIPTION
As related in this [issue](https://github.com/sonata-project/SonataUserBundle/issues/621) there was a problem with the error message in the login page, that was not being translated. That was a error with FOSUserBundle, that apparently will be fixed in the 2.0 version, but since there is no prediction to when it will be ready. I made some changes by myself based on the dev-master of FOSUserBundle.

I changed both security controllers and the templates for the login page to look more like the latest version of FOSUserBundle. Now the error message is translated with the 'security'. Also took out the Bad Credentials entry in one of the translation files since there is no need for it.