### PR TITLE
fixed argument replacing position

### DIFF
--- a/DependencyInjection/SonataUserExtension.php
+++ b/DependencyInjection/SonataUserExtension.php
@@ -99,7 +99,7 @@ class SonataUserExtension extends Extension
 
         $container
             ->getDefinition('sonata.user.google.authenticator.request_listener')
-            ->replaceArgument(2, $tokenStorageReference)
+            ->replaceArgument(1, $tokenStorageReference)
         ;
 
         $this->registerDoctrineMapping($config);


### PR DESCRIPTION
I am targetting this branch, because this bug was introduced by a PR to this branch: https://github.com/sonata-project/SonataUserBundle/pull/812

The `index` of `replaceArgument()` starts at 0 instead of 1. This resulted in the following error:
```
Type error: Argument 3 passed to Sonata\UserBundle\GoogleAuthenticator\RequestListener::__construct() must be an instance of Symfony\Bundle\FrameworkBundle\Templating\EngineInterface, instance of Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage given
```

## Changelog

```markdown
### Fixed
- Issue where service was injected to constructor at wrong position
```
