### PR TITLE
Removed useless ROLE_SUPER_ADMIN check in UserAdmin

### DIFF
--- a/Admin/Model/UserAdmin.php
+++ b/Admin/Model/UserAdmin.php
@@ -186,38 +186,28 @@ class UserAdmin extends Admin
                     ->add('gplusName', null, array('required' => false))
                 ->end()
             ->end()
-        ;
-
-        if ($this->getSubject() && !$this->getSubject()->hasRole('ROLE_SUPER_ADMIN')) {
-            $formMapper
-                ->tab('Security')
-                    ->with('Status')
-                        ->add('locked', null, array('required' => false))
-                        ->add('expired', null, array('required' => false))
-                        ->add('enabled', null, array('required' => false))
-                        ->add('credentialsExpired', null, array('required' => false))
-                    ->end()
-                    ->with('Groups')
-                        ->add('groups', 'sonata_type_model', array(
-                            'required' => false,
-                            'expanded' => true,
-                            'multiple' => true,
-                        ))
-                    ->end()
-                    ->with('Roles')
-                        ->add('realRoles', 'sonata_security_roles', array(
-                            'label'    => 'form.label_roles',
-                            'expanded' => true,
-                            'multiple' => true,
-                            'required' => false,
-                        ))
-                    ->end()
-                ->end()
-            ;
-        }
-
-        $formMapper
             ->tab('Security')
+                ->with('Status')
+                    ->add('locked', null, array('required' => false))
+                    ->add('expired', null, array('required' => false))
+                    ->add('enabled', null, array('required' => false))
+                    ->add('credentialsExpired', null, array('required' => false))
+                ->end()
+                ->with('Groups')
+                    ->add('groups', 'sonata_type_model', array(
+                        'required' => false,
+                        'expanded' => true,
+                        'multiple' => true,
+                    ))
+                ->end()
+                ->with('Roles')
+                    ->add('realRoles', 'sonata_security_roles', array(
+                        'label'    => 'form.label_roles',
+                        'expanded' => true,
+                        'multiple' => true,
+                        'required' => false,
+                    ))
+                ->end()
                 ->with('Keys')
                     ->add('token', null, array('required' => false))
                     ->add('twoStepVerificationCode', null, array('required' => false))


### PR DESCRIPTION
You can't edit the groups or status of other ROLE_SUPER_ADMIN users.

Refs https://github.com/sonata-project/SonataUserBundle/issues/706