### PR TITLE
fixed $authenticationErrorKey in SecurityFOSUser1Controller

### DIFF
--- a/Controller/SecurityFOSUser1Controller.php
+++ b/Controller/SecurityFOSUser1Controller.php
@@ -57,11 +57,11 @@ class SecurityFOSUser1Controller extends SecurityController
             ? Security::AUTHENTICATION_ERROR : SecurityContextInterface::AUTHENTICATION_ERROR;
 
         // get the error if any (works with forward and redirect -- see below)
-        if ($request->attributes->has(authenticationErrorKey)) {
-            $error = $request->attributes->get(authenticationErrorKey);
-        } elseif (null !== $session && $session->has(authenticationErrorKey)) {
-            $error = $session->get(authenticationErrorKey);
-            $session->remove(authenticationErrorKey);
+        if ($request->attributes->has($authenticationErrorKey)) {
+            $error = $request->attributes->get($authenticationErrorKey);
+        } elseif (null !== $session && $session->has($authenticationErrorKey)) {
+            $error = $session->get($authenticationErrorKey);
+            $session->remove($authenticationErrorKey);
         } else {
             $error = null;
         }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because hotfix of previous pullrequest.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
fixed $authenticationErrorKey in SecurityFOSUser1Controller
### Security
```

## Subject

fixed $authenticationErrorKey in SecurityFOSUser1Controller
