### PR TITLE
[WIP] FOSUser 2.0 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,8 @@ matrix:
     - php: '7.0'
       env: FOS_USER=1.3.*
     - php: '7.0'
+      env: FOS_USER=2.0.*@dev
+    - php: '7.0'
       env: FOS_USER=dev-master@dev
     - php: '7.0'
       env: SONATA_CORE=3.*

--- a/Document/BaseGroup.php
+++ b/Document/BaseGroup.php
@@ -11,7 +11,7 @@
 
 namespace Sonata\UserBundle\Document;
 
-use FOS\UserBundle\Document\Group as AbstractedGroup;
+use FOS\UserBundle\Model\Group as AbstractedGroup;
 
 /**
  * Represents a Base Group Document.

--- a/Entity/BaseGroup.php
+++ b/Entity/BaseGroup.php
@@ -11,7 +11,7 @@
 
 namespace Sonata\UserBundle\Entity;
 
-use FOS\UserBundle\Entity\Group as AbstractedGroup;
+use FOS\UserBundle\Model\Group as AbstractedGroup;
 
 /**
  * Represents a Base Group Entity.

--- a/Entity/GroupManager.php
+++ b/Entity/GroupManager.php
@@ -11,7 +11,7 @@
 
 namespace Sonata\UserBundle\Entity;
 
-use FOS\UserBundle\Entity\GroupManager as BaseGroupManager;
+use FOS\UserBundle\Doctrine\GroupManager as BaseGroupManager;
 use Sonata\DatagridBundle\Pager\Doctrine\Pager;
 use Sonata\DatagridBundle\ProxyQuery\Doctrine\ProxyQuery;
 use Sonata\UserBundle\Model\GroupManagerInterface;

--- a/Model/User.php
+++ b/Model/User.php
@@ -11,7 +11,7 @@
 
 namespace Sonata\UserBundle\Model;
 
-use FOS\UserBundle\Entity\User as AbstractedUser;
+use FOS\UserBundle\Model\User as AbstractedUser;
 
 /**
  * Represents a User model.

--- a/Tests/Controller/Api/GroupControllerTest.php
+++ b/Tests/Controller/Api/GroupControllerTest.php
@@ -55,7 +55,7 @@ class GroupControllerTest extends \PHPUnit_Framework_TestCase
         $group = $this->getMock('FOS\UserBundle\Model\GroupInterface');
 
         $groupManager = $this->getMock('Sonata\UserBundle\Model\GroupManagerInterface');
-        $groupManager->expects($this->once())->method('getClass')->will($this->returnValue('FOS\UserBundle\Entity\Group'));
+        $groupManager->expects($this->once())->method('getClass')->will($this->returnValue('Sonata\UserBundle\Entity\BaseGroup'));
         $groupManager->expects($this->once())->method('updateGroup')->will($this->returnValue($group));
 
         $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
@@ -74,7 +74,7 @@ class GroupControllerTest extends \PHPUnit_Framework_TestCase
     public function testPostGroupInvalidAction()
     {
         $groupManager = $this->getMock('Sonata\UserBundle\Model\GroupManagerInterface');
-        $groupManager->expects($this->once())->method('getClass')->will($this->returnValue('FOS\UserBundle\Entity\Group'));
+        $groupManager->expects($this->once())->method('getClass')->will($this->returnValue('Sonata\UserBundle\Entity\BaseGroup'));
 
         $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
         $form->expects($this->once())->method('submit');
@@ -93,7 +93,7 @@ class GroupControllerTest extends \PHPUnit_Framework_TestCase
         $group = $this->getMock('FOS\UserBundle\Model\GroupInterface');
 
         $groupManager = $this->getMock('Sonata\UserBundle\Model\GroupManagerInterface');
-        $groupManager->expects($this->once())->method('getClass')->will($this->returnValue('FOS\UserBundle\Entity\Group'));
+        $groupManager->expects($this->once())->method('getClass')->will($this->returnValue('Sonata\UserBundle\Entity\BaseGroup'));
         $groupManager->expects($this->once())->method('findGroupBy')->will($this->returnValue($group));
         $groupManager->expects($this->once())->method('updateGroup')->will($this->returnValue($group));
 
@@ -115,7 +115,7 @@ class GroupControllerTest extends \PHPUnit_Framework_TestCase
         $group = $this->getMock('FOS\UserBundle\Model\GroupInterface');
 
         $groupManager = $this->getMock('Sonata\UserBundle\Model\GroupManagerInterface');
-        $groupManager->expects($this->once())->method('getClass')->will($this->returnValue('FOS\UserBundle\Entity\Group'));
+        $groupManager->expects($this->once())->method('getClass')->will($this->returnValue('Sonata\UserBundle\Entity\BaseGroup'));
         $groupManager->expects($this->once())->method('findGroupBy')->will($this->returnValue($group));
 
         $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "sonata-project/core-bundle": "^3.0",
         "sonata-project/admin-bundle": "^3.1",
         "sonata-project/datagrid-bundle": "^2.2",
-        "friendsofsymfony/user-bundle": "^1.3",
+        "friendsofsymfony/user-bundle": "^1.3 || ^2.0@dev",
         "sonata-project/doctrine-extensions": "^1.0",
         "sonata-project/easy-extends-bundle": "^2.1",
         "sonata-project/google-authenticator": "^1.0",
@@ -35,6 +35,7 @@
     },
     "require-dev": {
         "sonata-project/seo-bundle": "^2.0",
+        "doctrine/doctrine-bundle": "^1.6",
         "doctrine/orm": "^2.0",
         "symfony/phpunit-bridge": "^2.8 || ^3.0",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0"


### PR DESCRIPTION
### Changelog

``` markdown
### Added
- Now compatible with FOSUserBundle 2.0
```
### Subject

Please note this is **WIP** to **TEST** if we can make this bundle compatible with both fos-user bundle v1 and v2.

I give **NO WARRANTY** this will work. It's a try. If it succeed, we can push this on a new minor.

Even if this works, please note the FOSUser 2.x support, even on a stable release of sonata-user-bundle, will be a **best effort**. Indeed, it's hard to ensure the support of an unstable dependency.

Before you asking, this PR will be **NOT** about SF 3 compatibility but only FOSUser. The SF 3 compatibility will depends of the success of this PR, or the stabilization of FOSUser v2 and will be worked on another PR.

I don't have sonata-user-bundle installed on any maintained private projects right now.
I'll trust unit test ATM, but I'll need a lot of feedback from all of you (if you can) to test this branch on your project against both FOSUser v1 and v2 and tell me what is not working and why. Thanks for help. :+1: 
### To do
- [ ] Make it compatible with both FOSUser v1 and v2
- [ ] Update the documentation
- [ ] Add an upgrade note
- [ ] Remove Travis hack. Update dev-kit instead.
