### PR TITLE
fix sonata-project/SonataUserBundle#818 : "bad UserManagerProxy decla...

### DIFF
--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -9,7 +9,7 @@
             <argument>%fos_user.model.user.class%</argument>
         </service>
         <service id="sonata.user.manager.user" class="Sonata\UserBundle\Entity\UserManagerProxy">
-            <argument>Sonata\UserBundle\Entity\User</argument>
+            <argument>%fos_user.model.user.class%</argument>
             <argument type="service" id="doctrine"/>
             <argument type="service" id="sonata.user.orm.user_manager"/>
         </service>


### PR DESCRIPTION
…ration ?"

I am targetting this branch (3.x), because the commit fixes a (minor) bug that breaks some of the methods of UserManagerProxy. (could be fixed delegating the concerned methods to the FosUserManager but it was simplier this way).

Closes #818

## Changelog

```markdown
### Fixed
- Declaration of `UserManagerProxy` uses `Sonata\UserBundle\Entity\User` instead of `%fos_user.model.user.class%`
```

## Subject

Fixing the `UserManagerProxy` service declaration to use `%fos_user.model.user.class%` instead of `Sonata\UserBundle\Entity\User`