### PR TITLE
Removed block bundle deprecations

### DIFF
--- a/Block/AccountBlockService.php
+++ b/Block/AccountBlockService.php
@@ -11,8 +11,8 @@
 
 namespace Sonata\UserBundle\Block;
 
-use Sonata\BlockBundle\Block\BaseBlockService;
 use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Block\Service\AbstractBlockService;
 use Sonata\UserBundle\Model\UserInterface;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\HttpFoundation\Response;
@@ -25,7 +25,7 @@ use Symfony\Component\Security\Core\SecurityContextInterface;
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class AccountBlockService extends BaseBlockService
+class AccountBlockService extends AbstractBlockService
 {
     /**
      * @var TokenStorageInterface|SecurityContextInterface

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
         "jms/serializer-bundle": "^0.13 || ^1.0",
         "nelmio/api-doc-bundle": "^2.4",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
+        "sonata-project/block-bundle": "^3.2",
         "sonata-project/seo-bundle": "^2.0",
         "symfony/phpunit-bridge": "^2.8 || ^3.0"
     },
@@ -50,6 +51,7 @@
         "friendsofsymfony/rest-bundle": "<1.1",
         "jms/serializer": "<0.13 || >=2.0",
         "nelmio/api-doc-bundle": "<2.4 || >= 3.0",
+        "sonata-project/block-bundle": "<3.2",
         "sonata-project/doctrine-orm-admin-bundle": "<3.0 || >=4.0",
         "sonata-project/seo-bundle": "<2.0 || >=3.0"
     },


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataTimelineBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because this is a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
 - Removed block service deprecation
```

## Subject

Removed sonata block bundle deprecation.
