### PR TITLE
Remove deprecations about form factory on SF2.8

### DIFF
--- a/DependencyInjection/SonataUserExtension.php
+++ b/DependencyInjection/SonataUserExtension.php
@@ -84,6 +84,19 @@ class SonataUserExtension extends Extension
             $authorizationCheckerReference = new Reference('security.context');
         }
 
+        // NEXT_MAJOR: Remove following lines
+        $profileFormDefinition = $container->getDefinition('sonata.user.profile.form');
+        $registrationFormDefinition = $container->getDefinition('sonata.user.registration.form');
+        if (method_exists($profileFormDefinition, 'setFactory')) {
+            $profileFormDefinition->setFactory(array('form.factory', 'createNamed'));
+            $registrationFormDefinition->setFactory(array('form.factory', 'createNamed'));
+        } else {
+            $profileFormDefinition->setFactoryClass('form.factory');
+            $profileFormDefinition->setFactoryMethod('createNamed');
+            $registrationFormDefinition->setFactoryClass('form.factory');
+            $registrationFormDefinition->setFactoryMethod('createNamed');
+        }
+
         if ($container->hasDefinition('sonata.user.editable_role_builder')) {
             $container
                 ->getDefinition('sonata.user.editable_role_builder')

--- a/Resources/config/form.xml
+++ b/Resources/config/form.xml
@@ -2,7 +2,10 @@
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <!-- profile form -->
-        <service id="sonata.user.profile.form" factory-method="createNamed" factory-service="form.factory" class="Symfony\Component\Form\Form">
+        <service id="sonata.user.profile.form" class="Symfony\Component\Form\Form">
+            <!-- NEXT_MAJOR: Uncomment Following line
+            <factory class="form.factory" method="createNamed"/>
+            -->
             <argument>%sonata.user.profile.form.name%</argument>
             <argument>%sonata.user.profile.form.type%</argument>
             <argument>null</argument>
@@ -26,7 +29,10 @@
             <argument>sonata_user_gender</argument>
             <tag name="form.type" alias="sonata_user_gender"/>
         </service>
-        <service id="sonata.user.registration.form" factory-method="createNamed" factory-service="form.factory" class="Symfony\Component\Form\Form">
+        <service id="sonata.user.registration.form" class="Symfony\Component\Form\Form">
+            <!-- NEXT_MAJOR: Uncomment Following line
+            <factory class="form.factory" method="createNamed"/>
+            -->
             <argument>%sonata.user.registration.form.name%</argument>
             <argument>%sonata.user.registration.form.type%</argument>
             <argument>null</argument>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Removed deprecations about form factory on SF2.8
```

## Subject

<!-- Describe your Pull Request content here -->
Removed deprecations about service definitions, form factory changes from SF2.3 to SF2.7/2.8. To be compatible with SF3.0 at some point we need this change.

Depends on: #838
