### PR TITLE
Redirect route can be empty after registration

### DIFF
--- a/Controller/RegistrationFOSUser1Controller.php
+++ b/Controller/RegistrationFOSUser1Controller.php
@@ -62,11 +62,7 @@ class RegistrationFOSUser1Controller extends Controller
                     $this->get('session')->remove('sonata_basket_delivery_redirect');
                     $url = $this->generateUrl($route);
                 } else {
-                    $url = $this->get('session')->get('sonata_user_redirect_url');
-                }
-
-                if (null === $route) {
-                    $url = $this->generateUrl('sonata_user_profile_show');
+                    $url = $this->get('session')->get('sonata_user_redirect_url', $this->generateUrl('sonata_user_profile_show'));
                 }
             }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Rebase of #735

### Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Remove unneeded sections.
    Follow this schema: http://keepachangelog.com/
-->

```markdown
### Fixed
- Fixed a potential empty route after calling `RegistrationFOSUser1Controller::registerAction`
```

### Subject
The route could be empty when no historic route was found in the user session.