### PR TITLE
TwigExtension configuration setting fix

### DIFF
--- a/DependencyInjection/SonataUserExtension.php
+++ b/DependencyInjection/SonataUserExtension.php
@@ -15,6 +15,7 @@ use Sonata\EasyExtendsBundle\Mapper\DoctrineCollector;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
@@ -22,8 +23,19 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 /**
  * @author     Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class SonataUserExtension extends Extension
+class SonataUserExtension extends Extension implements PrependExtensionInterface
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function prepend(ContainerBuilder $container)
+    {
+        if ($container->hasExtension('twig')) {
+            // add custom form widgets
+            $container->prependExtensionConfig('twig', ['form_themes' => ['SonataUserBundle:Form:form_admin_fields.html.twig']]);
+        }
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -121,12 +133,6 @@ class SonataUserExtension extends Extension
 
         $this->configureTranslationDomain($config, $container);
         $this->configureController($config, $container);
-
-        // add custom form widgets
-        $container->setParameter('twig.form.resources', array_merge(
-            $container->getParameter('twig.form.resources'),
-            ['SonataUserBundle:Form:form_admin_fields.html.twig']
-        ));
 
         $container->setParameter('sonata.user.default_avatar', $config['profile']['default_avatar']);
 

--- a/Tests/DependencyInjection/SonataUserExtensionTest.php
+++ b/Tests/DependencyInjection/SonataUserExtensionTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Tests\DependencyInjection;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+use Sonata\UserBundle\DependencyInjection\SonataUserExtension;
+use Symfony\Bundle\TwigBundle\DependencyInjection\TwigExtension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
+
+/**
+ * @author Anton Dyshkant <vyshkant@gmail.com>
+ */
+final class SonataUserExtensionTest extends AbstractExtensionTestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->container->setParameter('kernel.bundles', ['SonataAdminBundle' => true]);
+    }
+
+    public function testTwigConfigParameterIsSetting()
+    {
+        $fakeContainer = $this->getMockBuilder(ContainerBuilder::class)
+            ->setMethods(['hasExtension', 'prependExtensionConfig'])
+            ->getMock();
+
+        $fakeContainer->expects($this->once())
+            ->method('hasExtension')
+            ->with($this->equalTo('twig'))
+            ->willReturn(true);
+
+        $fakeContainer->expects($this->once())
+            ->method('prependExtensionConfig')
+            ->with('twig', ['form_themes' => ['SonataUserBundle:Form:form_admin_fields.html.twig']]);
+
+        foreach ($this->getContainerExtensions() as $extension) {
+            if ($extension instanceof PrependExtensionInterface) {
+                $extension->prepend($fakeContainer);
+            }
+        }
+    }
+
+    public function testTwigConfigParameterIsSet()
+    {
+        $fakeTwigExtension = $this->getMockBuilder(TwigExtension::class)->setMethods(['load', 'getAlias'])->getMock();
+
+        $fakeTwigExtension->expects($this->any())
+            ->method('getAlias')
+            ->willReturn('twig');
+
+        $this->container->registerExtension($fakeTwigExtension);
+
+        $this->load();
+
+        $twigConfigurations = $this->container->getExtensionConfig('twig');
+
+        $this->assertArrayHasKey(0, $twigConfigurations);
+        $this->assertArrayHasKey('form_themes', $twigConfigurations[0]);
+        $this->assertEquals(['SonataUserBundle:Form:form_admin_fields.html.twig'], $twigConfigurations[0]['form_themes']);
+    }
+
+    public function testTwigConfigParameterIsNotSet()
+    {
+        $this->load();
+
+        $twigConfigurations = $this->container->getExtensionConfig('twig');
+
+        $this->assertArrayNotHasKey(0, $twigConfigurations);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getContainerExtensions()
+    {
+        return [
+            new SonataUserExtension(),
+        ];
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
         "doctrine/orm": "^2.0",
         "friendsofsymfony/rest-bundle": "^1.5 || ^2.0",
         "jms/serializer-bundle": "^0.13 || ^1.0",
+        "matthiasnoback/symfony-dependency-injection-test": "^2.2",
         "nelmio/api-doc-bundle": "^2.4",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
         "sonata-project/block-bundle": "^3.2",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this fix does not break BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #924

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed the twig configuration setting bug.
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [x] Update the tests

## Subject

Fixed a bug where the `SonataUserBundle` was causing an exception if the `TwigBundle` was not loaded.