### PR TITLE
Fixing deprecated getMock in tests

### DIFF
--- a/Tests/Controller/Api/GroupControllerTest.php
+++ b/Tests/Controller/Api/GroupControllerTest.php
@@ -9,20 +9,21 @@
  * file that was distributed with this source code.
  */
 
-namespace Sonata\Test\UserBundle\Controller\Api;
+namespace Sonata\UserBundle\Tests\Controller\Api;
 
 use Sonata\UserBundle\Controller\Api\GroupController;
+use Sonata\UserBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
  */
-class GroupControllerTest extends \PHPUnit_Framework_TestCase
+class GroupControllerTest extends PHPUnit_Framework_TestCase
 {
     public function testGetGroupsAction()
     {
-        $group = $this->getMock('FOS\UserBundle\Model\GroupInterface');
-        $groupManager = $this->getMock('Sonata\UserBundle\Model\GroupManagerInterface');
+        $group = $this->createMock('FOS\UserBundle\Model\GroupInterface');
+        $groupManager = $this->createMock('Sonata\UserBundle\Model\GroupManagerInterface');
         $groupManager->expects($this->once())->method('getPager')->will($this->returnValue(array($group)));
 
         $paramFetcher = $this->getMockBuilder('FOS\RestBundle\Request\ParamFetcher')
@@ -36,7 +37,7 @@ class GroupControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testGetGroupAction()
     {
-        $group = $this->getMock('FOS\UserBundle\Model\GroupInterface');
+        $group = $this->createMock('FOS\UserBundle\Model\GroupInterface');
         $this->assertEquals($group, $this->createGroupController($group)->getGroupAction(1));
     }
 
@@ -51,9 +52,9 @@ class GroupControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testPostGroupAction()
     {
-        $group = $this->getMock('FOS\UserBundle\Model\GroupInterface');
+        $group = $this->createMock('FOS\UserBundle\Model\GroupInterface');
 
-        $groupManager = $this->getMock('Sonata\UserBundle\Model\GroupManagerInterface');
+        $groupManager = $this->createMock('Sonata\UserBundle\Model\GroupManagerInterface');
         $groupManager->expects($this->once())->method('getClass')->will($this->returnValue('FOS\UserBundle\Entity\Group'));
         $groupManager->expects($this->once())->method('updateGroup')->will($this->returnValue($group));
 
@@ -62,7 +63,7 @@ class GroupControllerTest extends \PHPUnit_Framework_TestCase
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($group));
 
-        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createGroupController(null, $groupManager, $formFactory)->postGroupAction(new Request());
@@ -72,14 +73,14 @@ class GroupControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testPostGroupInvalidAction()
     {
-        $groupManager = $this->getMock('Sonata\UserBundle\Model\GroupManagerInterface');
+        $groupManager = $this->createMock('Sonata\UserBundle\Model\GroupManagerInterface');
         $groupManager->expects($this->once())->method('getClass')->will($this->returnValue('FOS\UserBundle\Entity\Group'));
 
         $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
         $form->expects($this->once())->method('submit');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
 
-        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createGroupController(null, $groupManager, $formFactory)->postGroupAction(new Request());
@@ -89,9 +90,9 @@ class GroupControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testPutGroupAction()
     {
-        $group = $this->getMock('FOS\UserBundle\Model\GroupInterface');
+        $group = $this->createMock('FOS\UserBundle\Model\GroupInterface');
 
-        $groupManager = $this->getMock('Sonata\UserBundle\Model\GroupManagerInterface');
+        $groupManager = $this->createMock('Sonata\UserBundle\Model\GroupManagerInterface');
         $groupManager->expects($this->once())->method('getClass')->will($this->returnValue('FOS\UserBundle\Entity\Group'));
         $groupManager->expects($this->once())->method('findGroupBy')->will($this->returnValue($group));
         $groupManager->expects($this->once())->method('updateGroup')->will($this->returnValue($group));
@@ -101,7 +102,7 @@ class GroupControllerTest extends \PHPUnit_Framework_TestCase
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($group));
 
-        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createGroupController($group, $groupManager, $formFactory)->putGroupAction(1, new Request());
@@ -111,9 +112,9 @@ class GroupControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testPutGroupInvalidAction()
     {
-        $group = $this->getMock('FOS\UserBundle\Model\GroupInterface');
+        $group = $this->createMock('FOS\UserBundle\Model\GroupInterface');
 
-        $groupManager = $this->getMock('Sonata\UserBundle\Model\GroupManagerInterface');
+        $groupManager = $this->createMock('Sonata\UserBundle\Model\GroupManagerInterface');
         $groupManager->expects($this->once())->method('getClass')->will($this->returnValue('FOS\UserBundle\Entity\Group'));
         $groupManager->expects($this->once())->method('findGroupBy')->will($this->returnValue($group));
 
@@ -121,7 +122,7 @@ class GroupControllerTest extends \PHPUnit_Framework_TestCase
         $form->expects($this->once())->method('submit');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
 
-        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createGroupController($group, $groupManager, $formFactory)->putGroupAction(1, new Request());
@@ -131,9 +132,9 @@ class GroupControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testDeleteGroupAction()
     {
-        $group = $this->getMock('FOS\UserBundle\Model\GroupInterface');
+        $group = $this->createMock('FOS\UserBundle\Model\GroupInterface');
 
-        $groupManager = $this->getMock('Sonata\UserBundle\Model\GroupManagerInterface');
+        $groupManager = $this->createMock('Sonata\UserBundle\Model\GroupManagerInterface');
         $groupManager->expects($this->once())->method('findGroupBy')->will($this->returnValue($group));
         $groupManager->expects($this->once())->method('deleteGroup')->will($this->returnValue($group));
 
@@ -144,9 +145,9 @@ class GroupControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testDeleteGroupInvalidAction()
     {
-        $this->setExpectedException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
+        $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
 
-        $groupManager = $this->getMock('Sonata\UserBundle\Model\GroupManagerInterface');
+        $groupManager = $this->createMock('Sonata\UserBundle\Model\GroupManagerInterface');
         $groupManager->expects($this->once())->method('findGroupBy')->will($this->returnValue(null));
         $groupManager->expects($this->never())->method('deleteGroup');
 
@@ -163,13 +164,13 @@ class GroupControllerTest extends \PHPUnit_Framework_TestCase
     public function createGroupController($group = null, $groupManager = null, $formFactory = null)
     {
         if (null === $groupManager) {
-            $groupManager = $this->getMock('Sonata\UserBundle\Model\GroupManagerInterface');
+            $groupManager = $this->createMock('Sonata\UserBundle\Model\GroupManagerInterface');
         }
         if (null !== $group) {
             $groupManager->expects($this->once())->method('findGroupBy')->will($this->returnValue($group));
         }
         if (null === $formFactory) {
-            $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+            $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
         }
 
         return new GroupController($groupManager, $formFactory);

--- a/Tests/Controller/Api/UserControllerTest.php
+++ b/Tests/Controller/Api/UserControllerTest.php
@@ -9,20 +9,21 @@
  * file that was distributed with this source code.
  */
 
-namespace Sonata\Test\UserBundle\Controller\Api;
+namespace Sonata\UserBundle\Tests\Controller\Api;
 
 use Sonata\UserBundle\Controller\Api\UserController;
+use Sonata\UserBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
  */
-class UserControllerTest extends \PHPUnit_Framework_TestCase
+class UserControllerTest extends PHPUnit_Framework_TestCase
 {
     public function testGetUsersAction()
     {
-        $user = $this->getMock('Sonata\UserBundle\Model\UserInterface');
-        $userManager = $this->getMock('Sonata\UserBundle\Model\UserManagerInterface');
+        $user = $this->createMock('Sonata\UserBundle\Model\UserInterface');
+        $userManager = $this->createMock('Sonata\UserBundle\Model\UserManagerInterface');
         $userManager->expects($this->once())->method('getPager')->will($this->returnValue(array()));
 
         $paramFetcher = $this->getMockBuilder('FOS\RestBundle\Request\ParamFetcher')
@@ -36,7 +37,7 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testGetUserAction()
     {
-        $user = $this->getMock('Sonata\UserBundle\Model\UserInterface');
+        $user = $this->createMock('Sonata\UserBundle\Model\UserInterface');
         $this->assertEquals($user, $this->createUserController($user)->getUserAction(1));
     }
 
@@ -51,9 +52,9 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testPostUserAction()
     {
-        $user = $this->getMock('FOS\UserBundle\Model\UserInterface');
+        $user = $this->createMock('FOS\UserBundle\Model\UserInterface');
 
-        $userManager = $this->getMock('Sonata\UserBundle\Model\UserManagerInterface');
+        $userManager = $this->createMock('Sonata\UserBundle\Model\UserManagerInterface');
         $userManager->expects($this->once())->method('updateUser')->will($this->returnValue($user));
 
         $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
@@ -61,7 +62,7 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($user));
 
-        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createUserController(null, $userManager, null, $formFactory)->postUserAction(new Request());
@@ -71,13 +72,13 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testPostUserInvalidAction()
     {
-        $userManager = $this->getMock('Sonata\UserBundle\Model\UserManagerInterface');
+        $userManager = $this->createMock('Sonata\UserBundle\Model\UserManagerInterface');
 
         $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
         $form->expects($this->once())->method('submit');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
 
-        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createUserController(null, $userManager, null, $formFactory)->postUserAction(new Request());
@@ -87,9 +88,9 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testPutUserAction()
     {
-        $user = $this->getMock('FOS\UserBundle\Model\UserInterface');
+        $user = $this->createMock('FOS\UserBundle\Model\UserInterface');
 
-        $userManager = $this->getMock('Sonata\UserBundle\Model\UserManagerInterface');
+        $userManager = $this->createMock('Sonata\UserBundle\Model\UserManagerInterface');
         $userManager->expects($this->once())->method('findUserBy')->will($this->returnValue($user));
         $userManager->expects($this->once())->method('updateUser')->will($this->returnValue($user));
 
@@ -98,7 +99,7 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
         $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
         $form->expects($this->once())->method('getData')->will($this->returnValue($user));
 
-        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createUserController($user, $userManager, null, $formFactory)->putUserAction(1, new Request());
@@ -108,16 +109,16 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testPutUserInvalidAction()
     {
-        $user = $this->getMock('FOS\UserBundle\Model\UserInterface');
+        $user = $this->createMock('FOS\UserBundle\Model\UserInterface');
 
-        $userManager = $this->getMock('Sonata\UserBundle\Model\UserManagerInterface');
+        $userManager = $this->createMock('Sonata\UserBundle\Model\UserManagerInterface');
         $userManager->expects($this->once())->method('findUserBy')->will($this->returnValue($user));
 
         $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
         $form->expects($this->once())->method('submit');
         $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
 
-        $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
         $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
 
         $view = $this->createUserController($user, $userManager, null, $formFactory)->putUserAction(1, new Request());
@@ -127,16 +128,16 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testPostUserGroupAction()
     {
-        $user = $this->getMock('Sonata\UserBundle\Entity\BaseUser');
+        $user = $this->createMock('Sonata\UserBundle\Entity\BaseUser');
         $user->expects($this->once())->method('hasGroup')->will($this->returnValue(false));
 
-        $group = $this->getMock('FOS\UserBundle\Model\GroupInterface');
+        $group = $this->createMock('FOS\UserBundle\Model\GroupInterface');
 
-        $userManager = $this->getMock('Sonata\UserBundle\Model\UserManagerInterface');
+        $userManager = $this->createMock('Sonata\UserBundle\Model\UserManagerInterface');
         $userManager->expects($this->once())->method('findUserBy')->will($this->returnValue($user));
         $userManager->expects($this->once())->method('updateUser')->will($this->returnValue($user));
 
-        $groupManager = $this->getMock('Sonata\UserBundle\Model\GroupManagerInterface');
+        $groupManager = $this->createMock('Sonata\UserBundle\Model\GroupManagerInterface');
         $groupManager->expects($this->once())->method('findGroupBy')->will($this->returnValue($group));
 
         $view = $this->createUserController($user, $userManager, $groupManager)->postUserGroupAction(1, 1);
@@ -146,15 +147,15 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testPostUserGroupInvalidAction()
     {
-        $user = $this->getMock('Sonata\UserBundle\Entity\BaseUser');
+        $user = $this->createMock('Sonata\UserBundle\Entity\BaseUser');
         $user->expects($this->once())->method('hasGroup')->will($this->returnValue(true));
 
-        $group = $this->getMock('FOS\UserBundle\Model\GroupInterface');
+        $group = $this->createMock('FOS\UserBundle\Model\GroupInterface');
 
-        $userManager = $this->getMock('Sonata\UserBundle\Model\UserManagerInterface');
+        $userManager = $this->createMock('Sonata\UserBundle\Model\UserManagerInterface');
         $userManager->expects($this->once())->method('findUserBy')->will($this->returnValue($user));
 
-        $groupManager = $this->getMock('Sonata\UserBundle\Model\GroupManagerInterface');
+        $groupManager = $this->createMock('Sonata\UserBundle\Model\GroupManagerInterface');
         $groupManager->expects($this->once())->method('findGroupBy')->will($this->returnValue($group));
 
         $view = $this->createUserController($user, $userManager, $groupManager)->postUserGroupAction(1, 1);
@@ -169,16 +170,16 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testDeleteUserGroupAction()
     {
-        $user = $this->getMock('Sonata\UserBundle\Entity\BaseUser');
+        $user = $this->createMock('Sonata\UserBundle\Entity\BaseUser');
         $user->expects($this->once())->method('hasGroup')->will($this->returnValue(true));
 
-        $group = $this->getMock('FOS\UserBundle\Model\GroupInterface');
+        $group = $this->createMock('FOS\UserBundle\Model\GroupInterface');
 
-        $userManager = $this->getMock('Sonata\UserBundle\Model\UserManagerInterface');
+        $userManager = $this->createMock('Sonata\UserBundle\Model\UserManagerInterface');
         $userManager->expects($this->once())->method('findUserBy')->will($this->returnValue($user));
         $userManager->expects($this->once())->method('updateUser')->will($this->returnValue($user));
 
-        $groupManager = $this->getMock('Sonata\UserBundle\Model\GroupManagerInterface');
+        $groupManager = $this->createMock('Sonata\UserBundle\Model\GroupManagerInterface');
         $groupManager->expects($this->once())->method('findGroupBy')->will($this->returnValue($group));
 
         $view = $this->createUserController($user, $userManager, $groupManager)->deleteUserGroupAction(1, 1);
@@ -188,15 +189,15 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testDeleteUserGroupInvalidAction()
     {
-        $user = $this->getMock('Sonata\UserBundle\Entity\BaseUser');
+        $user = $this->createMock('Sonata\UserBundle\Entity\BaseUser');
         $user->expects($this->once())->method('hasGroup')->will($this->returnValue(false));
 
-        $group = $this->getMock('FOS\UserBundle\Model\GroupInterface');
+        $group = $this->createMock('FOS\UserBundle\Model\GroupInterface');
 
-        $userManager = $this->getMock('Sonata\UserBundle\Model\UserManagerInterface');
+        $userManager = $this->createMock('Sonata\UserBundle\Model\UserManagerInterface');
         $userManager->expects($this->once())->method('findUserBy')->will($this->returnValue($user));
 
-        $groupManager = $this->getMock('Sonata\UserBundle\Model\GroupManagerInterface');
+        $groupManager = $this->createMock('Sonata\UserBundle\Model\GroupManagerInterface');
         $groupManager->expects($this->once())->method('findGroupBy')->will($this->returnValue($group));
 
         $view = $this->createUserController($user, $userManager, $groupManager)->deleteUserGroupAction(1, 1);
@@ -211,9 +212,9 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
 
     public function testDeleteUserAction()
     {
-        $user = $this->getMock('FOS\UserBundle\Model\UserInterface');
+        $user = $this->createMock('FOS\UserBundle\Model\UserInterface');
 
-        $userManager = $this->getMock('Sonata\UserBundle\Model\UserManagerInterface');
+        $userManager = $this->createMock('Sonata\UserBundle\Model\UserManagerInterface');
         $userManager->expects($this->once())->method('findUserBy')->will($this->returnValue($user));
         $userManager->expects($this->once())->method('deleteUser')->will($this->returnValue($user));
 
@@ -226,7 +227,7 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
 
-        $userManager = $this->getMock('Sonata\UserBundle\Model\UserManagerInterface');
+        $userManager = $this->createMock('Sonata\UserBundle\Model\UserManagerInterface');
         $userManager->expects($this->once())->method('findUserBy')->will($this->returnValue(null));
         $userManager->expects($this->never())->method('deleteUser');
 
@@ -244,16 +245,16 @@ class UserControllerTest extends \PHPUnit_Framework_TestCase
     public function createUserController($user = null, $userManager = null, $groupManager = null, $formFactory = null)
     {
         if (null === $userManager) {
-            $userManager = $this->getMock('Sonata\UserBundle\Model\UserManagerInterface');
+            $userManager = $this->createMock('Sonata\UserBundle\Model\UserManagerInterface');
         }
         if (null === $groupManager) {
-            $groupManager = $this->getMock('Sonata\UserBundle\Model\GroupManagerInterface');
+            $groupManager = $this->createMock('Sonata\UserBundle\Model\GroupManagerInterface');
         }
         if (null !== $user) {
             $userManager->expects($this->once())->method('findUserBy')->will($this->returnValue($user));
         }
         if (null === $formFactory) {
-            $formFactory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+            $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
         }
 
         return new UserController($userManager, $groupManager, $formFactory);

--- a/Tests/Document/BaseUserTest.php
+++ b/Tests/Document/BaseUserTest.php
@@ -12,8 +12,9 @@
 namespace Sonata\UserBundle\Tests\Document;
 
 use Sonata\UserBundle\Document\BaseUser;
+use Sonata\UserBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
-class BaseUserTest extends \PHPUnit_Framework_TestCase
+class BaseUserTest extends PHPUnit_Framework_TestCase
 {
     public function testDateSetters()
     {
@@ -76,9 +77,9 @@ class BaseUserTest extends \PHPUnit_Framework_TestCase
     {
         // Given
         $user = new BaseUser();
-        $group1 = $this->getMock('FOS\UserBundle\Model\GroupInterface');
+        $group1 = $this->createMock('FOS\UserBundle\Model\GroupInterface');
         $group1->expects($this->any())->method('getName')->will($this->returnValue('Group 1'));
-        $group2 = $this->getMock('FOS\UserBundle\Model\GroupInterface');
+        $group2 = $this->createMock('FOS\UserBundle\Model\GroupInterface');
         $group2->expects($this->any())->method('getName')->will($this->returnValue('Group 2'));
 
         // When

--- a/Tests/Entity/BaseUserTest.php
+++ b/Tests/Entity/BaseUserTest.php
@@ -12,8 +12,9 @@
 namespace Sonata\UserBundle\Tests\Entity;
 
 use Sonata\UserBundle\Entity\BaseUser;
+use Sonata\UserBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
-class BaseUserTest extends \PHPUnit_Framework_TestCase
+class BaseUserTest extends PHPUnit_Framework_TestCase
 {
     public function testDateSetters()
     {
@@ -76,9 +77,9 @@ class BaseUserTest extends \PHPUnit_Framework_TestCase
     {
         // Given
         $user = new BaseUser();
-        $group1 = $this->getMock('FOS\UserBundle\Model\GroupInterface');
+        $group1 = $this->createMock('FOS\UserBundle\Model\GroupInterface');
         $group1->expects($this->any())->method('getName')->will($this->returnValue('Group 1'));
-        $group2 = $this->getMock('FOS\UserBundle\Model\GroupInterface');
+        $group2 = $this->createMock('FOS\UserBundle\Model\GroupInterface');
         $group2->expects($this->any())->method('getName')->will($this->returnValue('Group 2'));
 
         // When

--- a/Tests/Entity/UserManagerTest.php
+++ b/Tests/Entity/UserManagerTest.php
@@ -13,8 +13,9 @@ namespace Sonata\UserBundle\Tests\Entity;
 
 use Sonata\CoreBundle\Test\EntityManagerMockFactory;
 use Sonata\UserBundle\Entity\UserManager;
+use Sonata\UserBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
-class UserManagerTest extends \PHPUnit_Framework_TestCase
+class UserManagerTest extends PHPUnit_Framework_TestCase
 {
     public function testGetPager()
     {
@@ -263,8 +264,8 @@ class UserManagerTest extends \PHPUnit_Framework_TestCase
             'email',
         ));
 
-        $encoder = $this->getMock('Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface');
-        $canonicalizer = $this->getMock('FOS\UserBundle\Util\CanonicalizerInterface');
+        $encoder = $this->createMock('Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface');
+        $canonicalizer = $this->createMock('FOS\UserBundle\Util\CanonicalizerInterface');
 
         return new UserManager($encoder, $canonicalizer, $canonicalizer, $em, 'Sonata\UserBundle\Entity\BaseUser');
     }

--- a/Tests/Helpers/PHPUnit_Framework_TestCase.php
+++ b/Tests/Helpers/PHPUnit_Framework_TestCase.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Tests\Helpers;
+
+/**
+ * This is helpers class for supporting old and new PHPUnit versions.
+ *
+ * @todo NEXT_MAJOR: Remove this class when dropping support for < PHPUnit 5.4.
+ *
+ * @author Oleksandr Savchenko <savchenko.oleksandr.ua@gmail.com>
+ */
+class PHPUnit_Framework_TestCase extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function expectException($exception, $message = '', $code = null)
+    {
+        if (is_callable('parent::expectException')) {
+            parent::expectException($exception);
+
+            if ($message !== '') {
+                parent::expectExceptionMessage($message);
+            }
+
+            if ($code !== null) {
+                parent::expectExceptionCode($code);
+            }
+        }
+
+        return parent::setExpectedException($exception, $message, $code);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function createMock($originalClassName)
+    {
+        if (is_callable('parent::createMock')) {
+            return parent::createMock($originalClassName);
+        }
+
+        return parent::getMock($originalClassName);
+    }
+}

--- a/Tests/Menu/ProfileMenuBuilderTest.php
+++ b/Tests/Menu/ProfileMenuBuilderTest.php
@@ -12,23 +12,24 @@
 namespace Sonata\UserBundle\Tests\Menu;
 
 use Sonata\UserBundle\Menu\ProfileMenuBuilder;
+use Sonata\UserBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
  */
-class ProfileMenuBuilderTest extends \PHPUnit_Framework_TestCase
+class ProfileMenuBuilderTest extends PHPUnit_Framework_TestCase
 {
     public function testCreateProfileMenu()
     {
-        $menu = $this->getMock('Knp\Menu\ItemInterface');
-        $factory = $this->getMock('Knp\Menu\FactoryInterface');
+        $menu = $this->createMock('Knp\Menu\ItemInterface');
+        $factory = $this->createMock('Knp\Menu\FactoryInterface');
 
         $factory->expects($this->once())
             ->method('createItem')
             ->will($this->returnValue($menu));
 
-        $translator = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
-        $eventDispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $translator = $this->createMock('Symfony\Component\Translation\TranslatorInterface');
+        $eventDispatcher = $this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
 
         $builder = new ProfileMenuBuilder($factory, $translator, array(), $eventDispatcher);
 

--- a/Tests/Security/Authorization/Voter/UserAclVoterTest.php
+++ b/Tests/Security/Authorization/Voter/UserAclVoterTest.php
@@ -12,26 +12,27 @@
 namespace Sonata\UserBundle\Tests\Security\Authorization\Voter;
 
 use Sonata\UserBundle\Security\Authorization\Voter\UserAclVoter;
+use Sonata\UserBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
-class UserAclVoterTest extends \PHPUnit_Framework_TestCase
+class UserAclVoterTest extends PHPUnit_Framework_TestCase
 {
     public function testVoteWillAbstainWhenAUserIsLoggedInAndASuperAdmin()
     {
         // Given
-        $user = $this->getMock('FOS\UserBundle\Model\UserInterface');
+        $user = $this->createMock('FOS\UserBundle\Model\UserInterface');
         $user->expects($this->any())->method('isSuperAdmin')->will($this->returnValue(true));
 
-        $loggedInUser = $this->getMock('FOS\UserBundle\Model\UserInterface');
+        $loggedInUser = $this->createMock('FOS\UserBundle\Model\UserInterface');
         $loggedInUser->expects($this->any())->method('isSuperAdmin')->will($this->returnValue(true));
 
-        $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
+        $token = $this->createMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
         $token->expects($this->any())->method('getUser')->will($this->returnValue($loggedInUser));
 
-        $aclProvider = $this->getMock('Symfony\Component\Security\Acl\Model\AclProviderInterface');
-        $oidRetrievalStrategy = $this->getMock('Symfony\Component\Security\Acl\Model\ObjectIdentityRetrievalStrategyInterface');
-        $sidRetrievalStrategy = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityRetrievalStrategyInterface');
-        $permissionMap = $this->getMock('Symfony\Component\Security\Acl\Permission\PermissionMapInterface');
+        $aclProvider = $this->createMock('Symfony\Component\Security\Acl\Model\AclProviderInterface');
+        $oidRetrievalStrategy = $this->createMock('Symfony\Component\Security\Acl\Model\ObjectIdentityRetrievalStrategyInterface');
+        $sidRetrievalStrategy = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityRetrievalStrategyInterface');
+        $permissionMap = $this->createMock('Symfony\Component\Security\Acl\Permission\PermissionMapInterface');
 
         $voter = new UserAclVoter($aclProvider, $oidRetrievalStrategy, $sidRetrievalStrategy, $permissionMap);
 
@@ -45,19 +46,19 @@ class UserAclVoterTest extends \PHPUnit_Framework_TestCase
     public function testVoteWillDenyAccessWhenAUserIsLoggedInAndNotASuperAdmin()
     {
         // Given
-        $user = $this->getMock('FOS\UserBundle\Model\UserInterface');
+        $user = $this->createMock('FOS\UserBundle\Model\UserInterface');
         $user->expects($this->any())->method('isSuperAdmin')->will($this->returnValue(true));
 
-        $loggedInUser = $this->getMock('FOS\UserBundle\Model\UserInterface');
+        $loggedInUser = $this->createMock('FOS\UserBundle\Model\UserInterface');
         $loggedInUser->expects($this->any())->method('isSuperAdmin')->will($this->returnValue(false));
 
-        $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
+        $token = $this->createMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
         $token->expects($this->any())->method('getUser')->will($this->returnValue($loggedInUser));
 
-        $aclProvider = $this->getMock('Symfony\Component\Security\Acl\Model\AclProviderInterface');
-        $oidRetrievalStrategy = $this->getMock('Symfony\Component\Security\Acl\Model\ObjectIdentityRetrievalStrategyInterface');
-        $sidRetrievalStrategy = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityRetrievalStrategyInterface');
-        $permissionMap = $this->getMock('Symfony\Component\Security\Acl\Permission\PermissionMapInterface');
+        $aclProvider = $this->createMock('Symfony\Component\Security\Acl\Model\AclProviderInterface');
+        $oidRetrievalStrategy = $this->createMock('Symfony\Component\Security\Acl\Model\ObjectIdentityRetrievalStrategyInterface');
+        $sidRetrievalStrategy = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityRetrievalStrategyInterface');
+        $permissionMap = $this->createMock('Symfony\Component\Security\Acl\Permission\PermissionMapInterface');
 
         $voter = new UserAclVoter($aclProvider, $oidRetrievalStrategy, $sidRetrievalStrategy, $permissionMap);
 
@@ -71,18 +72,18 @@ class UserAclVoterTest extends \PHPUnit_Framework_TestCase
     public function testVoteWillAbstainWhenAUserIsNotAvailable()
     {
         // Given
-        $user = $this->getMock('FOS\UserBundle\Model\UserInterface');
+        $user = $this->createMock('FOS\UserBundle\Model\UserInterface');
         $user->expects($this->any())->method('isSuperAdmin')->will($this->returnValue(true));
 
         $loggedInUser = null;
 
-        $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
+        $token = $this->createMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
         $token->expects($this->any())->method('getUser')->will($this->returnValue($loggedInUser));
 
-        $aclProvider = $this->getMock('Symfony\Component\Security\Acl\Model\AclProviderInterface');
-        $oidRetrievalStrategy = $this->getMock('Symfony\Component\Security\Acl\Model\ObjectIdentityRetrievalStrategyInterface');
-        $sidRetrievalStrategy = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityRetrievalStrategyInterface');
-        $permissionMap = $this->getMock('Symfony\Component\Security\Acl\Permission\PermissionMapInterface');
+        $aclProvider = $this->createMock('Symfony\Component\Security\Acl\Model\AclProviderInterface');
+        $oidRetrievalStrategy = $this->createMock('Symfony\Component\Security\Acl\Model\ObjectIdentityRetrievalStrategyInterface');
+        $sidRetrievalStrategy = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityRetrievalStrategyInterface');
+        $permissionMap = $this->createMock('Symfony\Component\Security\Acl\Permission\PermissionMapInterface');
 
         $voter = new UserAclVoter($aclProvider, $oidRetrievalStrategy, $sidRetrievalStrategy, $permissionMap);
 
@@ -96,18 +97,23 @@ class UserAclVoterTest extends \PHPUnit_Framework_TestCase
     public function testVoteWillAbstainWhenAUserIsLoggedInButIsNotAFOSUser()
     {
         // Given
-        $user = $this->getMock('FOS\UserBundle\Model\UserInterface');
+        $user = $this->createMock('FOS\UserBundle\Model\UserInterface');
         $user->expects($this->any())->method('isSuperAdmin')->will($this->returnValue(true));
 
-        $loggedInUser = $this->getMock('Symfony\Component\Core\User\UserInterface');
+        // NEXT_MAJOR: Remove this when bumping SF requirements to 2.8
+        if (interface_exists('Symfony\Component\Security\Core\User\UserInterface')) {
+            $loggedInUser = $this->createMock('Symfony\Component\Security\Core\User\UserInterface');
+        } else {
+            $loggedInUser = $this->createMock('Symfony\Component\Core\User\UserInterface');
+        }
 
-        $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
+        $token = $this->createMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
         $token->expects($this->any())->method('getUser')->will($this->returnValue($loggedInUser));
 
-        $aclProvider = $this->getMock('Symfony\Component\Security\Acl\Model\AclProviderInterface');
-        $oidRetrievalStrategy = $this->getMock('Symfony\Component\Security\Acl\Model\ObjectIdentityRetrievalStrategyInterface');
-        $sidRetrievalStrategy = $this->getMock('Symfony\Component\Security\Acl\Model\SecurityIdentityRetrievalStrategyInterface');
-        $permissionMap = $this->getMock('Symfony\Component\Security\Acl\Permission\PermissionMapInterface');
+        $aclProvider = $this->createMock('Symfony\Component\Security\Acl\Model\AclProviderInterface');
+        $oidRetrievalStrategy = $this->createMock('Symfony\Component\Security\Acl\Model\ObjectIdentityRetrievalStrategyInterface');
+        $sidRetrievalStrategy = $this->createMock('Symfony\Component\Security\Acl\Model\SecurityIdentityRetrievalStrategyInterface');
+        $permissionMap = $this->createMock('Symfony\Component\Security\Acl\Permission\PermissionMapInterface');
 
         $voter = new UserAclVoter($aclProvider, $oidRetrievalStrategy, $sidRetrievalStrategy, $permissionMap);
 

--- a/Tests/Security/EditableRolesBuilderTest.php
+++ b/Tests/Security/EditableRolesBuilderTest.php
@@ -12,18 +12,19 @@
 namespace Sonata\UserBundle\Tests\Security\Authorization\Voter;
 
 use Sonata\UserBundle\Security\EditableRolesBuilder;
+use Sonata\UserBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
 
-class EditableRolesBuilderTest extends \PHPUnit_Framework_TestCase
+class EditableRolesBuilderTest extends PHPUnit_Framework_TestCase
 {
     public function getTokenStorageMock()
     {
         // Set the SecurityContext for Symfony <2.6
         // NEXT_MAJOR: Remove conditional return when bumping requirements to SF 2.6+
         if (interface_exists('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')) {
-            return $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
+            return $this->createMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
         }
 
-        return $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
+        return $this->createMock('Symfony\Component\Security\Core\SecurityContextInterface');
     }
 
     public function getAuthorizationCheckerMock()
@@ -31,10 +32,10 @@ class EditableRolesBuilderTest extends \PHPUnit_Framework_TestCase
         // Set the SecurityContext for Symfony <2.6
         // NEXT_MAJOR: Remove conditional return when bumping requirements to SF 2.6+
         if (interface_exists('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface')) {
-            return $this->getMock('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
+            return $this->createMock('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
         }
 
-        return $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
+        return $this->createMock('Symfony\Component\Security\Core\SecurityContextInterface');
     }
 
     /**
@@ -42,7 +43,7 @@ class EditableRolesBuilderTest extends \PHPUnit_Framework_TestCase
      */
     public function testRolesFromHierarchy()
     {
-        $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
+        $token = $this->createMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
 
         $tokenStorage = $this->getTokenStorageMock();
         $tokenStorage->expects($this->any())->method('getToken')->will($this->returnValue($token));
@@ -91,15 +92,15 @@ class EditableRolesBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testRolesFromAdminWithMasterAdmin()
     {
-        $securityHandler = $this->getMock('Sonata\AdminBundle\Security\Handler\SecurityHandlerInterface');
+        $securityHandler = $this->createMock('Sonata\AdminBundle\Security\Handler\SecurityHandlerInterface');
         $securityHandler->expects($this->once())->method('getBaseRole')->will($this->returnValue('ROLE_FOO_%s'));
 
-        $admin = $this->getMock('Sonata\AdminBundle\Admin\AdminInterface');
+        $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
         $admin->expects($this->once())->method('isGranted')->will($this->returnValue(true));
         $admin->expects($this->once())->method('getSecurityInformation')->will($this->returnValue(array('GUEST' => array(0 => 'VIEW', 1 => 'LIST'), 'STAFF' => array(0 => 'EDIT', 1 => 'LIST', 2 => 'CREATE'), 'EDITOR' => array(0 => 'OPERATOR', 1 => 'EXPORT'), 'ADMIN' => array(0 => 'MASTER'))));
         $admin->expects($this->once())->method('getSecurityHandler')->will($this->returnValue($securityHandler));
 
-        $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
+        $token = $this->createMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
 
         $tokenStorage = $this->getTokenStorageMock();
         $tokenStorage->expects($this->any())->method('getToken')->will($this->returnValue($token));


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Removed deprecations when executing tests on PHPUnit >5.4
```

## Subject

<!-- Describe your Pull Request content here -->
Replaced all calls to getMock by createMock, with a fallback to getMock