### PR TITLE
Fix non-use of container for has/get services.

### DIFF
--- a/Controller/SecurityFOSUser1Controller.php
+++ b/Controller/SecurityFOSUser1Controller.php
@@ -80,11 +80,11 @@ class SecurityFOSUser1Controller extends SecurityController
             ? Security::LAST_USERNAME : SecurityContextInterface::LAST_USERNAME;
 
         // NEXT_MAJOR: Symfony <2.4 BC. To be removed.
-        if ($this->has('security.csrf.token_manager')) {
-            $csrfToken = $this->get('security.csrf.token_manager')->getToken('authenticate')->getValue();
+        if ($this->container->has('security.csrf.token_manager')) {
+            $csrfToken = $this->container->get('security.csrf.token_manager')->getToken('authenticate')->getValue();
         } else {
-            $csrfToken = $this->has('form.csrf_provider')
-                ? $this->get('form.csrf_provider')->generateCsrfToken('authenticate')
+            $csrfToken = $this->container->has('form.csrf_provider')
+                ? $this->container->get('form.csrf_provider')->generateCsrfToken('authenticate')
                 : null;
         }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because I'm adding a patch and is backward compatible. Not a major change.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fix non-use of container for has/get services.
```

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

## Subject

In commit 728211902d19834554bed108f5c4a8ae3f70e337 an error was introduced in file *Controller/SecurityFOSUser1Controller.php* using `$this->has` and `$this->get` instead of `$this->container->has` and `$this->container->get`. This PR fixes that.

<!-- Describe your Pull Request content here -->