### PR TITLE
Fixed paths related to SonataEasyExtendsBundle

### DIFF
--- a/Resources/config/doctrine/Group.mongodb.xml.skeleton
+++ b/Resources/config/doctrine/Group.mongodb.xml.skeleton
@@ -4,7 +4,7 @@
       xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
                     http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
 
-    <document name="Application\Sonata\UserBundle\Document\Group" collection="fos_user_group">
+    <document name="{{ namespace }}\Document\Group" collection="fos_user_group">
 
 		<field fieldName="id" id="true" strategy="INCREMENT" />
         

--- a/Resources/config/doctrine/Group.orm.xml.skeleton
+++ b/Resources/config/doctrine/Group.orm.xml.skeleton
@@ -4,7 +4,7 @@
                   xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
                   http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
-    <entity name="Application\Sonata\UserBundle\Entity\Group" table="fos_user_group">
+    <entity name="{{ namespace }}\Entity\Group" table="fos_user_group">
 
         <id name="id" column="id" type="integer">
             <generator strategy="AUTO" />

--- a/Resources/config/doctrine/User.mongodb.xml.skeleton
+++ b/Resources/config/doctrine/User.mongodb.xml.skeleton
@@ -4,7 +4,7 @@
       xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
                     http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
 
-    <document name="Application\Sonata\UserBundle\Document\User" collection="fos_user_user" customId="true">
+    <document name="{{ namespace }}\Document\User" collection="fos_user_user" customId="true">
 
         <field fieldName="id" id="true" strategy="INCREMENT" />
 

--- a/Resources/config/doctrine/User.orm.xml.skeleton
+++ b/Resources/config/doctrine/User.orm.xml.skeleton
@@ -4,7 +4,7 @@
                   xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
                   http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
-    <entity name="Application\Sonata\UserBundle\Entity\User" table="fos_user_user">
+    <entity name="{{ namespace }}\Entity\User" table="fos_user_user">
 
         <id name="id" column="id" type="integer">
             <generator strategy="AUTO" />

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "sonata-project/core-bundle": "^3.2",
         "sonata-project/datagrid-bundle": "^2.2.1",
         "sonata-project/doctrine-extensions": "^1.0",
-        "sonata-project/easy-extends-bundle": "^2.1",
+        "sonata-project/easy-extends-bundle": "^2.2",
         "sonata-project/google-authenticator": "^1.0",
         "symfony/console": "^2.3",
         "symfony/form": "^2.3",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because my patch is fixing the bug, arisen due to the hardcoded class-path.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed hardcoded paths to classes in `.xml.skeleton` files of config
```

## Subject

<!-- Describe your Pull Request content here -->
Fixed some hardcoded paths, which become invalid after enabling
the '--namespace' option in SonataEasyExtendsBundle's last release
(https://github.com/sonata-project/SonataEasyExtendsBundle/releases/tag/2.2.0)

See also: https://github.com/sonata-project/SonataMediaBundle/pull/1250