### PR TITLE
Add optional dependency JMSSerializerBundle when using FOSRestBundle and NelmioApiDocBundle

### DIFF
--- a/DependencyInjection/SonataUserExtension.php
+++ b/DependencyInjection/SonataUserExtension.php
@@ -54,7 +54,7 @@ class SonataUserExtension extends Extension
 
         if ('orm' === $config['manager_type'] && isset(
             $bundles['FOSRestBundle'],
-            $bundles['NelmioApiDocBundle'], 
+            $bundles['NelmioApiDocBundle'],
             $bundles['JMSSerializerBundle']
         )) {
             $loader->load('serializer.xml');

--- a/DependencyInjection/SonataUserExtension.php
+++ b/DependencyInjection/SonataUserExtension.php
@@ -52,7 +52,11 @@ class SonataUserExtension extends Extension
         $loader->load('google_authenticator.xml');
         $loader->load('twig.xml');
 
-        if ('orm' === $config['manager_type'] && isset($bundles['FOSRestBundle']) && isset($bundles['NelmioApiDocBundle']) && isset($bundles['JMSSerializerBundle'])) {
+        if ('orm' === $config['manager_type'] && isset(
+            $bundles['FOSRestBundle'],
+            $bundles['NelmioApiDocBundle'], 
+            $bundles['JMSSerializerBundle']
+        )) {
             $loader->load('serializer.xml');
 
             $loader->load('api_form.xml');

--- a/DependencyInjection/SonataUserExtension.php
+++ b/DependencyInjection/SonataUserExtension.php
@@ -52,7 +52,7 @@ class SonataUserExtension extends Extension
         $loader->load('google_authenticator.xml');
         $loader->load('twig.xml');
 
-        if ('orm' === $config['manager_type'] && isset($bundles['FOSRestBundle']) && isset($bundles['NelmioApiDocBundle'])) {
+        if ('orm' === $config['manager_type'] && isset($bundles['FOSRestBundle']) && isset($bundles['NelmioApiDocBundle']) && isset($bundles['JMSSerializerBundle'])) {
             $loader->load('serializer.xml');
 
             $loader->load('api_form.xml');


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because its a fix that can be easy backported without breaking anything.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #810

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Add missing (optional) dependency for JMSSerializerBundle, needed for the services defined in serializer.xml and api_form.xml

### Fixed
- fixed a cross dependency when using UserBundle with FOSRestBundle and NelmioApiDocBundle depending JMSSerializerBundle.
```

## Subject

<!-- Describe your Pull Request content here -->

Add missing dependency for JMSSerializerBundle, needed for the services defined in serializer.xml and api_form.xml