### PR TITLE
Update to DatagridBundle 2.2.1 to fix build

### DIFF
--- a/Tests/Entity/GroupManagerTest.php
+++ b/Tests/Entity/GroupManagerTest.php
@@ -21,6 +21,7 @@ class GroupManagerTest extends \PHPUnit_Framework_TestCase
         $self = $this;
         $this
             ->getUserManager(function ($qb) use ($self) {
+                $qb->expects($self->once())->method('getRootAliases')->will($self->returnValue(array('g')));
                 $qb->expects($self->never())->method('andWhere');
                 $qb->expects($self->once())->method('orderBy')->with(
                     $self->equalTo('g.name'),
@@ -52,6 +53,7 @@ class GroupManagerTest extends \PHPUnit_Framework_TestCase
         $self = $this;
         $this
             ->getUserManager(function ($qb) use ($self) {
+                $qb->expects($self->once())->method('getRootAliases')->will($self->returnValue(array('g')));
                 $qb->expects($self->once())->method('andWhere')->with($self->equalTo('g.enabled = :enabled'));
                 $qb->expects($self->once())->method('orderBy')->with(
                     $self->equalTo('g.name'),
@@ -67,6 +69,7 @@ class GroupManagerTest extends \PHPUnit_Framework_TestCase
         $self = $this;
         $this
             ->getUserManager(function ($qb) use ($self) {
+                $qb->expects($self->once())->method('getRootAliases')->will($self->returnValue(array('g')));
                 $qb->expects($self->once())->method('andWhere')->with($self->equalTo('g.enabled = :enabled'));
                 $qb->expects($self->once())->method('orderBy')->with(
                     $self->equalTo('g.name'),

--- a/Tests/Entity/UserManagerTest.php
+++ b/Tests/Entity/UserManagerTest.php
@@ -21,6 +21,7 @@ class UserManagerTest extends \PHPUnit_Framework_TestCase
         $self = $this;
         $this
             ->getUserManager(function ($qb) use ($self) {
+                $qb->expects($self->once())->method('getRootAliases')->will($self->returnValue(array('u')));
                 $qb->expects($self->never())->method('andWhere');
                 $qb->expects($self->once())->method('orderBy')->with(
                     $self->equalTo('u.username'),
@@ -53,6 +54,7 @@ class UserManagerTest extends \PHPUnit_Framework_TestCase
         $self = $this;
         $this
             ->getUserManager(function ($qb) use ($self) {
+                $qb->expects($self->once())->method('getRootAliases')->will($self->returnValue(array('u')));
                 $qb->expects($self->once())->method('andWhere')->with($self->equalTo('u.enabled = :enabled'));
                 $qb->expects($self->once())->method('setParameter')->with(
                     $self->equalTo('enabled'),
@@ -71,6 +73,7 @@ class UserManagerTest extends \PHPUnit_Framework_TestCase
         $self = $this;
         $this
             ->getUserManager(function ($qb) use ($self) {
+                $qb->expects($self->once())->method('getRootAliases')->will($self->returnValue(array('u')));
                 $qb->expects($self->once())->method('andWhere')->with($self->equalTo('u.enabled = :enabled'));
                 $qb->expects($self->once())->method('setParameter')->with(
                     $self->equalTo('enabled'),
@@ -89,6 +92,7 @@ class UserManagerTest extends \PHPUnit_Framework_TestCase
         $self = $this;
         $this
             ->getUserManager(function ($qb) use ($self) {
+                $qb->expects($self->once())->method('getRootAliases')->will($self->returnValue(array('u')));
                 $qb->expects($self->once())->method('andWhere')->with($self->equalTo('u.enabled = :enabled'));
                 $qb->expects($self->once())->method('setParameter')->with(
                     $self->equalTo('enabled'),
@@ -107,6 +111,7 @@ class UserManagerTest extends \PHPUnit_Framework_TestCase
         $self = $this;
         $this
             ->getUserManager(function ($qb) use ($self) {
+                $qb->expects($self->once())->method('getRootAliases')->will($self->returnValue(array('u')));
                 $qb->expects($self->once())->method('andWhere')->with($self->equalTo('u.locked = :locked'));
                 $qb->expects($self->once())->method('setParameter')->with(
                     $self->equalTo('locked'),
@@ -125,6 +130,7 @@ class UserManagerTest extends \PHPUnit_Framework_TestCase
         $self = $this;
         $this
             ->getUserManager(function ($qb) use ($self) {
+                $qb->expects($self->once())->method('getRootAliases')->will($self->returnValue(array('u')));
                 $qb->expects($self->once())->method('andWhere')->with($self->equalTo('u.locked = :locked'));
                 $qb->expects($self->once())->method('orderBy')->with(
                     $self->equalTo('u.username'),
@@ -143,6 +149,7 @@ class UserManagerTest extends \PHPUnit_Framework_TestCase
         $self = $this;
         $this
             ->getUserManager(function ($qb) use ($self) {
+                $qb->expects($self->once())->method('getRootAliases')->will($self->returnValue(array('u')));
                 $qb->expects($self->exactly(2))->method('andWhere')->withConsecutive(
                     array($self->equalTo('u.enabled = :enabled')),
                     array($self->equalTo('u.locked = :locked'))
@@ -170,6 +177,7 @@ class UserManagerTest extends \PHPUnit_Framework_TestCase
         $self = $this;
         $this
             ->getUserManager(function ($qb) use ($self) {
+                $qb->expects($self->once())->method('getRootAliases')->will($self->returnValue(array('u')));
                 $qb->expects($self->exactly(2))->method('andWhere')->withConsecutive(
                     array($self->equalTo('u.enabled = :enabled')),
                     array($self->equalTo('u.locked = :locked'))
@@ -197,6 +205,7 @@ class UserManagerTest extends \PHPUnit_Framework_TestCase
         $self = $this;
         $this
             ->getUserManager(function ($qb) use ($self) {
+                $qb->expects($self->once())->method('getRootAliases')->will($self->returnValue(array('u')));
                 $qb->expects($self->exactly(2))->method('andWhere')->withConsecutive(
                     array($self->equalTo('u.enabled = :enabled')),
                     array($self->equalTo('u.locked = :locked'))
@@ -224,6 +233,7 @@ class UserManagerTest extends \PHPUnit_Framework_TestCase
         $self = $this;
         $this
             ->getUserManager(function ($qb) use ($self) {
+                $qb->expects($self->once())->method('getRootAliases')->will($self->returnValue(array('u')));
                 $qb->expects($self->exactly(2))->method('andWhere')->withConsecutive(
                     array($self->equalTo('u.enabled = :enabled')),
                     array($self->equalTo('u.locked = :locked'))

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "friendsofsymfony/user-bundle": "^1.3",
         "sonata-project/admin-bundle": "^3.1",
         "sonata-project/core-bundle": "^3.0",
-        "sonata-project/datagrid-bundle": "^2.2",
+        "sonata-project/datagrid-bundle": "^2.2.1",
         "sonata-project/doctrine-extensions": "^1.0",
         "sonata-project/easy-extends-bundle": "^2.1",
         "sonata-project/google-authenticator": "^1.0",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is fixing the travis build.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Subject

<!-- Describe your Pull Request content here -->
Update to datagrid 2.2.1 and mock getRootAliases to fix travis builds