### PR TITLE
remove SecurityContextInterface it was removed in symfony 3.0

### DIFF
--- a/Block/AccountBlockService.php
+++ b/Block/AccountBlockService.php
@@ -18,7 +18,7 @@ use Sonata\UserBundle\Model\UserInterface;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Security\Core\SecurityContextInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 /**
  * Class AccountBlockService.
@@ -31,22 +31,22 @@ use Symfony\Component\Security\Core\SecurityContextInterface;
 class AccountBlockService extends BaseBlockService
 {
     /**
-     * @var ProfileMenuBuilder
+     * @var TokenStorageInterface
      */
-    private $securityContext;
+    protected $tokenStorage;
 
     /**
      * Constructor.
      *
-     * @param string                   $name
-     * @param EngineInterface          $templating
-     * @param SecurityContextInterface $securityContext
+     * @param string                $name
+     * @param EngineInterface       $templating
+     * @param TokenStorageInterface $tokenStorage
      */
-    public function __construct($name, EngineInterface $templating, SecurityContextInterface $securityContext)
+    public function __construct($name, EngineInterface $templating, TokenStorageInterface $tokenStorage)
     {
         parent::__construct($name, $templating);
 
-        $this->securityContext = $securityContext;
+        $this->tokenStorage = $tokenStorage;
     }
 
     /**
@@ -55,8 +55,8 @@ class AccountBlockService extends BaseBlockService
     public function execute(BlockContextInterface $blockContext, Response $response = null)
     {
         $user = false;
-        if ($this->securityContext->getToken()) {
-            $user = $this->securityContext->getToken()->getUser();
+        if ($this->tokenStorage->getToken()) {
+            $user = $this->tokenStorage->getToken()->getUser();
         }
 
         if (!$user instanceof UserInterface) {

--- a/Block/AccountBlockService.php
+++ b/Block/AccountBlockService.php
@@ -18,6 +18,7 @@ use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\SecurityContextInterface;
 
 /**
  * Class AccountBlockService.
@@ -30,20 +31,26 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
 class AccountBlockService extends BaseBlockService
 {
     /**
-     * @var TokenStorageInterface
+     * @var TokenStorageInterface|SecurityContextInterface
      */
     private $tokenStorage;
 
     /**
      * Constructor.
      *
-     * @param string                $name
-     * @param EngineInterface       $templating
-     * @param TokenStorageInterface $tokenStorage
+     * NEXT_MAJOR: Go back to signature class check when bumping requirements to SF 2.6+.
+     * 
+     * @param string                                         $name
+     * @param EngineInterface                                $templating
+     * @param TokenStorageInterface|SecurityContextInterface $tokenStorage
      */
-    public function __construct($name, EngineInterface $templating, TokenStorageInterface $tokenStorage)
+    public function __construct($name, EngineInterface $templating, $tokenStorage)
     {
         parent::__construct($name, $templating);
+
+        if (!$tokenStorage instanceof TokenStorageInterface && !$tokenStorage instanceof SecurityContextInterface) {
+            throw new \InvalidArgumentException('Argument 1 should be an instance of Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface or Symfony\Component\Security\Core\SecurityContextInterface');
+        }
 
         $this->tokenStorage = $tokenStorage;
     }

--- a/Block/AccountBlockService.php
+++ b/Block/AccountBlockService.php
@@ -39,7 +39,7 @@ class AccountBlockService extends BaseBlockService
      * Constructor.
      *
      * NEXT_MAJOR: Go back to signature class check when bumping requirements to SF 2.6+.
-     * 
+     *
      * @param string                                         $name
      * @param EngineInterface                                $templating
      * @param TokenStorageInterface|SecurityContextInterface $tokenStorage

--- a/Block/AccountBlockService.php
+++ b/Block/AccountBlockService.php
@@ -38,7 +38,7 @@ class AccountBlockService extends BaseBlockService
     /**
      * Constructor.
      *
-     * NEXT_MAJOR: Go back to signature class check when bumping requirements to SF 2.6+.
+     * NEXT_MAJOR: Go back to type hinting check when bumping requirements to SF 2.6+.
      *
      * @param string                                         $name
      * @param EngineInterface                                $templating
@@ -49,7 +49,9 @@ class AccountBlockService extends BaseBlockService
         parent::__construct($name, $templating);
 
         if (!$tokenStorage instanceof TokenStorageInterface && !$tokenStorage instanceof SecurityContextInterface) {
-            throw new \InvalidArgumentException('Argument 1 should be an instance of Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface or Symfony\Component\Security\Core\SecurityContextInterface');
+            throw new \InvalidArgumentException(
+                'Argument 3 should be an instance of Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface or Symfony\Component\Security\Core\SecurityContextInterface'
+            );
         }
 
         $this->tokenStorage = $tokenStorage;

--- a/Block/AccountBlockService.php
+++ b/Block/AccountBlockService.php
@@ -13,7 +13,6 @@ namespace Sonata\UserBundle\Block;
 
 use Sonata\BlockBundle\Block\BaseBlockService;
 use Sonata\BlockBundle\Block\BlockContextInterface;
-use Sonata\UserBundle\Menu\ProfileMenuBuilder;
 use Sonata\UserBundle\Model\UserInterface;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\HttpFoundation\Response;
@@ -33,7 +32,7 @@ class AccountBlockService extends BaseBlockService
     /**
      * @var TokenStorageInterface
      */
-    protected $tokenStorage;
+    private $tokenStorage;
 
     /**
      * Constructor.

--- a/Controller/AdminSecurityController.php
+++ b/Controller/AdminSecurityController.php
@@ -43,7 +43,7 @@ class AdminSecurityController extends Controller
 
         $session = $request->getSession();
 
-        // Symfony <2.6 BC. To be removed.
+        // NEXT_MAJOR: Symfony <2.6 BC. To be removed.
         $authenticationErrorKey = class_exists('Symfony\Component\Security\Core\Security')
             ? Security::AUTHENTICATION_ERROR : SecurityContextInterface::AUTHENTICATION_ERROR;
 
@@ -61,6 +61,7 @@ class AdminSecurityController extends Controller
             $error = null; // The value does not come from the security component.
         }
 
+        // NEXT_MAJOR: Symfony <2.6 BC. To be removed.
         $lastUsernameKey = class_exists('Symfony\Component\Security\Core\Security')
             ? Security::LAST_USERNAME : SecurityContextInterface::LAST_USERNAME;
 

--- a/Controller/SecurityFOSUser1Controller.php
+++ b/Controller/SecurityFOSUser1Controller.php
@@ -15,6 +15,7 @@ use FOS\UserBundle\Controller\SecurityController;
 use Sonata\UserBundle\Model\UserInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Security\Core\SecurityContextInterface;
 
 /**
@@ -51,12 +52,16 @@ class SecurityFOSUser1Controller extends SecurityController
         /** @var $session \Symfony\Component\HttpFoundation\Session\Session */
         $session = $request->getSession();
 
+        // NEXT_MAJOR: Symfony <2.6 BC. To be removed.
+        $authenticationErrorKey = class_exists('Symfony\Component\Security\Core\Security')
+            ? Security::AUTHENTICATION_ERROR : SecurityContextInterface::AUTHENTICATION_ERROR;
+
         // get the error if any (works with forward and redirect -- see below)
-        if ($request->attributes->has(SecurityContextInterface::AUTHENTICATION_ERROR)) {
-            $error = $request->attributes->get(SecurityContextInterface::AUTHENTICATION_ERROR);
-        } elseif (null !== $session && $session->has(SecurityContextInterface::AUTHENTICATION_ERROR)) {
-            $error = $session->get(SecurityContextInterface::AUTHENTICATION_ERROR);
-            $session->remove(SecurityContextInterface::AUTHENTICATION_ERROR);
+        if ($request->attributes->has(authenticationErrorKey)) {
+            $error = $request->attributes->get(authenticationErrorKey);
+        } elseif (null !== $session && $session->has(authenticationErrorKey)) {
+            $error = $session->get(authenticationErrorKey);
+            $session->remove(authenticationErrorKey);
         } else {
             $error = null;
         }
@@ -65,8 +70,12 @@ class SecurityFOSUser1Controller extends SecurityController
             $error = null; // The value does not come from the security component.
         }
 
+        // NEXT_MAJOR: Symfony <2.6 BC. To be removed.
+        $lastUserNameKey = class_exists('Symfony\Component\Security\Core\Security')
+            ? Security::LAST_USERNAME : SecurityContextInterface::LAST_USERNAME;
+
         return $this->renderLogin(array(
-            'last_username' => (null === $session) ? '' : $session->get(SecurityContextInterface::LAST_USERNAME),
+            'last_username' => (null === $session) ? '' : $session->get($lastUserNameKey),
             'error' => $error,
             'csrf_token' => $this->container->get('form.csrf_provider')->generateCsrfToken('authenticate'),
         ));

--- a/DependencyInjection/SonataUserExtension.php
+++ b/DependencyInjection/SonataUserExtension.php
@@ -69,6 +69,32 @@ class SonataUserExtension extends Extension
 
         $config = $this->addDefaults($config);
 
+        // Set the SecurityContext for Symfony <2.6
+        // NEXT_MAJOR: Go back to simple xml configuration when bumping requirements to SF 2.6+
+        if (interface_exists('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')) {
+            $tokenStorageReference = new Reference('security.token_storage');
+            $authorizationCheckerReference = new Reference('security.authorization_checker');
+        } else {
+            $tokenStorageReference = new Reference('security.context');
+            $authorizationCheckerReference = new Reference('security.context');
+        }
+
+        $container
+            ->getDefinition('sonata.user.editable_role_builder')
+            ->replaceArgument(0, $tokenStorageReference)
+            ->replaceArgument(1, $authorizationCheckerReference)
+        ;
+
+        $container
+            ->getDefinition('sonata.user.block.account')
+            ->replaceArgument(2, $tokenStorageReference)
+        ;
+
+        $container
+            ->getDefinition('sonata.user.google.authenticator.request_listener')
+            ->replaceArgument(2, $tokenStorageReference)
+        ;
+
         $this->registerDoctrineMapping($config);
         $this->configureAdminClass($config, $container);
         $this->configureClass($config, $container);

--- a/GoogleAuthenticator/RequestListener.php
+++ b/GoogleAuthenticator/RequestListener.php
@@ -14,8 +14,8 @@ namespace Sonata\UserBundle\GoogleAuthenticator;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernel;
-use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 class RequestListener
 {

--- a/GoogleAuthenticator/RequestListener.php
+++ b/GoogleAuthenticator/RequestListener.php
@@ -15,7 +15,7 @@ use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernel;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
-use Symfony\Component\Security\Core\SecurityContextInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 class RequestListener
 {
@@ -25,9 +25,9 @@ class RequestListener
     protected $helper;
 
     /**
-     * @var SecurityContextInterface
+     * @var TokenStorageInterface
      */
-    protected $securityContext;
+    protected $tokenStorage;
 
     /**
      * @var EngineInterface
@@ -35,14 +35,14 @@ class RequestListener
     protected $templating;
 
     /**
-     * @param Helper                   $helper
-     * @param SecurityContextInterface $securityContext
-     * @param EngineInterface          $templating
+     * @param Helper                $helper
+     * @param TokenStorageInterface $tokenStorage
+     * @param EngineInterface       $templating
      */
-    public function __construct(Helper $helper, SecurityContextInterface $securityContext, EngineInterface $templating)
+    public function __construct(Helper $helper, TokenStorageInterface $tokenStorage, EngineInterface $templating)
     {
         $this->helper = $helper;
-        $this->securityContext = $securityContext;
+        $this->tokenStorage = $tokenStorage;
         $this->templating = $templating;
     }
 
@@ -55,7 +55,7 @@ class RequestListener
             return;
         }
 
-        $token = $this->securityContext->getToken();
+        $token = $this->tokenStorage->getToken();
 
         if (!$token) {
             return;
@@ -65,10 +65,10 @@ class RequestListener
             return;
         }
 
-        $key = $this->helper->getSessionKey($this->securityContext->getToken());
+        $key = $this->helper->getSessionKey($token);
         $request = $event->getRequest();
         $session = $event->getRequest()->getSession();
-        $user = $this->securityContext->getToken()->getUser();
+        $user = $token->getUser();
 
         if (!$session->has($key)) {
             return;

--- a/GoogleAuthenticator/RequestListener.php
+++ b/GoogleAuthenticator/RequestListener.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernel;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\SecurityContextInterface;
 
 class RequestListener
 {
@@ -25,7 +26,7 @@ class RequestListener
     protected $helper;
 
     /**
-     * @var TokenStorageInterface
+     * @var TokenStorageInterface|SecurityContextInterface
      */
     protected $tokenStorage;
 
@@ -35,12 +36,18 @@ class RequestListener
     protected $templating;
 
     /**
-     * @param Helper                $helper
-     * @param TokenStorageInterface $tokenStorage
-     * @param EngineInterface       $templating
+     * NEXT_MAJOR: Go back to signature class check when bumping requirements to SF 2.6+.
+     * 
+     * @param Helper                                         $helper
+     * @param TokenStorageInterface|SecurityContextInterface $tokenStorage
+     * @param EngineInterface                                $templating
      */
-    public function __construct(Helper $helper, TokenStorageInterface $tokenStorage, EngineInterface $templating)
+    public function __construct(Helper $helper, $tokenStorage, EngineInterface $templating)
     {
+        if (!$tokenStorage instanceof TokenStorageInterface && !$tokenStorage instanceof SecurityContextInterface) {
+            throw new \InvalidArgumentException('Argument 1 should be an instance of Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface or Symfony\Component\Security\Core\SecurityContextInterface');
+        }
+
         $this->helper = $helper;
         $this->tokenStorage = $tokenStorage;
         $this->templating = $templating;

--- a/GoogleAuthenticator/RequestListener.php
+++ b/GoogleAuthenticator/RequestListener.php
@@ -37,7 +37,7 @@ class RequestListener
 
     /**
      * NEXT_MAJOR: Go back to signature class check when bumping requirements to SF 2.6+.
-     * 
+     *
      * @param Helper                                         $helper
      * @param TokenStorageInterface|SecurityContextInterface $tokenStorage
      * @param EngineInterface                                $templating

--- a/GoogleAuthenticator/RequestListener.php
+++ b/GoogleAuthenticator/RequestListener.php
@@ -36,7 +36,7 @@ class RequestListener
     protected $templating;
 
     /**
-     * NEXT_MAJOR: Go back to signature class check when bumping requirements to SF 2.6+.
+     * NEXT_MAJOR: Go back to type hinting check when bumping requirements to SF 2.6+.
      *
      * @param Helper                                         $helper
      * @param TokenStorageInterface|SecurityContextInterface $tokenStorage
@@ -45,7 +45,9 @@ class RequestListener
     public function __construct(Helper $helper, $tokenStorage, EngineInterface $templating)
     {
         if (!$tokenStorage instanceof TokenStorageInterface && !$tokenStorage instanceof SecurityContextInterface) {
-            throw new \InvalidArgumentException('Argument 1 should be an instance of Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface or Symfony\Component\Security\Core\SecurityContextInterface');
+            throw new \InvalidArgumentException(
+                'Argument 2 should be an instance of Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface or Symfony\Component\Security\Core\SecurityContextInterface'
+            );
         }
 
         $this->helper = $helper;

--- a/Resources/config/admin.xml
+++ b/Resources/config/admin.xml
@@ -2,7 +2,8 @@
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <service id="sonata.user.editable_role_builder" class="Sonata\UserBundle\Security\EditableRolesBuilder">
-            <argument type="service" id="security.context"/>
+            <argument type="service" id="security.token_storage"/>
+            <argument type="service" id="security.authorization_checker"/>
             <argument type="service" id="sonata.admin.pool"/>
             <argument>%security.role_hierarchy.roles%</argument>
         </service>

--- a/Resources/config/admin.xml
+++ b/Resources/config/admin.xml
@@ -2,8 +2,8 @@
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <service id="sonata.user.editable_role_builder" class="Sonata\UserBundle\Security\EditableRolesBuilder">
-            <argument type="service" id="security.token_storage"/>
-            <argument type="service" id="security.authorization_checker"/>
+            <argument/>
+            <argument/>
             <argument type="service" id="sonata.admin.pool"/>
             <argument>%security.role_hierarchy.roles%</argument>
         </service>

--- a/Resources/config/block.xml
+++ b/Resources/config/block.xml
@@ -12,7 +12,7 @@
             <tag name="sonata.block"/>
             <argument>sonata.user.block.account</argument>
             <argument type="service" id="templating"/>
-            <argument type="service" id="security.context"/>
+            <argument type="service" id="security.token_storage"/>
         </service>
     </services>
 </container>

--- a/Resources/config/block.xml
+++ b/Resources/config/block.xml
@@ -12,7 +12,7 @@
             <tag name="sonata.block"/>
             <argument>sonata.user.block.account</argument>
             <argument type="service" id="templating"/>
-            <argument type="service" id="security.token_storage"/>
+            <argument/>
         </service>
     </services>
 </container>

--- a/Resources/config/google_authenticator.xml
+++ b/Resources/config/google_authenticator.xml
@@ -15,7 +15,7 @@
         <service id="sonata.user.google.authenticator.request_listener" class="Sonata\UserBundle\GoogleAuthenticator\RequestListener">
             <tag name="kernel.event_listener" event="kernel.request" method="onCoreRequest" priority="-1"/>
             <argument type="service" id="sonata.user.google.authenticator.provider"/>
-            <argument type="service" id="security.context"/>
+            <argument type="service" id="security.token_storage"/>
             <argument type="service" id="templating"/>
         </service>
     </services>

--- a/Resources/config/google_authenticator.xml
+++ b/Resources/config/google_authenticator.xml
@@ -15,7 +15,7 @@
         <service id="sonata.user.google.authenticator.request_listener" class="Sonata\UserBundle\GoogleAuthenticator\RequestListener">
             <tag name="kernel.event_listener" event="kernel.request" method="onCoreRequest" priority="-1"/>
             <argument type="service" id="sonata.user.google.authenticator.provider"/>
-            <argument type="service" id="security.token_storage"/>
+            <argument/>
             <argument type="service" id="templating"/>
         </service>
     </services>

--- a/Security/EditableRolesBuilder.php
+++ b/Security/EditableRolesBuilder.php
@@ -14,16 +14,17 @@ namespace Sonata\UserBundle\Security;
 use Sonata\AdminBundle\Admin\Pool;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Security\Core\SecurityContextInterface;
 
 class EditableRolesBuilder
 {
     /**
-     * @var TokenStorageInterface
+     * @var TokenStorageInterface|SecurityContextInterface
      */
     protected $tokenStorage;
 
     /**
-     * @var AuthorizationCheckerInterface
+     * @var AuthorizationCheckerInterface|SecurityContextInterface
      */
     protected $authorizationChecker;
 
@@ -38,13 +39,22 @@ class EditableRolesBuilder
     protected $rolesHierarchy;
 
     /**
-     * @param TokenStorageInterface         $tokenStorage
-     * @param AuthorizationCheckerInterface $authorizationChecker
-     * @param Pool                          $pool
-     * @param array                         $rolesHierarchy
+     * NEXT_MAJOR: Go back to signature class check when bumping requirements to SF 2.6+.
+     * 
+     * @param TokenStorageInterface|SecurityContextInterface         $tokenStorage
+     * @param AuthorizationCheckerInterface|SecurityContextInterface $authorizationChecker
+     * @param Pool                                                   $pool
+     * @param array                                                  $rolesHierarchy
      */
-    public function __construct(TokenStorageInterface $tokenStorage, AuthorizationCheckerInterface $authorizationChecker, Pool $pool, array $rolesHierarchy = array())
+    public function __construct($tokenStorage, $authorizationChecker, Pool $pool, array $rolesHierarchy = array())
     {
+        if (!$tokenStorage instanceof TokenStorageInterface && !$tokenStorage instanceof SecurityContextInterface) {
+            throw new \InvalidArgumentException('Argument 1 should be an instance of Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface or Symfony\Component\Security\Core\SecurityContextInterface');
+        }
+        if (!$authorizationChecker instanceof AuthorizationCheckerInterface && !$authorizationChecker instanceof SecurityContextInterface) {
+            throw new \InvalidArgumentException('Argument 2 should be an instance of Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface or Symfony\Component\Security\Core\SecurityContextInterface');
+        }
+
         $this->tokenStorage = $tokenStorage;
         $this->authorizationChecker = $authorizationChecker;
         $this->pool = $pool;

--- a/Security/EditableRolesBuilder.php
+++ b/Security/EditableRolesBuilder.php
@@ -39,7 +39,7 @@ class EditableRolesBuilder
     protected $rolesHierarchy;
 
     /**
-     * NEXT_MAJOR: Go back to signature class check when bumping requirements to SF 2.6+.
+     * NEXT_MAJOR: Go back to type hinting check when bumping requirements to SF 2.6+.
      *
      * @param TokenStorageInterface|SecurityContextInterface         $tokenStorage
      * @param AuthorizationCheckerInterface|SecurityContextInterface $authorizationChecker
@@ -49,10 +49,14 @@ class EditableRolesBuilder
     public function __construct($tokenStorage, $authorizationChecker, Pool $pool, array $rolesHierarchy = array())
     {
         if (!$tokenStorage instanceof TokenStorageInterface && !$tokenStorage instanceof SecurityContextInterface) {
-            throw new \InvalidArgumentException('Argument 1 should be an instance of Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface or Symfony\Component\Security\Core\SecurityContextInterface');
+            throw new \InvalidArgumentException(
+                'Argument 1 should be an instance of Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface or Symfony\Component\Security\Core\SecurityContextInterface'
+            );
         }
         if (!$authorizationChecker instanceof AuthorizationCheckerInterface && !$authorizationChecker instanceof SecurityContextInterface) {
-            throw new \InvalidArgumentException('Argument 2 should be an instance of Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface or Symfony\Component\Security\Core\SecurityContextInterface');
+            throw new \InvalidArgumentException(
+                'Argument 2 should be an instance of Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface or Symfony\Component\Security\Core\SecurityContextInterface'
+            );
         }
 
         $this->tokenStorage = $tokenStorage;

--- a/Security/EditableRolesBuilder.php
+++ b/Security/EditableRolesBuilder.php
@@ -40,7 +40,7 @@ class EditableRolesBuilder
 
     /**
      * NEXT_MAJOR: Go back to signature class check when bumping requirements to SF 2.6+.
-     * 
+     *
      * @param TokenStorageInterface|SecurityContextInterface         $tokenStorage
      * @param AuthorizationCheckerInterface|SecurityContextInterface $authorizationChecker
      * @param Pool                                                   $pool

--- a/Tests/Security/EditableRolesBuilderTest.php
+++ b/Tests/Security/EditableRolesBuilderTest.php
@@ -22,9 +22,11 @@ class EditableRolesBuilderTest extends \PHPUnit_Framework_TestCase
     {
         $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
 
-        $security = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
-        $security->expects($this->any())->method('isGranted')->will($this->returnValue(true));
-        $security->expects($this->any())->method('getToken')->will($this->returnValue($token));
+        $tokenStorage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
+        $tokenStorage->expects($this->any())->method('getToken')->will($this->returnValue($token));
+
+        $authorizationChecker = $this->getMock('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
+        $authorizationChecker->expects($this->any())->method('isGranted')->will($this->returnValue(true));
 
         $pool = $this->getMockBuilder('Sonata\AdminBundle\Admin\Pool')
                 ->disableOriginalConstructor()
@@ -58,7 +60,7 @@ class EditableRolesBuilderTest extends \PHPUnit_Framework_TestCase
             'SONATA' => 'SONATA: ',
         );
 
-        $builder = new EditableRolesBuilder($security, $pool, $rolesHierarchy);
+        $builder = new EditableRolesBuilder($tokenStorage, $authorizationChecker, $pool, $rolesHierarchy);
         list($roles, $rolesReadOnly) = $builder->getRoles();
 
         $this->assertEmpty($rolesReadOnly);
@@ -77,9 +79,11 @@ class EditableRolesBuilderTest extends \PHPUnit_Framework_TestCase
 
         $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
 
-        $security = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
-        $security->expects($this->any())->method('isGranted')->will($this->returnValue(true));
-        $security->expects($this->any())->method('getToken')->will($this->returnValue($token));
+        $tokenStorage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
+        $tokenStorage->expects($this->any())->method('getToken')->will($this->returnValue($token));
+
+        $authorizationChecker = $this->getMock('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
+        $authorizationChecker->expects($this->any())->method('isGranted')->will($this->returnValue(true));
 
         $pool = $this->getMockBuilder('Sonata\AdminBundle\Admin\Pool')
                 ->disableOriginalConstructor()
@@ -88,7 +92,7 @@ class EditableRolesBuilderTest extends \PHPUnit_Framework_TestCase
         $pool->expects($this->once())->method('getInstance')->will($this->returnValue($admin));
         $pool->expects($this->once())->method('getAdminServiceIds')->will($this->returnValue(array('myadmin')));
 
-        $builder = new EditableRolesBuilder($security, $pool, array());
+        $builder = new EditableRolesBuilder($tokenStorage, $authorizationChecker, $pool, array());
 
         $expected = array(
           'ROLE_FOO_GUEST' => 'ROLE_FOO_GUEST',
@@ -104,14 +108,17 @@ class EditableRolesBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testWithNoSecurityToken()
     {
-        $security = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
-        $security->expects($this->any())->method('getToken')->will($this->returnValue(null));
+        $tokenStorage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
+        $tokenStorage->expects($this->any())->method('getToken')->will($this->returnValue(null));
+
+        $authorizationChecker = $this->getMock('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
+        $authorizationChecker->expects($this->any())->method('isGranted')->will($this->returnValue(false));
 
         $pool = $this->getMockBuilder('Sonata\AdminBundle\Admin\Pool')
                 ->disableOriginalConstructor()
                 ->getMock();
 
-        $builder = new EditableRolesBuilder($security, $pool, array());
+        $builder = new EditableRolesBuilder($tokenStorage, $authorizationChecker, $pool, array());
 
         list($roles, $rolesReadOnly) = $builder->getRoles();
 

--- a/Tests/Security/EditableRolesBuilderTest.php
+++ b/Tests/Security/EditableRolesBuilderTest.php
@@ -15,15 +15,14 @@ use Sonata\UserBundle\Security\EditableRolesBuilder;
 
 class EditableRolesBuilderTest extends \PHPUnit_Framework_TestCase
 {
-
     public function getTokenStorageMock()
     {
         // Set the SecurityContext for Symfony <2.6
         // TODO: Remove conditional return when bumping requirements to SF 2.6+
         if (interface_exists('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')) {
             return $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
-
         }
+
         return $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
     }
 
@@ -34,6 +33,7 @@ class EditableRolesBuilderTest extends \PHPUnit_Framework_TestCase
         if (interface_exists('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface')) {
             return $this->getMock('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
         }
+
         return $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
     }
 

--- a/Tests/Security/EditableRolesBuilderTest.php
+++ b/Tests/Security/EditableRolesBuilderTest.php
@@ -15,6 +15,28 @@ use Sonata\UserBundle\Security\EditableRolesBuilder;
 
 class EditableRolesBuilderTest extends \PHPUnit_Framework_TestCase
 {
+
+    public function getTokenStorageMock()
+    {
+        // Set the SecurityContext for Symfony <2.6
+        // TODO: Remove conditional return when bumping requirements to SF 2.6+
+        if (interface_exists('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')) {
+            return $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
+
+        }
+        return $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
+    }
+
+    public function getAuthorizationCheckerMock()
+    {
+        // Set the SecurityContext for Symfony <2.6
+        // TODO: Remove conditional return when bumping requirements to SF 2.6+
+        if (interface_exists('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface')) {
+            return $this->getMock('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
+        }
+        return $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
+    }
+
     /**
      * @group legacy
      */
@@ -22,10 +44,10 @@ class EditableRolesBuilderTest extends \PHPUnit_Framework_TestCase
     {
         $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
 
-        $tokenStorage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
+        $tokenStorage = $this->getTokenStorageMock();
         $tokenStorage->expects($this->any())->method('getToken')->will($this->returnValue($token));
 
-        $authorizationChecker = $this->getMock('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
+        $authorizationChecker = $this->getAuthorizationCheckerMock();
         $authorizationChecker->expects($this->any())->method('isGranted')->will($this->returnValue(true));
 
         $pool = $this->getMockBuilder('Sonata\AdminBundle\Admin\Pool')
@@ -79,10 +101,10 @@ class EditableRolesBuilderTest extends \PHPUnit_Framework_TestCase
 
         $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
 
-        $tokenStorage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
+        $tokenStorage = $this->getTokenStorageMock();
         $tokenStorage->expects($this->any())->method('getToken')->will($this->returnValue($token));
 
-        $authorizationChecker = $this->getMock('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
+        $authorizationChecker = $this->getAuthorizationCheckerMock();
         $authorizationChecker->expects($this->any())->method('isGranted')->will($this->returnValue(true));
 
         $pool = $this->getMockBuilder('Sonata\AdminBundle\Admin\Pool')
@@ -108,10 +130,10 @@ class EditableRolesBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testWithNoSecurityToken()
     {
-        $tokenStorage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
+        $tokenStorage = $this->getTokenStorageMock();
         $tokenStorage->expects($this->any())->method('getToken')->will($this->returnValue(null));
 
-        $authorizationChecker = $this->getMock('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
+        $authorizationChecker = $this->getAuthorizationCheckerMock();
         $authorizationChecker->expects($this->any())->method('isGranted')->will($this->returnValue(false));
 
         $pool = $this->getMockBuilder('Sonata\AdminBundle\Admin\Pool')

--- a/Tests/Security/EditableRolesBuilderTest.php
+++ b/Tests/Security/EditableRolesBuilderTest.php
@@ -18,7 +18,7 @@ class EditableRolesBuilderTest extends \PHPUnit_Framework_TestCase
     public function getTokenStorageMock()
     {
         // Set the SecurityContext for Symfony <2.6
-        // TODO: Remove conditional return when bumping requirements to SF 2.6+
+        // NEXT_MAJOR: Remove conditional return when bumping requirements to SF 2.6+
         if (interface_exists('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')) {
             return $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
         }
@@ -29,7 +29,7 @@ class EditableRolesBuilderTest extends \PHPUnit_Framework_TestCase
     public function getAuthorizationCheckerMock()
     {
         // Set the SecurityContext for Symfony <2.6
-        // TODO: Remove conditional return when bumping requirements to SF 2.6+
+        // NEXT_MAJOR: Remove conditional return when bumping requirements to SF 2.6+
         if (interface_exists('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface')) {
             return $this->getMock('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
         }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because its an internal fix and is BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
replace SecurityContextInterface with TokenStorageInterface and/or AuthorizationCheckerInterface

### Removed
removed use of SecurityContextInterface which was dropped in symfony 3.0
```

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

## Subject

<!-- Describe your Pull Request content here -->

removed SecurityContextInterface and replace it with TokenStorageInterface and/or AuthorizationCheckerInterface

it is part of the work to get sonata ready for symfony 3.*