### PR TITLE
Move sonata routes above fos

### DIFF
--- a/Resources/config/routing/sonata_change_password_1.xml
+++ b/Resources/config/routing/sonata_change_password_1.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <routes xmlns="http://symfony.com/schema/routing" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
-    <route id="fos_user_change_password" path="/change-password" methods="GET POST">
+    <route id="sonata_user_change_password" path="/change-password" methods="GET POST">
         <default key="_controller">SonataUserBundle:ChangePasswordFOSUser1:changePassword</default>
     </route>
-    <route id="sonata_user_change_password" path="/change-password" methods="GET POST">
+    <route id="fos_user_change_password" path="/change-password" methods="GET POST">
         <default key="_controller">SonataUserBundle:ChangePasswordFOSUser1:changePassword</default>
     </route>
 </routes>

--- a/Resources/config/routing/sonata_profile_1.xml
+++ b/Resources/config/routing/sonata_profile_1.xml
@@ -1,14 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <routes xmlns="http://symfony.com/schema/routing" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
-    <route id="fos_user_profile_show" path="/" methods="GET">
-        <default key="_controller">SonataUserBundle:ProfileFOSUser1:show</default>
-    </route>
-    <route id="fos_user_profile_edit_authentication" path="/edit-authentication">
-        <default key="_controller">SonataUserBundle:ProfileFOSUser1:editAuthentication</default>
-    </route>
-    <route id="fos_user_profile_edit" path="/edit-profile">
-        <default key="_controller">SonataUserBundle:ProfileFOSUser1:editProfile</default>
-    </route>
     <route id="sonata_user_profile_show" path="/" methods="GET">
         <default key="_controller">SonataUserBundle:ProfileFOSUser1:show</default>
     </route>
@@ -16,6 +7,15 @@
         <default key="_controller">SonataUserBundle:ProfileFOSUser1:editAuthentication</default>
     </route>
     <route id="sonata_user_profile_edit" path="/edit-profile">
+        <default key="_controller">SonataUserBundle:ProfileFOSUser1:editProfile</default>
+    </route>
+    <route id="fos_user_profile_show" path="/" methods="GET">
+        <default key="_controller">SonataUserBundle:ProfileFOSUser1:show</default>
+    </route>
+    <route id="fos_user_profile_edit_authentication" path="/edit-authentication">
+        <default key="_controller">SonataUserBundle:ProfileFOSUser1:editAuthentication</default>
+    </route>
+    <route id="fos_user_profile_edit" path="/edit-profile">
         <default key="_controller">SonataUserBundle:ProfileFOSUser1:editProfile</default>
     </route>
 </routes>

--- a/Resources/config/routing/sonata_registration_1.xml
+++ b/Resources/config/routing/sonata_registration_1.xml
@@ -1,17 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <routes xmlns="http://symfony.com/schema/routing" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
-    <route id="fos_user_registration_register" path="/">
-        <default key="_controller">SonataUserBundle:RegistrationFOSUser1:register</default>
-    </route>
-    <route id="fos_user_registration_check_email" path="/check-email" methods="GET">
-        <default key="_controller">SonataUserBundle:RegistrationFOSUser1:checkEmail</default>
-    </route>
-    <route id="fos_user_registration_confirm" path="/confirm/{token}" methods="GET">
-        <default key="_controller">SonataUserBundle:RegistrationFOSUser1:confirm</default>
-    </route>
-    <route id="fos_user_registration_confirmed" path="/confirmed" methods="GET">
-        <default key="_controller">SonataUserBundle:RegistrationFOSUser1:confirmed</default>
-    </route>
     <route id="sonata_user_registration_register" path="/">
         <default key="_controller">SonataUserBundle:RegistrationFOSUser1:register</default>
     </route>
@@ -22,6 +10,18 @@
         <default key="_controller">SonataUserBundle:RegistrationFOSUser1:confirm</default>
     </route>
     <route id="sonata_user_registration_confirmed" path="/confirmed" methods="GET">
+        <default key="_controller">SonataUserBundle:RegistrationFOSUser1:confirmed</default>
+    </route>
+    <route id="fos_user_registration_register" path="/">
+        <default key="_controller">SonataUserBundle:RegistrationFOSUser1:register</default>
+    </route>
+    <route id="fos_user_registration_check_email" path="/check-email" methods="GET">
+        <default key="_controller">SonataUserBundle:RegistrationFOSUser1:checkEmail</default>
+    </route>
+    <route id="fos_user_registration_confirm" path="/confirm/{token}" methods="GET">
+        <default key="_controller">SonataUserBundle:RegistrationFOSUser1:confirm</default>
+    </route>
+    <route id="fos_user_registration_confirmed" path="/confirmed" methods="GET">
         <default key="_controller">SonataUserBundle:RegistrationFOSUser1:confirmed</default>
     </route>
 </routes>

--- a/Resources/config/routing/sonata_resetting_1.xml
+++ b/Resources/config/routing/sonata_resetting_1.xml
@@ -1,17 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <routes xmlns="http://symfony.com/schema/routing" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
-    <route id="fos_user_resetting_request" path="/request" methods="GET">
-        <default key="_controller">SonataUserBundle:ResettingFOSUser1:request</default>
-    </route>
-    <route id="fos_user_resetting_send_email" path="/send-email" methods="POST">
-        <default key="_controller">SonataUserBundle:ResettingFOSUser1:sendEmail</default>
-    </route>
-    <route id="fos_user_resetting_check_email" path="/check-email" methods="GET">
-        <default key="_controller">SonataUserBundle:ResettingFOSUser1:checkEmail</default>
-    </route>
-    <route id="fos_user_resetting_reset" path="/reset/{token}" methods="GET POST">
-        <default key="_controller">SonataUserBundle:ResettingFOSUser1:reset</default>
-    </route>
     <route id="sonata_user_resetting_request" path="/request" methods="GET">
         <default key="_controller">SonataUserBundle:ResettingFOSUser1:request</default>
     </route>
@@ -22,6 +10,18 @@
         <default key="_controller">SonataUserBundle:ResettingFOSUser1:checkEmail</default>
     </route>
     <route id="sonata_user_resetting_reset" path="/reset/{token}" methods="GET POST">
+        <default key="_controller">SonataUserBundle:ResettingFOSUser1:reset</default>
+    </route>
+    <route id="fos_user_resetting_request" path="/request" methods="GET">
+        <default key="_controller">SonataUserBundle:ResettingFOSUser1:request</default>
+    </route>
+    <route id="fos_user_resetting_send_email" path="/send-email" methods="POST">
+        <default key="_controller">SonataUserBundle:ResettingFOSUser1:sendEmail</default>
+    </route>
+    <route id="fos_user_resetting_check_email" path="/check-email" methods="GET">
+        <default key="_controller">SonataUserBundle:ResettingFOSUser1:checkEmail</default>
+    </route>
+    <route id="fos_user_resetting_reset" path="/reset/{token}" methods="GET POST">
         <default key="_controller">SonataUserBundle:ResettingFOSUser1:reset</default>
     </route>
 </routes>

--- a/Resources/config/routing/sonata_security_1.xml
+++ b/Resources/config/routing/sonata_security_1.xml
@@ -1,14 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <routes xmlns="http://symfony.com/schema/routing" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
-    <route id="fos_user_security_login" path="/login">
-        <default key="_controller">SonataUserBundle:SecurityFOSUser1:login</default>
-    </route>
-    <route id="fos_user_security_check" path="/login_check" methods="POST">
-        <default key="_controller">SonataUserBundle:SecurityFOSUser1:check</default>
-    </route>
-    <route id="fos_user_security_logout" path="/logout">
-        <default key="_controller">SonataUserBundle:SecurityFOSUser1:logout</default>
-    </route>
     <route id="sonata_user_security_login" path="/login">
         <default key="_controller">SonataUserBundle:SecurityFOSUser1:login</default>
     </route>
@@ -16,6 +7,15 @@
         <default key="_controller">SonataUserBundle:SecurityFOSUser1:check</default>
     </route>
     <route id="sonata_user_security_logout" path="/logout">
+        <default key="_controller">SonataUserBundle:SecurityFOSUser1:logout</default>
+    </route>
+    <route id="fos_user_security_login" path="/login">
+        <default key="_controller">SonataUserBundle:SecurityFOSUser1:login</default>
+    </route>
+    <route id="fos_user_security_check" path="/login_check" methods="POST">
+        <default key="_controller">SonataUserBundle:SecurityFOSUser1:check</default>
+    </route>
+    <route id="fos_user_security_logout" path="/logout">
         <default key="_controller">SonataUserBundle:SecurityFOSUser1:logout</default>
     </route>
 </routes>


### PR DESCRIPTION
I am targeting this branch, because its BC.

## Changelog

```markdown

### Changed
- Moved sonata routes above fos
```

## Subject

When fos routes are above sonata's, if we navigate for example to `sonata_user_profile_show`, it will be detected as `fos_user_profile_show`. It influences on KnpMenu. It does not detect `sonata_user_profile_show` as current url and does not highlight it.

#### Before
<img width="326" alt="2017-03-21 22 14 03" src="https://cloud.githubusercontent.com/assets/1560126/24146944/c4963c2a-0e83-11e7-9e59-7b22820c91b4.png">

#### After
<img width="346" alt="2017-03-21 22 14 17" src="https://cloud.githubusercontent.com/assets/1560126/24146945/c878f472-0e83-11e7-8b0f-308fe7718225.png">
