### PR TITLE
The service "sonata.user.editable_role_builder" should be checked to exist

### DIFF
--- a/DependencyInjection/SonataUserExtension.php
+++ b/DependencyInjection/SonataUserExtension.php
@@ -84,11 +84,13 @@ class SonataUserExtension extends Extension
             $authorizationCheckerReference = new Reference('security.context');
         }
 
-        $container
-            ->getDefinition('sonata.user.editable_role_builder')
-            ->replaceArgument(0, $tokenStorageReference)
-            ->replaceArgument(1, $authorizationCheckerReference)
-        ;
+        if ($container->hasDefinition('sonata.user.editable_role_builder')) {
+            $container
+                ->getDefinition('sonata.user.editable_role_builder')
+                ->replaceArgument(0, $tokenStorageReference)
+                ->replaceArgument(1, $authorizationCheckerReference)
+            ;
+        }
 
         $container
             ->getDefinition('sonata.user.block.account')


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because {reason}.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- the bundle can be used without a `sonata.user.editable_role_builder` service
```
## Subject

<!-- Describe your Pull Request content here -->
Service "sonata.user.editable_role_builder" uses with the "SonataAdminBundle" only and should be checked to exist.