### PR TITLE
Update version number for admin bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "symfony/security-acl": "~2.8|~3.0",
         "symfony/console": "~2.8|~3.0",
         "sonata-project/core-bundle": "~2.3,>=2.3.10",
-        "sonata-project/admin-bundle": "~2.3|~2.4@dev",
+        "sonata-project/admin-bundle": "~2.3|~3.0@dev",
         "friendsofsymfony/user-bundle": "~2.0@dev",
         "sonata-project/doctrine-extensions": "~1.0",
         "sonata-project/easy-extends-bundle": "~2.1",


### PR DESCRIPTION
Version 2.4 does not exist anymore.
See https://github.com/sonata-project/SonataAdminBundle/issues/3731 for details.