### PR TITLE
Deprecate sonata basket delivery redirect

### DIFF
--- a/Controller/RegistrationFOSUser1Controller.php
+++ b/Controller/RegistrationFOSUser1Controller.php
@@ -13,7 +13,6 @@ namespace Sonata\UserBundle\Controller;
 
 use FOS\UserBundle\Model\UserInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
@@ -68,7 +67,7 @@ class RegistrationFOSUser1Controller extends Controller
 
             $this->setFlash('fos_user_success', 'registration.flash.user_created');
 
-            $response = new RedirectResponse($url);
+            $response = $this->redirect($url);
 
             if ($authUser) {
                 $this->authenticateUser($user, $response);

--- a/Controller/RegistrationFOSUser1Controller.php
+++ b/Controller/RegistrationFOSUser1Controller.php
@@ -58,6 +58,12 @@ class RegistrationFOSUser1Controller extends Controller
                 $route = $this->get('session')->get('sonata_basket_delivery_redirect');
 
                 if (null !== $route) {
+                    // NEXT_MAJOR: remove the if block
+                    @trigger_error(<<<'EOT'
+Setting a redirect url in the sonata_basket_delivery_redirect session variable
+is deprecated since 3.x and will no longer result in a redirection to this url in 4.0.
+EOT
+                    , E_USER_DEPRECATED);
                     $this->get('session')->remove('sonata_basket_delivery_redirect');
                     $url = $this->generateUrl($route);
                 } else {

--- a/Controller/RegistrationFOSUser1Controller.php
+++ b/Controller/RegistrationFOSUser1Controller.php
@@ -67,7 +67,10 @@ EOT
                     $this->get('session')->remove('sonata_basket_delivery_redirect');
                     $url = $this->generateUrl($route);
                 } else {
-                    $url = $this->get('session')->get('sonata_user_redirect_url', $this->generateUrl('sonata_user_profile_show'));
+                    $url = $this->get('session')->get(
+                        'sonata_user_redirect_url',
+                        $this->generateUrl('sonata_user_profile_show')
+                    );
                 }
             }
 
@@ -134,7 +137,10 @@ EOT
 
         $this->get('fos_user.user_manager')->updateUser($user);
         if ($redirectRoute = $this->container->getParameter('sonata.user.register.confirm.redirect_route')) {
-            $response = $this->redirect($this->generateUrl($redirectRoute, $this->container->getParameter('sonata.user.register.confirm.redirect_route_params')));
+            $response = $this->redirect($this->generateUrl(
+                $redirectRoute,
+                $this->container->getParameter('sonata.user.register.confirm.redirect_route_params')
+            ));
         } else {
             $response = $this->redirect($this->generateUrl('fos_user_registration_confirmed'));
         }

--- a/Controller/RegistrationFOSUser1Controller.php
+++ b/Controller/RegistrationFOSUser1Controller.php
@@ -181,7 +181,8 @@ EOT
             $this->get('fos_user.security.login_manager')->loginUser(
                 $this->container->getParameter('fos_user.firewall_name'),
                 $user,
-                $response);
+                $response
+            );
         } catch (AccountStatusException $ex) {
             // We simply do not authenticate users which do not pass the user
             // checker (not enabled, expired, etc.).

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,11 @@
 UPGRADE 3.x
 ===========
 
+### Deprecated sonata_basket_delivery_redirect session variable
+
+Relying on this variable to get a redirection after registration is deprecated
+and will be removed in 4.0.
+
 UPGRADE FROM 3.0 to 3.1
 =======================
 

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -6,6 +6,6 @@ UPGRADE FROM 3.0 to 3.1
 
 ### Tests
 
-All files under the ``Tests`` directory are now correctly handled as internal test classes. 
-You can't extend them anymore, because they are only loaded when running internal tests. 
+All files under the ``Tests`` directory are now correctly handled as internal test classes.
+You can't extend them anymore, because they are only loaded when running internal tests.
 More information can be found in the [composer docs](https://getcomposer.org/doc/04-schema.md#autoload-dev).


### PR DESCRIPTION
I am targetting this branch, because this is BC (new deprecation)

Closes #800

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Relying on the `sonata_basket_delivery_redirect` is deprecated and won't be supported anymore
```

## Subject

There is a strange, undocumented mechanism that allows people to be redirected to an arbitrary route after registration, based on a very specific session variable named `sonata_basket_delivery_redirect`. This could be useful, but if it is, it should be implemented in a simpler way, for instance, reusing the `sonata_user_redirect_url` variable, and check if it is already set before overwriting it with the referer.
