### PR TITLE
Use the admin pool option to get the master role name

### DIFF
--- a/Security/EditableRolesBuilder.php
+++ b/Security/EditableRolesBuilder.php
@@ -107,7 +107,9 @@ class EditableRolesBuilder
             }
         }
 
-        $isMaster = $this->authorizationChecker->isGranted('ROLE_SUPER_ADMIN');
+        $isMaster = $this->authorizationChecker->isGranted(
+            $this->pool->getOption('role_super_admin', 'ROLE_SUPER_ADMIN')
+        );
 
         // get roles from the service container
         foreach ($this->rolesHierarchy as $name => $rolesHierarchy) {


### PR DESCRIPTION
I am targeting this branch, because this PR make SonataUserBundle compatible with configurable roles (see subject section).

## Changelog

```markdown
### Changed
- Use sonata admin pool the get the master role name
```

## Subject

This PR is related to https://github.com/sonata-project/SonataAdminBundle/pull/4548. We are introducing the ability to configure sonata "main" roles under the section `security` of SonataAdminBundle.

Without this PR, changing the SonataAdminBundle `ROLE_SUPER_ADMIN` to something else will break the security role builder of this bundle.

No breaking changes are introduced and this may be merged at anytime.