### PR TITLE
Drop old versions of php/sf

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^5.3 || ^7.0",
+        "php": "^7.1",
         "friendsofsymfony/user-bundle": "^1.3",
         "sonata-project/admin-bundle": "^3.1",
         "sonata-project/core-bundle": "^3.2",
@@ -25,10 +25,10 @@
         "sonata-project/doctrine-extensions": "^1.0",
         "sonata-project/easy-extends-bundle": "^2.2",
         "sonata-project/google-authenticator": "^1.0 || ^2.0",
-        "symfony/console": "^2.3",
-        "symfony/form": "^2.3",
-        "symfony/http-foundation": "^2.3",
-        "symfony/security": "^2.3"
+        "symfony/console": "^2.8",
+        "symfony/form": "^2.8",
+        "symfony/http-foundation": "^2.8",
+        "symfony/security": "^2.8"
     },
     "require-dev": {
         "doctrine/orm": "^2.0",
@@ -38,7 +38,7 @@
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
         "sonata-project/block-bundle": "^3.2",
         "sonata-project/seo-bundle": "^2.0",
-        "symfony/phpunit-bridge": "^2.8 || ^3.0"
+        "symfony/phpunit-bridge": "^3.3"
     },
     "suggest": {
         "friendsofsymfony/rest-bundle": "For using the public API methods.",


### PR DESCRIPTION
I am targeting this branch, because this is BC.

## Changelog

```markdown
### Removed
- Support for old versions of php and Symfony.
```
