### PR TITLE
Security token can be null in login form on 404

### DIFF
--- a/Controller/SecurityFOSUser1Controller.php
+++ b/Controller/SecurityFOSUser1Controller.php
@@ -28,9 +28,9 @@ class SecurityFOSUser1Controller extends SecurityController
      */
     public function loginAction()
     {
-        $user = $this->container->get('security.context')->getToken()->getUser();
+        $token = $this->container->get('security.context')->getToken();
 
-        if ($user instanceof UserInterface) {
+        if ($token && $token->getUser() instanceof UserInterface) {
             $this->container->get('session')->getFlashBag()->set('sonata_user_error', 'sonata_user_already_authenticated');
             $url = $this->container->get('router')->generate('sonata_user_profile_show');
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Rebase of https://github.com/sonata-project/SonataUserBundle/pull/613

### Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Remove unneeded sections.
    Follow this schema: http://keepachangelog.com/
-->

```markdown
### Fixed
- Fixed a potential null error in `SecurityFOSUser1Controller::loginAction`

```

### Subject
The security token could be null while you're trying to login.