### PR TITLE
Fixed deprecation of security.context on AdminSecurityController

### DIFF
--- a/Controller/AdminResettingController.php
+++ b/Controller/AdminResettingController.php
@@ -27,7 +27,11 @@ class AdminResettingController extends ResettingController
      */
     public function requestAction()
     {
-        if ($this->container->get('security.context')->isGranted('IS_AUTHENTICATED_FULLY')) {
+        // NEXT_MAJOR: remove when dropping Symfony <2.8 support
+        $authorizationCheckerService = $this->container->has('security.authorization_checker')
+            ? $this->container->get('security.authorization_checker') : $this->container->get('security.context');
+
+        if ($authorizationCheckerService->isGranted('IS_AUTHENTICATED_FULLY')) {
             return new RedirectResponse($this->container->get('router')->generate('sonata_admin_dashboard'));
         }
 
@@ -102,7 +106,11 @@ class AdminResettingController extends ResettingController
      */
     public function resetAction($token)
     {
-        if ($this->container->get('security.context')->isGranted('IS_AUTHENTICATED_FULLY')) {
+        // NEXT_MAJOR: remove when dropping Symfony <2.8 support
+        $authorizationCheckerService = $this->container->has('security.authorization_checker')
+            ? $this->container->get('security.authorization_checker') : $this->container->get('security.context');
+
+        if ($authorizationCheckerService->isGranted('IS_AUTHENTICATED_FULLY')) {
             return new RedirectResponse($this->container->get('router')->generate('sonata_admin_dashboard'));
         }
 

--- a/Controller/AdminSecurityController.php
+++ b/Controller/AdminSecurityController.php
@@ -77,7 +77,7 @@ class AdminSecurityController extends Controller
         }
 
         // NEXT_MAJOR: remove when dropping Symfony <2.8 support
-        $authorizationCheckerService = class_exists('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface')
+        $authorizationCheckerService = $this->has('security.authorization_checker')
             ? $this->get('security.authorization_checker') : $this->get('security.context');
 
         if ($authorizationCheckerService->isGranted('ROLE_ADMIN')) {

--- a/Controller/SecurityFOSUser1Controller.php
+++ b/Controller/SecurityFOSUser1Controller.php
@@ -28,7 +28,11 @@ class SecurityFOSUser1Controller extends SecurityController
      */
     public function loginAction()
     {
-        $token = $this->container->get('security.context')->getToken();
+        // NEXT_MAJOR: remove when dropping Symfony <2.8 support
+        $tokenStorageService = $this->container->has('security.token_storage')
+            ? $this->container->get('security.token_storage') : $this->container->get('security.context');
+
+        $token = $tokenStorageService->getToken();
 
         if ($token && $token->getUser() instanceof UserInterface) {
             $this->container->get('session')->getFlashBag()->set('sonata_user_error', 'sonata_user_already_authenticated');


### PR DESCRIPTION
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because it is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->



## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Deprecation of `security.context` on `AdminSecurityController`
```

## Subject

<!-- Describe your Pull Request content here -->
It removes a deprecated message. The code was testing if a class_exists on an interface (that always returns false). I replaced it with a container has method, which is used earlier in the same class for another BC trick.
