### PR TITLE
Fixed empty route after registration

### DIFF
--- a/Controller/RegistrationFOSUser1Controller.php
+++ b/Controller/RegistrationFOSUser1Controller.php
@@ -65,11 +65,12 @@ EOT
                     $this->get('session')->remove('sonata_basket_delivery_redirect');
                     $url = $this->generateUrl($route);
                 } else {
-                    $url = $this->get('session')->get(
-                        'sonata_user_redirect_url',
-                        $this->generateUrl('sonata_user_profile_show')
-                    );
+                    $url = $this->get('session')->get('sonata_user_redirect_url');
                 }
+            }
+
+            if (!$url) {
+                $url = $this->generateUrl('sonata_user_profile_show');
             }
 
             $this->setFlash('fos_user_success', 'registration.flash.user_created');

--- a/Controller/RegistrationFOSUser1Controller.php
+++ b/Controller/RegistrationFOSUser1Controller.php
@@ -13,6 +13,7 @@ namespace Sonata\UserBundle\Controller;
 
 use FOS\UserBundle\Model\UserInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
@@ -26,7 +27,7 @@ use Symfony\Component\Security\Core\Exception\AccountStatusException;
 class RegistrationFOSUser1Controller extends Controller
 {
     /**
-     * @return RedirectResponse
+     * @return RedirectResponse|Response
      */
     public function registerAction()
     {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog
```
### Fixed
 - Fixed empty route after registration
```

## Subject

The current solution doesn't check for valid routes (non-empty / non-null) after a registration. E.g. the stored `sonata_user_redirect_url` value could contain an empty value, if the referer is empty.
