### PR TITLE
Fixing wrong factory definition

### DIFF
--- a/DependencyInjection/SonataUserExtension.php
+++ b/DependencyInjection/SonataUserExtension.php
@@ -88,12 +88,12 @@ class SonataUserExtension extends Extension
         $profileFormDefinition = $container->getDefinition('sonata.user.profile.form');
         $registrationFormDefinition = $container->getDefinition('sonata.user.registration.form');
         if (method_exists($profileFormDefinition, 'setFactory')) {
-            $profileFormDefinition->setFactory(array('form.factory', 'createNamed'));
-            $registrationFormDefinition->setFactory(array('form.factory', 'createNamed'));
+            $profileFormDefinition->setFactory(array(new Reference('form.factory'), 'createNamed'));
+            $registrationFormDefinition->setFactory(array(new Reference('form.factory'), 'createNamed'));
         } else {
-            $profileFormDefinition->setFactoryClass('form.factory');
+            $profileFormDefinition->setFactoryClass(new Reference('form.factory'));
             $profileFormDefinition->setFactoryMethod('createNamed');
-            $registrationFormDefinition->setFactoryClass('form.factory');
+            $registrationFormDefinition->setFactoryClass(new Reference('form.factory'));
             $registrationFormDefinition->setFactoryMethod('createNamed');
         }
 

--- a/Resources/config/form.xml
+++ b/Resources/config/form.xml
@@ -4,7 +4,7 @@
         <!-- profile form -->
         <service id="sonata.user.profile.form" class="Symfony\Component\Form\Form">
             <!-- NEXT_MAJOR: Uncomment Following line
-            <factory class="form.factory" method="createNamed"/>
+            <factory class="Symfony\Component\Form\FormFactory" method="createNamed"/>
             -->
             <argument>%sonata.user.profile.form.name%</argument>
             <argument>%sonata.user.profile.form.type%</argument>
@@ -31,7 +31,7 @@
         </service>
         <service id="sonata.user.registration.form" class="Symfony\Component\Form\Form">
             <!-- NEXT_MAJOR: Uncomment Following line
-            <factory class="form.factory" method="createNamed"/>
+            <factory class="Symfony\Component\Form\FormFactory" method="createNamed"/>
             -->
             <argument>%sonata.user.registration.form.name%</argument>
             <argument>%sonata.user.registration.form.type%</argument>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Subject

<!-- Describe your Pull Request content here -->
I did a PR earlier which removed some deprecations (#839). Without this change, I get the following error on cache clear: invalid class name ('form.factory').

Setting factory as a Reference fixes this.
