### PR TITLE
Fix missing token storage argument in request listener

### DIFF
--- a/Resources/config/google_authenticator.xml
+++ b/Resources/config/google_authenticator.xml
@@ -15,7 +15,7 @@
         <service id="sonata.user.google.authenticator.request_listener" class="Sonata\UserBundle\GoogleAuthenticator\RequestListener">
             <tag name="kernel.event_listener" event="kernel.request" method="onCoreRequest" priority="-1"/>
             <argument type="service" id="sonata.user.google.authenticator.provider"/>
-            <argument/>
+            <argument type="service" id="security.token_storage"/>
             <argument type="service" id="templating"/>
         </service>
     </services>


### PR DESCRIPTION
## Changelog

```markdown
### Fixed
- Fix missing token storage argument in request listener service declaration
```

## Subject

Since some deprecated code was [removed](https://github.com/sonata-project/SonataUserBundle/commit/96ae5b93112aab464858992b79342c76be5bee4e#diff-4e79b6870e449a6ed01dc86464a70ee4L195), the token storage argument is missing from the request listener service declaration.