### PR TITLE
Fix for the 'Bad Credentials' translation problem

### DIFF
--- a/Controller/AdminSecurityController.php
+++ b/Controller/AdminSecurityController.php
@@ -17,6 +17,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Security\Core\SecurityContextInterface;
 
@@ -53,12 +54,11 @@ class AdminSecurityController extends Controller
             $error = $session->get($authenticationErrorKey);
             $session->remove($authenticationErrorKey);
         } else {
-            $error = '';
+            $error = null;
         }
 
-        if ($error) {
-            // TODO: this is a potential security risk (see http://trac.symfony-project.org/ticket/9523)
-            $error = $error->getMessage();
+        if (!$error instanceof AuthenticationException) {
+            $error = null; // The value does not come from the security component.
         }
 
         $lastUsernameKey = class_exists('Symfony\Component\Security\Core\Security')

--- a/Resources/translations/SonataUserBundle.de.xliff
+++ b/Resources/translations/SonataUserBundle.de.xliff
@@ -514,10 +514,6 @@
                 <source>Gender</source>
                 <target>Geschlecht</target>
             </trans-unit>
-            <trans-unit id="Bad credentials">
-                <source>Bad credentials</source>
-                <target>Benutzername oder Passwort ungültig</target>
-            </trans-unit>
             <trans-unit id="sonata_profile_title">
                 <source>sonata_profile_title</source>
                 <target>Profil</target>

--- a/Resources/views/Admin/Security/login.html.twig
+++ b/Resources/views/Admin/Security/login.html.twig
@@ -30,7 +30,9 @@
             {% block sonata_user_login_form %}
                 {% block sonata_user_login_error %}
                     {% if error %}
-                        <div class="alert alert-danger">{{ error|trans({}, 'FOSUserBundle') }}</div>
+                        <div class="alert alert-danger alert-error">
+                            {{ error.messageKey|trans(error.messageData, 'security') }}
+                        </div>
                     {% endif %}
                 {% endblock %}
                 <p class="login-box-msg">{{ 'title_user_authentication'|trans({}, 'SonataUserBundle') }}</p>

--- a/Resources/views/Security/base_login.html.twig
+++ b/Resources/views/Security/base_login.html.twig
@@ -25,7 +25,9 @@ file that was distributed with this source code.
 
                     {% block sonata_user_login_error %}
                         {% if error %}
-                            <div class="alert alert-danger alert-error">{{ error|trans({}, 'FOSUserBundle') }}</div>
+                            <div class="alert alert-danger alert-error">
+                                {{ error.messageKey|trans(error.messageData, 'security') }}
+                            </div>
                         {% endif %}
                     {% endblock %}
 


### PR DESCRIPTION
Note: This is a rebuild of PR #716 
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this the is branch I'm currently using in my projects, later I will check if the problem happens in other branches and if this solution works on then.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #788 
Fixes   #621 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

```markdown

### Changed
- Changed implementation of loginAction in SecurityFOSUser1Controller.php
- Changed implementation of loginAction in AdminSecurityController.php
- Changed how the error message is translated on login.html.twig
- Changed how the error message is translated on base_login.html.twig

### Removed
- Removed translation for 'Bad credentials' message in SonataUserBundle.de.xliff

### Fixed
- Fixed a possible security risk as noticed in this [line](https://github.com/sonata-project/SonataUserBundle/blob/88a962818dd6218379ff1439183a15647837bda0/Controller/AdminSecurityController.php#L40)
```

## Subject
As related in issue #621 there was a problem with the error message in the login page, that was not being translated. That was a error with FOSUserBundle, that apparently will be fixed in the 2.0 version, but since there is no prediction to when it will be ready. I made some changes by myself based on the dev-master of FOSUserBundle.

I changed both security controllers and the templates for the login page to look more like the latest version of FOSUserBundle. Now the error message is translated with the 'security' catalogue. Also took out the Bad Credentials entry in one of the translation files since there is no need for it.

<!-- Describe your Pull Request content here -->
