### PR TITLE
Use render function instead of render tag

### DIFF
--- a/Resources/views/Profile/edit_authentication.html.twig
+++ b/Resources/views/Profile/edit_authentication.html.twig
@@ -28,7 +28,7 @@ file that was distributed with this source code.
                 <h3 class="panel-title">{{ 'sonata_change_password_link'|trans({}, 'SonataUserBundle') }}</h3>
             </div>
             <div class="panel-body">
-                {% render url("sonata_user_change_password") %}
+                {{ render(url("sonata_user_change_password")) }}
             </div>
         </div>
     </div>

--- a/Resources/views/Profile/edit_profile.html.twig
+++ b/Resources/views/Profile/edit_profile.html.twig
@@ -31,5 +31,5 @@ file that was distributed with this source code.
         </div>
     </div>
 
-    {% render url("sonata_user_profile_edit_authentication") %}
+    {{ render(url("sonata_user_profile_edit_authentication")) }}
 {% endblock %}

--- a/Resources/views/Security/base_login.html.twig
+++ b/Resources/views/Security/base_login.html.twig
@@ -76,7 +76,7 @@ file that was distributed with this source code.
         </div>
         <div class="col-sm-6">
             {% block sonata_user_registration %}
-                {% render controller("SonataUserBundle:RegistrationFOSUser1:register") %}
+                {{ render(controller("SonataUserBundle:RegistrationFOSUser1:register")) }}
             {% endblock %}
         </div>
     </div>


### PR DESCRIPTION
I am targeting this branch, because this is BC.

Closes #862

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Compatibility with Twig 2.0 was improved
```

## Subject

<!-- Describe your Pull Request content here -->
The render tag has been deprecated for ages.
