### PR TITLE
Tests: using a compatible version of matthiasnoback/SymfonyDependencyInjectionTest

### DIFF
--- a/Tests/DependencyInjection/SonataUserExtensionTest.php
+++ b/Tests/DependencyInjection/SonataUserExtensionTest.php
@@ -91,4 +91,17 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
             new SonataUserExtension(),
         ];
     }
+
+    protected function load(array $configurationValues = [])
+    {
+        $configs = [$this->getMinimalConfiguration(), $configurationValues];
+
+        foreach ($this->container->getExtensions() as $extension) {
+            if ($extension instanceof PrependExtensionInterface) {
+                $extension->prepend($this->container);
+            }
+
+            $extension->load($configs, $this->container);
+        }
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "doctrine/orm": "^2.0",
         "friendsofsymfony/rest-bundle": "^1.5 || ^2.0",
         "jms/serializer-bundle": "^0.13 || ^1.0",
-        "matthiasnoback/symfony-dependency-injection-test": "^2.2",
+        "matthiasnoback/symfony-dependency-injection-test": "^1.1",
         "nelmio/api-doc-bundle": "^2.4",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
         "sonata-project/block-bundle": "^3.2",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

## Subject

Using a version of `matthiasnoback/SymfonyDependencyInjectionTest` compatible with PHPUnit 5.7.