### PR TITLE
Fix container calls when not extending from Controller

### DIFF
--- a/Controller/SecurityFOSUser1Controller.php
+++ b/Controller/SecurityFOSUser1Controller.php
@@ -80,12 +80,10 @@ class SecurityFOSUser1Controller extends SecurityController
             ? Security::LAST_USERNAME : SecurityContextInterface::LAST_USERNAME;
 
         // NEXT_MAJOR: Symfony <2.4 BC. To be removed.
-        if ($this->has('security.csrf.token_manager')) {
-            $csrfToken = $this->get('security.csrf.token_manager')->getToken('authenticate')->getValue();
+        if ($this->container->has('security.csrf.token_manager')) {
+            $csrfToken = $this->container->get('security.csrf.token_manager')->getToken('authenticate')->getValue();
         } else {
-            $csrfToken = $this->has('form.csrf_provider')
-                ? $this->get('form.csrf_provider')->generateCsrfToken('authenticate')
-                : null;
+            $csrfToken = $this->container->get('form.csrf_provider')->generateCsrfToken('authenticate');
         }
 
         return $this->renderLogin(array(


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it is fixing a bug.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes https://github.com/sonata-project/SonataUserBundle/pull/850

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fix container calls when not extending from Controller
```

## Subject

<!-- Describe your Pull Request content here -->
This change was wrong: https://github.com/sonata-project/SonataUserBundle/pull/845/files#diff-b773cf909994196ea448ba8b717c1c55R72

We are not extending from Controller but from ContainerAware (FOSUser SecurityController extends from it) so we are not able to use `has` and `get` functions directly, we need to user `container` property.