### PR TITLE
Fix class inheritance

### DIFF
--- a/Block/AccountBlockService.php
+++ b/Block/AccountBlockService.php
@@ -12,7 +12,7 @@
 namespace Sonata\UserBundle\Block;
 
 use Sonata\BlockBundle\Block\BlockContextInterface;
-use Sonata\BlockBundle\Block\Service\AbstractBlockService;
+use Sonata\BlockBundle\Block\Service\AbstractAdminBlockService;
 use Sonata\UserBundle\Model\UserInterface;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\HttpFoundation\Response;
@@ -25,7 +25,7 @@ use Symfony\Component\Security\Core\SecurityContextInterface;
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class AccountBlockService extends AbstractBlockService
+class AccountBlockService extends AbstractAdminBlockService
 {
     /**
      * @var TokenStorageInterface|SecurityContextInterface


### PR DESCRIPTION
I am targeting this branch, because it is a bug fix.

Closes https://github.com/sonata-project/SonataPageBundle/issues/841

## Changelog
```markdown
### Fixed
- `AccountBlockService` extends `AbstractAdminBlockService` instead of wrong `AbstractBlockService`
```

