### PR TITLE
Define non-BC annotations dynamically

### DIFF
--- a/Controller/Api/GroupController.php
+++ b/Controller/Api/GroupController.php
@@ -66,7 +66,6 @@ class GroupController
      *
      * @QueryParam(name="page", requirements="\d+", default="1", description="Page for groups list pagination (1-indexed)")
      * @QueryParam(name="count", requirements="\d+", default="10", description="Number of groups by page")
-     * @QueryParam(name="orderBy", array=true, requirements="ASC|DESC", nullable=true, strict=true, description="Query groups order by clause (key is field, value is direction")
      * @QueryParam(name="enabled", requirements="0|1", nullable=true, strict=true, description="Enabled/disabled groups only?")
      *
      * @View(serializerGroups="sonata_api_read", serializerEnableMaxDepthChecks=true)
@@ -77,6 +76,20 @@ class GroupController
      */
     public function getGroupsAction(ParamFetcherInterface $paramFetcher)
     {
+        $orderByQueryParam = new QueryParam();
+        $orderByQueryParam->name = 'orderBy';
+        $orderByQueryParam->requirements = 'ASC|DESC';
+        $orderByQueryParam->nullable = true;
+        $orderByQueryParam->strict = true;
+        $orderByQueryParam->description = 'Query groups order by clause (key is field, value is direction)';
+        if (property_exists($orderByQueryParam, 'map')) {
+            $orderByQueryParam->map = true;
+        } else {
+            $orderByQueryParam->array = true;
+        }
+
+        $paramFetcher->addParam($orderByQueryParam);
+
         $supportedFilters = array(
             'enabled' => '',
         );

--- a/Controller/Api/UserController.php
+++ b/Controller/Api/UserController.php
@@ -75,7 +75,6 @@ class UserController
      *
      * @QueryParam(name="page", requirements="\d+", default="1", description="Page for users list pagination (1-indexed)")
      * @QueryParam(name="count", requirements="\d+", default="10", description="Number of users by page")
-     * @QueryParam(name="orderBy", array=true, requirements="ASC|DESC", nullable=true, strict=true, description="Query users order by clause (key is field, value is direction")
      * @QueryParam(name="enabled", requirements="0|1", nullable=true, strict=true, description="Enabled/disabled users only?")
      * @QueryParam(name="locked", requirements="0|1", nullable=true, strict=true, description="Locked/Non-locked users only?")
      *
@@ -87,6 +86,20 @@ class UserController
      */
     public function getUsersAction(ParamFetcherInterface $paramFetcher)
     {
+        $orderByQueryParam = new QueryParam();
+        $orderByQueryParam->name = 'orderBy';
+        $orderByQueryParam->requirements = 'ASC|DESC';
+        $orderByQueryParam->nullable = true;
+        $orderByQueryParam->strict = true;
+        $orderByQueryParam->description = 'Query users order by clause (key is field, value is direction)';
+        if (property_exists($orderByQueryParam, 'map')) {
+            $orderByQueryParam->map = true;
+        } else {
+            $orderByQueryParam->array = true;
+        }
+
+        $paramFetcher->addParam($orderByQueryParam);
+
         $supporedCriteria = array(
             'enabled' => '',
             'locked' => '',

--- a/Tests/Controller/Api/GroupControllerTest.php
+++ b/Tests/Controller/Api/GroupControllerTest.php
@@ -28,7 +28,9 @@ class GroupControllerTest extends \PHPUnit_Framework_TestCase
         $groupManager = $this->getMock('Sonata\UserBundle\Model\GroupManagerInterface');
         $groupManager->expects($this->once())->method('getPager')->will($this->returnValue(array($group)));
 
-        $paramFetcher = $this->getMock('FOS\RestBundle\Request\ParamFetcherInterface');
+        $paramFetcher = $this->getMockBuilder('FOS\RestBundle\Request\ParamFetcher')
+            ->disableOriginalConstructor()
+            ->getMock();
         $paramFetcher->expects($this->exactly(3))->method('get');
         $paramFetcher->expects($this->once())->method('all')->will($this->returnValue(array()));
 

--- a/Tests/Controller/Api/UserControllerTest.php
+++ b/Tests/Controller/Api/UserControllerTest.php
@@ -28,7 +28,9 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
         $userManager = $this->getMock('Sonata\UserBundle\Model\UserManagerInterface');
         $userManager->expects($this->once())->method('getPager')->will($this->returnValue(array()));
 
-        $paramFetcher = $this->getMock('FOS\RestBundle\Request\ParamFetcherInterface');
+        $paramFetcher = $this->getMockBuilder('FOS\RestBundle\Request\ParamFetcher')
+            ->disableOriginalConstructor()
+            ->getMock();
         $paramFetcher->expects($this->exactly(3))->method('get');
         $paramFetcher->expects($this->once())->method('all')->will($this->returnValue(array()));
 

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
     "require-dev": {
         "doctrine/orm": "^2.0",
-        "friendsofsymfony/rest-bundle": "^1.1 || ^2.0",
+        "friendsofsymfony/rest-bundle": "^1.5 || ^2.0",
         "jms/serializer-bundle": "^0.13 || ^1.0",
         "nelmio/api-doc-bundle": "^2.4",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",


### PR DESCRIPTION
I am targetting this branch, because this is a BC patch

See https://github.com/sonata-project/SonataUserBundle/commit/4b6e29540eab072e40535386050cef5a5c68e960#commitcomment-19809506

## Changelog

```markdown
### Fixed
- compatibility with FOSRestBundle 2.x was improved
```

## To do

- [x] Fix the unit tests
- [ ] Test on a real application @lemorragia, help?
- [ ] Decide whether to add `NEXT_MAJOR` instruction ( @sonata-project/contributors  are we dropping FOSRestBundle in the next major version ?)

## Subject

FOSRestBundle 1.x and 2.x do not use the same property name to specify
whether a query parameter is an array / map .
This has a drawback: this parameter will not appear in the
documentation, or be usable in the sandbox. But now both versions of
the FOSRestBundle should be usable.