### PR TITLE
fix(bc): support >2.8 security classes

### DIFF
--- a/Controller/AdminSecurityController.php
+++ b/Controller/AdminSecurityController.php
@@ -17,7 +17,8 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
-use Symfony\Component\Security\Core\SecurityContext;
+use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Core\SecurityContextInterface;
 
 class AdminSecurityController extends Controller
 {
@@ -41,12 +42,16 @@ class AdminSecurityController extends Controller
 
         $session = $request->getSession();
 
+        // Symfony <2.6 BC. To be removed.
+        $authenticationErrorKey = class_exists('Symfony\Component\Security\Core\Security')
+            ? Security::AUTHENTICATION_ERROR : SecurityContextInterface::AUTHENTICATION_ERROR;
+
         // get the error if any (works with forward and redirect -- see below)
-        if ($request->attributes->has(SecurityContext::AUTHENTICATION_ERROR)) {
-            $error = $request->attributes->get(SecurityContext::AUTHENTICATION_ERROR);
-        } elseif (null !== $session && $session->has(SecurityContext::AUTHENTICATION_ERROR)) {
-            $error = $session->get(SecurityContext::AUTHENTICATION_ERROR);
-            $session->remove(SecurityContext::AUTHENTICATION_ERROR);
+        if ($request->attributes->has($authenticationErrorKey)) {
+            $error = $request->attributes->get($authenticationErrorKey);
+        } elseif (null !== $session && $session->has($authenticationErrorKey)) {
+            $error = $session->get($authenticationErrorKey);
+            $session->remove($authenticationErrorKey);
         } else {
             $error = '';
         }
@@ -55,8 +60,12 @@ class AdminSecurityController extends Controller
             // TODO: this is a potential security risk (see http://trac.symfony-project.org/ticket/9523)
             $error = $error->getMessage();
         }
+
+        $lastUsernameKey = class_exists('Symfony\Component\Security\Core\Security')
+            ? Security::LAST_USERNAME : SecurityContextInterface::LAST_USERNAME;
+
         // last username entered by the user
-        $lastUsername = (null === $session) ? '' : $session->get(SecurityContext::LAST_USERNAME);
+        $lastUsername = (null === $session) ? '' : $session->get($lastUsernameKey);
 
         if ($this->has('security.csrf.token_manager')) { // sf >= 2.4
             $csrfToken = $this->get('security.csrf.token_manager')->getToken('authenticate');
@@ -66,7 +75,11 @@ class AdminSecurityController extends Controller
                 : null;
         }
 
-        if ($this->get('security.context')->isGranted('ROLE_ADMIN')) {
+        // NEXT_MAJOR: remove when dropping Symfony <2.8 support
+        $authorizationCheckerService = class_exists('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface')
+            ? $this->get('security.authorization_checker') : $this->get('security.context');
+
+        if ($authorizationCheckerService->isGranted('ROLE_ADMIN')) {
             $refererUri = $request->server->get('HTTP_REFERER');
 
             return $this->redirect($refererUri && $refererUri != $request->getUri() ? $refererUri : $this->generateUrl('sonata_admin_dashboard'));


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because it is the stable one

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
 - symfony 3 security classes use in AdminSecurityController
```
## Subject
Support symfony 3 security classes
<!-- Describe your Pull Request content here -->

