### PR TITLE
allow the usage of FOSRestBundle 2.x

### DIFF
--- a/Controller/Api/GroupController.php
+++ b/Controller/Api/GroupController.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\UserBundle\Controller\Api;
 
+use FOS\RestBundle\Context\Context;
 use FOS\RestBundle\Controller\Annotations\QueryParam;
 use FOS\RestBundle\Controller\Annotations\View;
 use FOS\RestBundle\Request\ParamFetcherInterface;
@@ -229,10 +230,17 @@ class GroupController
             $this->groupManager->updateGroup($group);
 
             $view = FOSRestView::create($group);
-            $serializationContext = SerializationContext::create();
-            $serializationContext->setGroups(array('sonata_api_read'));
-            $serializationContext->enableMaxDepthChecks();
-            $view->setSerializationContext($serializationContext);
+
+            if (class_exists('FOS\RestBundle\Context\Context')) {
+                $context = new Context();
+                $context->setGroups(array('sonata_api_read'));
+                $view->setContext($context);
+            } else {
+                $serializationContext = SerializationContext::create();
+                $serializationContext->setGroups(array('sonata_api_read'));
+                $serializationContext->enableMaxDepthChecks();
+                $view->setSerializationContext($serializationContext);
+            }
 
             return $view;
         }

--- a/Controller/Api/UserController.php
+++ b/Controller/Api/UserController.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\UserBundle\Controller\Api;
 
+use FOS\RestBundle\Context\Context;
 use FOS\RestBundle\Controller\Annotations\QueryParam;
 use FOS\RestBundle\Controller\Annotations\View;
 use FOS\RestBundle\Request\ParamFetcherInterface;
@@ -361,10 +362,17 @@ class UserController
             $this->userManager->updateUser($user);
 
             $view = FOSRestView::create($user);
-            $serializationContext = SerializationContext::create();
-            $serializationContext->setGroups(array('sonata_api_read'));
-            $serializationContext->enableMaxDepthChecks();
-            $view->setSerializationContext($serializationContext);
+
+            if (class_exists('FOS\RestBundle\Context\Context')) {
+                $context = new Context();
+                $context->setGroups(array('sonata_api_read'));
+                $view->setContext($context);
+            } else {
+                $serializationContext = SerializationContext::create();
+                $serializationContext->setGroups(array('sonata_api_read'));
+                $serializationContext->enableMaxDepthChecks();
+                $view->setSerializationContext($serializationContext);
+            }
 
             return $view;
         }

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
     "require-dev": {
         "doctrine/orm": "^2.0",
-        "friendsofsymfony/rest-bundle": "^1.1",
+        "friendsofsymfony/rest-bundle": "^1.1 || ^2.0",
         "jms/serializer-bundle": "^0.13 || ^1.0",
         "nelmio/api-doc-bundle": "^2.4",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
@@ -47,7 +47,7 @@
         "sonata-project/seo-bundle": "For SEO breadcrumb block service usage"
     },
     "conflict": {
-        "friendsofsymfony/rest-bundle": "<1.1 || >=2.0",
+        "friendsofsymfony/rest-bundle": "<1.1",
         "jms/serializer": "<0.13 || >=2.0",
         "nelmio/api-doc-bundle": "<2.4 || >= 3.0",
         "sonata-project/doctrine-orm-admin-bundle": "<3.0 || >=4.0",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT! -->

This change allows users to use SonataUserBundle with FOSRestBundle 2.x. There are no BC breaking changes. So the PR can be applied to the `3.x` branch.

Closes #775

## Changelog

```markdown
### Removed
- The conflict rule for FOSRestBundle `>=2.0`.
```

## To do

- [x] Update API controllers if necessary

## Subject

Removed the conflict rule for FOSRestBundle `>=2.0` allowing it to use SonataUserBundle with maintained versions of FOSRestBundle.

