### PR TITLE
Stop using deprecated csrf token generation

### DIFF
--- a/Controller/AdminSecurityController.php
+++ b/Controller/AdminSecurityController.php
@@ -68,8 +68,9 @@ class AdminSecurityController extends Controller
         // last username entered by the user
         $lastUsername = (null === $session) ? '' : $session->get($lastUsernameKey);
 
-        if ($this->has('security.csrf.token_manager')) { // sf >= 2.4
-            $csrfToken = $this->get('security.csrf.token_manager')->getToken('authenticate');
+        // NEXT_MAJOR: Symfony <2.4 BC. To be removed.
+        if ($this->has('security.csrf.token_manager')) {
+            $csrfToken = $this->get('security.csrf.token_manager')->getToken('authenticate')->getValue();
         } else {
             $csrfToken = $this->has('form.csrf_provider')
                 ? $this->get('form.csrf_provider')->generateCsrfToken('authenticate')
@@ -86,7 +87,7 @@ class AdminSecurityController extends Controller
             return $this->redirect($refererUri && $refererUri != $request->getUri() ? $refererUri : $this->generateUrl('sonata_admin_dashboard'));
         }
 
-        // TODO: Deprecated in 2.3, to be removed in 3.0
+        // NEXT_MAJOR: Deprecated in 2.3, to be removed in 4.0
         try {
             $resetRoute = $this->generateUrl('sonata_user_admin_resetting_request');
         } catch (RouteNotFoundException $e) {
@@ -100,7 +101,7 @@ class AdminSecurityController extends Controller
                 'csrf_token' => $csrfToken,
                 'base_template' => $this->get('sonata.admin.pool')->getTemplate('layout'),
                 'admin_pool' => $this->get('sonata.admin.pool'),
-                'reset_route' => $resetRoute, // TODO: Deprecated in 2.3, to be removed in 3.0
+                'reset_route' => $resetRoute, // NEXT_MAJOR: Deprecated in 2.3, to be removed in 4.0
             ));
     }
 

--- a/Controller/SecurityFOSUser1Controller.php
+++ b/Controller/SecurityFOSUser1Controller.php
@@ -75,10 +75,19 @@ class SecurityFOSUser1Controller extends SecurityController
         $lastUserNameKey = class_exists('Symfony\Component\Security\Core\Security')
             ? Security::LAST_USERNAME : SecurityContextInterface::LAST_USERNAME;
 
+        // NEXT_MAJOR: Symfony <2.4 BC. To be removed.
+        if ($this->has('security.csrf.token_manager')) {
+            $csrfToken = $this->get('security.csrf.token_manager')->getToken('authenticate')->getValue();
+        } else {
+            $csrfToken = $this->has('form.csrf_provider')
+                ? $this->get('form.csrf_provider')->generateCsrfToken('authenticate')
+                : null;
+        }
+
         return $this->renderLogin(array(
             'last_username' => (null === $session) ? '' : $session->get($lastUserNameKey),
             'error' => $error,
-            'csrf_token' => $this->container->get('form.csrf_provider')->generateCsrfToken('authenticate'),
+            'csrf_token' => $csrfToken,
         ));
     }
 }

--- a/Tests/Controller/AdminResettingControllerTest.php
+++ b/Tests/Controller/AdminResettingControllerTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Tests\Controller;
+
+use Sonata\UserBundle\Controller\AdminResettingController;
+use Sonata\UserBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
+
+class AdminResettingControllerTest extends PHPUnit_Framework_TestCase
+{
+    private $controller;
+
+    protected function setUp()
+    {
+        $this->controller = new AdminResettingController();
+    }
+
+    public function testItIsInstantiable()
+    {
+        $this->assertNotNull($this->controller);
+    }
+}

--- a/Tests/Controller/AdminSecurityControllerTest.php
+++ b/Tests/Controller/AdminSecurityControllerTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Tests\Controller;
+
+use Sonata\UserBundle\Controller\AdminSecurityController;
+use Sonata\UserBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
+
+class AdminSecurityControllerTest extends PHPUnit_Framework_TestCase
+{
+    private $controller;
+
+    protected function setUp()
+    {
+        $this->controller = new AdminSecurityController();
+    }
+
+    public function testItIsInstantiable()
+    {
+        $this->assertNotNull($this->controller);
+    }
+}

--- a/Tests/Controller/ChangePasswordFOSUser1ControllerTest.php
+++ b/Tests/Controller/ChangePasswordFOSUser1ControllerTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Tests\Controller;
+
+use Sonata\UserBundle\Controller\ChangePasswordFOSUser1Controller;
+use Sonata\UserBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
+
+class ChangePasswordFOSUser1ControllerTest extends PHPUnit_Framework_TestCase
+{
+    private $controller;
+
+    protected function setUp()
+    {
+        $this->controller = new ChangePasswordFOSUser1Controller();
+    }
+
+    public function testItIsInstantiable()
+    {
+        $this->assertNotNull($this->controller);
+    }
+}

--- a/Tests/Controller/ProfileFOSUser1ControllerTest.php
+++ b/Tests/Controller/ProfileFOSUser1ControllerTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Tests\Controller;
+
+use Sonata\UserBundle\Controller\ProfileFOSUser1Controller;
+use Sonata\UserBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
+
+class ProfileFOSUser1ControllerTest extends PHPUnit_Framework_TestCase
+{
+    private $controller;
+
+    protected function setUp()
+    {
+        $this->controller = new ProfileFOSUser1Controller();
+    }
+
+    public function testItIsInstantiable()
+    {
+        $this->assertNotNull($this->controller);
+    }
+}

--- a/Tests/Controller/RegistrationFOSUser1ControllerTest.php
+++ b/Tests/Controller/RegistrationFOSUser1ControllerTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Tests\Controller;
+
+use Sonata\UserBundle\Controller\RegistrationFOSUser1Controller;
+use Sonata\UserBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
+
+class RegistrationFOSUser1ControllerTest extends PHPUnit_Framework_TestCase
+{
+    private $controller;
+
+    protected function setUp()
+    {
+        $this->controller = new RegistrationFOSUser1Controller();
+    }
+
+    public function testItIsInstantiable()
+    {
+        $this->assertNotNull($this->controller);
+    }
+}

--- a/Tests/Controller/ResettingFOSUser1ControllerTest.php
+++ b/Tests/Controller/ResettingFOSUser1ControllerTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Tests\Controller;
+
+use Sonata\UserBundle\Controller\ResettingFOSUser1Controller;
+use Sonata\UserBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
+
+class ResettingFOSUser1ControllerTest extends PHPUnit_Framework_TestCase
+{
+    private $controller;
+
+    protected function setUp()
+    {
+        $this->controller = new ResettingFOSUser1Controller();
+    }
+
+    public function testItIsInstantiable()
+    {
+        $this->assertNotNull($this->controller);
+    }
+}

--- a/Tests/Controller/SecurityFOSUser1ControllerTest.php
+++ b/Tests/Controller/SecurityFOSUser1ControllerTest.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Tests\Controller;
+
+use Sonata\UserBundle\Controller\SecurityFOSUser1Controller;
+use Sonata\UserBundle\Tests\Helpers\PHPUnit_Framework_TestCase;
+
+class SecurityFOSUser1ControllerTest extends PHPUnit_Framework_TestCase
+{
+    private $controller;
+
+    protected function setUp()
+    {
+        $this->controller = new SecurityFOSUser1Controller();
+    }
+
+    public function testItIsInstantiable()
+    {
+        $this->assertNotNull($this->controller);
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Avoid deprecation message by changing csrf token generation when possible
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [x] Update the tests

## Subject

<!-- Describe your Pull Request content here -->
To increase SF 3 compatibility, I changed the way we generate CSRF tokens with a BC layer.

Also I added some missing test classes, to start increasing code coverage, which is really low at the moment.