### PR TITLE
Add Symfony 3.3.* to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,8 @@ matrix:
     - php: '7.1'
       env: SYMFONY=3.2.*
     - php: '7.1'
+      env: SYMFONY=3.3.*
+    - php: '7.1'
       env: SYMFONY=dev-master@dev
     - php: '7.1'
       env: FOS_USER=2.*


### PR DESCRIPTION
I am targeting this branch, because it adds Symfony 3.x support.

## Changelog

```markdown
### Added
- Added Symfony 3.3.* to Travis CI config
```

## Subject

This PR adds Symfony 3.3.* as an environment in the Travis CI config.
