### PR TITLE
Stop using request if request_stack is present

### DIFF
--- a/Controller/AdminResettingController.php
+++ b/Controller/AdminResettingController.php
@@ -46,7 +46,14 @@ class AdminResettingController extends ResettingController
      */
     public function sendEmailAction()
     {
-        $username = $this->container->get('request')->request->get('username');
+        // NEXT_MAJOR: Inject $request in the method signature instead.
+        if ($this->container->has('request_stack')) {
+            $request = $this->container->get('request_stack')->getCurrentRequest();
+        } else {
+            $request = $this->container->get('request');
+        }
+
+        $username = $request->request->get('username');
 
         /** @var $user UserInterface */
         $user = $this->container->get('fos_user.user_manager')->findUserByUsernameOrEmail($username);

--- a/Controller/AdminSecurityController.php
+++ b/Controller/AdminSecurityController.php
@@ -30,8 +30,6 @@ class AdminSecurityController extends Controller
      */
     public function loginAction(Request $request = null)
     {
-        $request = $request === null ? $request = $this->get('request') : $request;
-
         $user = $this->getUser();
 
         if ($user instanceof UserInterface) {
@@ -96,13 +94,13 @@ class AdminSecurityController extends Controller
         }
 
         return $this->render('SonataUserBundle:Admin:Security/login.html.'.$this->container->getParameter('fos_user.template.engine'), array(
-                'last_username' => $lastUsername,
-                'error' => $error,
-                'csrf_token' => $csrfToken,
-                'base_template' => $this->get('sonata.admin.pool')->getTemplate('layout'),
-                'admin_pool' => $this->get('sonata.admin.pool'),
-                'reset_route' => $resetRoute, // NEXT_MAJOR: Deprecated in 2.3, to be removed in 4.0
-            ));
+            'last_username' => $lastUsername,
+            'error' => $error,
+            'csrf_token' => $csrfToken,
+            'base_template' => $this->get('sonata.admin.pool')->getTemplate('layout'),
+            'admin_pool' => $this->get('sonata.admin.pool'),
+            'reset_route' => $resetRoute, // NEXT_MAJOR: Deprecated in 2.3, to be removed in 4.0
+        ));
     }
 
     public function checkAction()

--- a/Controller/RegistrationFOSUser1Controller.php
+++ b/Controller/RegistrationFOSUser1Controller.php
@@ -84,7 +84,14 @@ EOT
             return $response;
         }
 
-        $this->get('session')->set('sonata_user_redirect_url', $this->get('request')->headers->get('referer'));
+        // NEXT_MAJOR: Inject $request in the method signature instead.
+        if ($this->has('request_stack')) {
+            $request = $this->get('request_stack')->getCurrentRequest();
+        } else {
+            $request = $this->get('request');
+        }
+
+        $this->get('session')->set('sonata_user_redirect_url', $request->headers->get('referer'));
 
         return $this->render('FOSUserBundle:Registration:register.html.'.$this->getEngine(), array(
             'form' => $form->createView(),

--- a/Controller/SecurityFOSUser1Controller.php
+++ b/Controller/SecurityFOSUser1Controller.php
@@ -48,8 +48,12 @@ class SecurityFOSUser1Controller extends SecurityController
             and the 1.3.6 version of FOSUserBundle
         */
 
-        /** @var $request \Symfony\Component\HttpFoundation\Request */
-        $request = $this->container->get('request');
+        // NEXT_MAJOR: Inject $request in the method signature instead.
+        if ($this->container->has('request_stack')) {
+            $request = $this->container->get('request_stack')->getCurrentRequest();
+        } else {
+            $request = $this->container->get('request');
+        }
         /** @var $session \Symfony\Component\HttpFoundation\Session\Session */
         $session = $request->getSession();
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Avoid deprecation message by using request_stack when it is present
```

## Subject

<!-- Describe your Pull Request content here -->
To increase compatibility with SF 3, I replaced all `get('request')` by `request_stack` with a BC layer.