### PR TITLE
Remove deprecated Admin class, use AbstractAdmin

### DIFF
--- a/Admin/Model/GroupAdmin.php
+++ b/Admin/Model/GroupAdmin.php
@@ -11,12 +11,12 @@
 
 namespace Sonata\UserBundle\Admin\Model;
 
-use Sonata\AdminBundle\Admin\Admin;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
 
-class GroupAdmin extends Admin
+class GroupAdmin extends AbstractAdmin
 {
     /**
      * {@inheritdoc}

--- a/Admin/Model/UserAdmin.php
+++ b/Admin/Model/UserAdmin.php
@@ -12,13 +12,13 @@
 namespace Sonata\UserBundle\Admin\Model;
 
 use FOS\UserBundle\Model\UserManagerInterface;
-use Sonata\AdminBundle\Admin\Admin;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Show\ShowMapper;
 
-class UserAdmin extends Admin
+class UserAdmin extends AbstractAdmin
 {
     /**
      * @var UserManagerInterface

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "symfony/security": "^2.3",
         "symfony/console": "^2.3",
         "sonata-project/core-bundle": "^3.0",
-        "sonata-project/admin-bundle": "^3.0",
+        "sonata-project/admin-bundle": "^3.1",
         "sonata-project/datagrid-bundle": "^2.2",
         "friendsofsymfony/user-bundle": "^1.3",
         "sonata-project/doctrine-extensions": "^1.0",


### PR DESCRIPTION
### Changelog

```markdown
### Changed
- Admin classes extend `Sonata\AdminBundle\Admin\AbstractAdmin`
```

### Subject

Removes deprecated Admin class usage.

