### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Check out the documentation on the [official website](https://sonata-project.org
 
 For general support and questions, please use [StackOverflow](http://stackoverflow.com/questions/tagged/sonata).
 
-If you think you found a bug or you have a feature idea to propose, feel free to open a issue
+If you think you found a bug or you have a feature idea to propose, feel free to open an issue
 **after looking** at the [contributing guide](CONTRIBUTING.md).
 
 ## License

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Check out the documentation on the [official website](https://sonata-project.org
 
 For general support and questions, please use [StackOverflow](http://stackoverflow.com/questions/tagged/sonata).
 
-If you think you find a bug or you have a feature idea to propose, feel free to open a issue
+If you think you found a bug or you have a feature idea to propose, feel free to open a issue
 **after looking** at the [contributing guide](CONTRIBUTING.md).
 
 ## License


### PR DESCRIPTION
"find" -> "found"

I am targetting this branch, because it's a simple typo, which is completely backwards compatible.

## Subject

Typo fix.
