### PR TITLE
Make REST dependency optional (again)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,19 +27,20 @@
         "sonata-project/datagrid-bundle": "^2.2",
         "friendsofsymfony/user-bundle": "^1.3",
         "sonata-project/doctrine-extensions": "^1.0",
-        "sonata-project/easy-extends-bundle": "^2.1",
-        "friendsofsymfony/rest-bundle": "^1.1",
-        "jms/serializer-bundle": "^0.13 || ^1.0",
-        "nelmio/api-doc-bundle": "^2.4"
+        "sonata-project/easy-extends-bundle": "^2.1"
     },
     "require-dev": {
+        "friendsofsymfony/rest-bundle": "^1.1",
         "sonata-project/seo-bundle": "^2.0",
         "doctrine/orm": "^2.0",
+        "jms/serializer-bundle": "^0.13 || ^1.0",
+        "nelmio/api-doc-bundle": "^2.4",
         "symfony/phpunit-bridge": "^2.8 || ^3.0",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
         "sonata-project/google-authenticator": "^1.0"
     },
     "suggest": {
+        "friendsofsymfony/rest-bundle": "For using the public API methods.",
         "sonata-project/doctrine-orm-admin-bundle": "^3.0",
         "sonata-project/seo-bundle": "For SEO breadcrumb block service usage",
         "sonata-project/google-authenticator": "For google auth user login"


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because these dependency were optional in this branch.

## Subject

Somehow the changes of #650 were reverted by 031cf62260b6da8a8c4eaa1a4bd302894b828aba when merging the `2.x` branch to the master.

