### PR TITLE
Remove non FQCN from form types

### DIFF
--- a/Admin/Model/GroupAdmin.php
+++ b/Admin/Model/GroupAdmin.php
@@ -61,6 +61,11 @@ class GroupAdmin extends AbstractAdmin
      */
     protected function configureFormFields(FormMapper $formMapper)
     {
+        // NEXT_MAJOR: Keep FQCN when bumping Symfony requirement to 2.8+.
+        $securityRolesType = method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')
+            ? 'Sonata\UserBundle\Form\Type\SecurityRolesType'
+            : 'sonata_security_roles';
+
         $formMapper
             ->tab('Group')
                 ->with('General', array('class' => 'col-md-6'))
@@ -69,7 +74,7 @@ class GroupAdmin extends AbstractAdmin
             ->end()
             ->tab('Security')
                 ->with('Roles', array('class' => 'col-md-12'))
-                    ->add('roles', 'sonata_security_roles', array(
+                    ->add('roles', $securityRolesType, array(
                         'expanded' => true,
                         'multiple' => true,
                         'required' => false,

--- a/Admin/Model/UserAdmin.php
+++ b/Admin/Model/UserAdmin.php
@@ -174,17 +174,38 @@ class UserAdmin extends AbstractAdmin
 
         $now = new \DateTime();
 
+        // NEXT_MAJOR: Keep FQCN when bumping Symfony requirement to 2.8+.
+        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+            $textType = 'Symfony\Component\Form\Extension\Core\Type\TextType';
+            $datePickerType = 'Sonata\CoreBundle\Form\Type\DatePickerType';
+            $urlType = 'Symfony\Component\Form\Extension\Core\Type\UrlType';
+            $userGenderType = 'Sonata\UserBundle\Form\Type\UserGenderListType';
+            $localeType = 'Symfony\Component\Form\Extension\Core\Type\LocaleType';
+            $timezoneType = 'Symfony\Component\Form\Extension\Core\Type\TimezoneType';
+            $modelType = 'Sonata\AdminBundle\Form\Type\ModelType';
+            $securityRolesType = 'Sonata\UserBundle\Form\Type\SecurityRolesType';
+        } else {
+            $textType = 'text';
+            $datePickerType = 'sonata_type_date_picker';
+            $urlType = 'url';
+            $userGenderType = 'sonata_user_gender';
+            $localeType = 'locale';
+            $timezoneType = 'timezone';
+            $modelType = 'sonata_type_model';
+            $securityRolesType = 'sonata_security_roles';
+        }
+
         $formMapper
             ->tab('User')
                 ->with('General')
                     ->add('username')
                     ->add('email')
-                    ->add('plainPassword', 'text', array(
+                    ->add('plainPassword', $textType, array(
                         'required' => (!$this->getSubject() || is_null($this->getSubject()->getId())),
                     ))
                 ->end()
                 ->with('Profile')
-                    ->add('dateOfBirth', 'sonata_type_date_picker', array(
+                    ->add('dateOfBirth', $datePickerType, array(
                         'years' => range(1900, $now->format('Y')),
                         'dp_min_date' => '1-1-1900',
                         'dp_max_date' => $now->format('c'),
@@ -192,14 +213,14 @@ class UserAdmin extends AbstractAdmin
                     ))
                     ->add('firstname', null, array('required' => false))
                     ->add('lastname', null, array('required' => false))
-                    ->add('website', 'url', array('required' => false))
-                    ->add('biography', 'text', array('required' => false))
-                    ->add('gender', 'sonata_user_gender', array(
+                    ->add('website', $urlType, array('required' => false))
+                    ->add('biography', $textType, array('required' => false))
+                    ->add('gender', $userGenderType, array(
                         'required' => true,
                         'translation_domain' => $this->getTranslationDomain(),
                     ))
-                    ->add('locale', 'locale', array('required' => false))
-                    ->add('timezone', 'timezone', array('required' => false))
+                    ->add('locale', $localeType, array('required' => false))
+                    ->add('timezone', $timezoneType, array('required' => false))
                     ->add('phone', null, array('required' => false))
                 ->end()
                 ->with('Social')
@@ -219,14 +240,14 @@ class UserAdmin extends AbstractAdmin
                     ->add('credentialsExpired', null, array('required' => false))
                 ->end()
                 ->with('Groups')
-                    ->add('groups', 'sonata_type_model', array(
+                    ->add('groups', $modelType, array(
                         'required' => false,
                         'expanded' => true,
                         'multiple' => true,
                     ))
                 ->end()
                 ->with('Roles')
-                    ->add('realRoles', 'sonata_security_roles', array(
+                    ->add('realRoles', $securityRolesType, array(
                         'label' => 'form.label_roles',
                         'expanded' => true,
                         'multiple' => true,

--- a/Form/Type/ProfileType.php
+++ b/Form/Type/ProfileType.php
@@ -37,8 +37,25 @@ class ProfileType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        // NEXT_MAJOR: Keep FQCN when bumping Symfony requirement to 2.8+.
+        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+            $userGenderType = 'Sonata\UserBundle\Form\Type\UserGenderListType';
+            $birthdayType = 'Symfony\Component\Form\Extension\Core\Type\BirthdayType';
+            $urlType = 'Symfony\Component\Form\Extension\Core\Type\UrlType';
+            $textareaType = 'Symfony\Component\Form\Extension\Core\Type\TextareaType';
+            $localeType = 'Symfony\Component\Form\Extension\Core\Type\LocaleType';
+            $timezoneType = 'Symfony\Component\Form\Extension\Core\Type\TimezoneType';
+        } else {
+            $userGenderType = 'sonata_user_gender';
+            $birthdayType = 'birthday';
+            $urlType = 'url';
+            $textareaType = 'text';
+            $localeType = 'locale';
+            $timezoneType = 'timezone';
+        }
+
         $builder
-            ->add('gender', 'sonata_user_gender', array(
+            ->add('gender', $userGenderType, array(
                 'label' => 'form.label_gender',
                 'required' => true,
                 'translation_domain' => 'SonataUserBundle',
@@ -55,24 +72,24 @@ class ProfileType extends AbstractType
                 'label' => 'form.label_lastname',
                 'required' => false,
             ))
-            ->add('dateOfBirth', 'birthday', array(
+            ->add('dateOfBirth', $birthdayType, array(
                 'label' => 'form.label_date_of_birth',
                 'required' => false,
                 'widget' => 'single_text',
             ))
-            ->add('website', 'url', array(
+            ->add('website', $urlType, array(
                 'label' => 'form.label_website',
                 'required' => false,
             ))
-            ->add('biography', 'textarea', array(
+            ->add('biography', $textareaType, array(
                 'label' => 'form.label_biography',
                 'required' => false,
             ))
-            ->add('locale', 'locale', array(
+            ->add('locale', $localeType, array(
                 'label' => 'form.label_locale',
                 'required' => false,
             ))
-            ->add('timezone', 'timezone', array(
+            ->add('timezone', $timezoneType, array(
                 'label' => 'form.label_timezone',
                 'required' => false,
             ))

--- a/Form/Type/RegistrationFormType.php
+++ b/Form/Type/RegistrationFormType.php
@@ -42,17 +42,28 @@ class RegistrationFormType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        // NEXT_MAJOR: Keep FQCN when bumping Symfony requirement to 2.8+.
+        if (method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
+            $emailType = 'Symfony\Component\Form\Extension\Core\Type\EmailType';
+            $repeatedType = 'Symfony\Component\Form\Extension\Core\Type\RepeatedType';
+            $passwordType = 'Symfony\Component\Form\Extension\Core\Type\PasswordType';
+        } else {
+            $emailType = 'email';
+            $repeatedType = 'repeated';
+            $passwordType = 'password';
+        }
+
         $builder
             ->add('username', null, array_merge(array(
                 'label' => 'form.username',
                 'translation_domain' => 'SonataUserBundle',
             ), $this->mergeOptions))
-            ->add('email', 'email', array_merge(array(
+            ->add('email', $emailType, array_merge(array(
                 'label' => 'form.email',
                 'translation_domain' => 'SonataUserBundle',
             ), $this->mergeOptions))
-            ->add('plainPassword', 'repeated', array_merge(array(
-                'type' => 'password',
+            ->add('plainPassword', $repeatedType, array_merge(array(
+                'type' => $passwordType,
                 'options' => array('translation_domain' => 'SonataUserBundle'),
                 'first_options' => array_merge(array(
                     'label' => 'form.password',


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Removed form types non FQCN on SF2.8+
```

## Subject

<!-- Describe your Pull Request content here -->
Removed deprecation messages from non FQCN on form types. We are not compatible with SF3, this is the first step