### PR TITLE
Fixed missing German translation

### DIFF
--- a/Resources/translations/SonataUserBundle.de.xliff
+++ b/Resources/translations/SonataUserBundle.de.xliff
@@ -486,6 +486,26 @@
                 <source>Profile</source>
                 <target>Profil</target>
             </trans-unit>
+            <trans-unit id="group_user">
+                <source>User</source>
+                <target>Benutzer</target>
+            </trans-unit>
+            <trans-unit id="group_status">
+                <source>Status</source>
+                <target>Status</target>
+            </trans-unit>
+            <trans-unit id="group_social">
+                <source>Social</source>
+                <target>Soziale Kanäle</target>
+            </trans-unit>
+            <trans-unit id="group_roles">
+                <source>Roles</source>
+                <target>Rollen</target>
+            </trans-unit>
+            <trans-unit id="group_keys">
+                <source>Keys</source>
+                <target>Schlüssel</target>
+            </trans-unit>
             <trans-unit id="group_security">
                 <source>Security</source>
                 <target>Sicherheit</target>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is a translation fix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Subject

The translation key was missing for the user edit dialog.

