### PR TITLE
Make Google Authenticator dependency optional

### DIFF
--- a/DependencyInjection/SonataUserExtension.php
+++ b/DependencyInjection/SonataUserExtension.php
@@ -49,7 +49,11 @@ class SonataUserExtension extends Extension
         $loader->load('block.xml');
         $loader->load('menu.xml');
         $loader->load('form.xml');
-        $loader->load('google_authenticator.xml');
+
+        if (class_exists('Google\Authenticator\GoogleAuthenticator')) {
+            $loader->load('google_authenticator.xml');
+        }
+
         $loader->load('twig.xml');
 
         if ('orm' === $config['manager_type'] && isset($bundles['FOSRestBundle']) && isset($bundles['NelmioApiDocBundle'])) {

--- a/Resources/doc/reference/installation.rst
+++ b/Resources/doc/reference/installation.rst
@@ -28,6 +28,7 @@ Enable the Bundle
     php composer.phar require sonata-project/doctrine-orm-admin-bundle  --no-update # optional
     php composer.phar require friendsofsymfony/rest-bundle  --no-update # optional when using api
     php composer.phar require nelmio/api-doc-bundle  --no-update # optional when using api
+    php composer.phar require sonata-project/google-authenticator --no-update # optional
     php composer.phar update
 
 Next, be sure to enable the bundles in your and ``AppKernel.php`` file:
@@ -80,10 +81,10 @@ When using ACL, the ``UserBundle`` can prevent `normal` user to change settings 
     # app/config/security.yml
     security:
         # [...]
-        
+
         encoders:
             FOS\UserBundle\Model\UserInterface: sha512
-        
+
         acl:
             connection: default
 

--- a/Resources/doc/reference/introduction.rst
+++ b/Resources/doc/reference/introduction.rst
@@ -9,7 +9,7 @@ Integrates the ``FOS/UserBundle`` in the Sonata Admin Project and adds some feat
 
  - ``AdminBundle``: add user and group management
  - ``EasyExtends``: allows to generate Application level model
- - ``Features``: User profile dashboard, user profile menu, Google Authenticator support, ...
+ - ``Features``: User profile dashboard, user profile menu, Google Authenticator support (optional), ...
 
 The roles to be assigned to users are splitted in 2 parts:
 

--- a/composer.json
+++ b/composer.json
@@ -28,20 +28,21 @@
         "friendsofsymfony/user-bundle": "^1.3",
         "sonata-project/doctrine-extensions": "^1.0",
         "sonata-project/easy-extends-bundle": "^2.1",
-        "sonata-project/google-authenticator": "^1.0",
         "friendsofsymfony/rest-bundle": "^1.1",
         "jms/serializer-bundle": "~0.13 || ^1.0",
         "nelmio/api-doc-bundle": "^2.4"
     },
     "require-dev": {
         "sonata-project/seo-bundle": "^2.0",
+        "sonata-project/google-authenticator": "^1.0",
         "doctrine/orm": "^2.0",
         "symfony/phpunit-bridge": "^2.8 || ^3.0",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0"
     },
     "suggest": {
         "sonata-project/doctrine-orm-admin-bundle": "^3.0",
-        "sonata-project/seo-bundle": "For SEO breadcrumb block service usage"
+        "sonata-project/seo-bundle": "For SEO breadcrumb block service usage",
+        "sonata-project/google-authenticator": "For two-factor authentication",
     },
     "conflict": {
         "jms/serializer": "<0.13",


### PR DESCRIPTION
Resubmission of sonata-project/SonataUserBundle#653

### Changelog

```markdown
### Changed
- Google Authenticator is now optional, you have to install it manually.
```

### Subject

This PR removes the mandatory Google Authenticator dependency. It provides a feature, not a core functionality, so making it optional actually makes sense.

