### PR TITLE
Make REST dependency optional (again)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,7 @@
     ],
     "require": {
         "php": "^5.3 || ^7.0",
-        "friendsofsymfony/rest-bundle": "^1.1",
         "friendsofsymfony/user-bundle": "^1.3",
-        "jms/serializer-bundle": "^0.13 || ^1.0",
-        "nelmio/api-doc-bundle": "^2.4",
         "sonata-project/admin-bundle": "^3.1",
         "sonata-project/core-bundle": "^3.0",
         "sonata-project/datagrid-bundle": "^2.2",
@@ -35,16 +32,24 @@
     },
     "require-dev": {
         "doctrine/orm": "^2.0",
+        "friendsofsymfony/rest-bundle": "^1.1",
+        "jms/serializer-bundle": "^0.13 || ^1.0",
+        "nelmio/api-doc-bundle": "^2.4",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
         "sonata-project/seo-bundle": "^2.0",
         "symfony/phpunit-bridge": "^2.8 || ^3.0"
     },
     "suggest": {
+        "friendsofsymfony/rest-bundle": "For using the public API methods.",
+        "jms/serializer": "For using the public API methods.",
+        "nelmio/api-doc-bundle": "For using the public API methods.",
         "sonata-project/doctrine-orm-admin-bundle": "^3.0",
         "sonata-project/seo-bundle": "For SEO breadcrumb block service usage"
     },
     "conflict": {
-        "jms/serializer": "<0.13",
+        "friendsofsymfony/rest-bundle": "<1.1 || >=2.0",
+        "jms/serializer": "<0.13 || >=2.0",
+        "nelmio/api-doc-bundle": "<2.4 || >= 3.0",
         "sonata-project/doctrine-orm-admin-bundle": "<3.0 || >=4.0",
         "sonata-project/seo-bundle": "<2.0 || >=3.0"
     },


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because these dependency were optional in this branch.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- The `friendsofsymfony/rest-bundle` dependency is optional again
- The `jms/serializer-bundle` dependency is optional again
- The `nelmio/api-doc-bundle` dependency is optional again
```

## Subject

Somehow the changes of #650 were reverted by 031cf62260b6da8a8c4eaa1a4bd302894b828aba when merging the `2.x` branch to the master.