### PR TITLE
Configuration default values moved to the Configuration class

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -11,6 +11,10 @@
 
 namespace Sonata\UserBundle\DependencyInjection;
 
+use Sonata\UserBundle\Admin\Entity\GroupAdmin;
+use Sonata\UserBundle\Admin\Entity\UserAdmin;
+use Sonata\UserBundle\Entity\BaseGroup;
+use Sonata\UserBundle\Entity\BaseUser;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -65,9 +69,10 @@ class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
                 ->arrayNode('class')
+                    ->addDefaultsIfNotSet()
                     ->children()
-                        ->scalarNode('group')->cannotBeEmpty()->end()
-                        ->scalarNode('user')->cannotBeEmpty()->end()
+                        ->scalarNode('group')->cannotBeEmpty()->defaultValue(BaseGroup::class)->end()
+                        ->scalarNode('user')->cannotBeEmpty()->defaultValue(BaseUser::class)->end()
                     ->end()
                 ->end()
                 ->arrayNode('admin')
@@ -76,7 +81,7 @@ class Configuration implements ConfigurationInterface
                         ->arrayNode('group')
                             ->addDefaultsIfNotSet()
                             ->children()
-                                ->scalarNode('class')->cannotBeEmpty()->end()
+                                ->scalarNode('class')->cannotBeEmpty()->defaultValue(GroupAdmin::class)->end()
                                 ->scalarNode('controller')->cannotBeEmpty()->defaultValue('SonataAdminBundle:CRUD')->end()
                                 ->scalarNode('translation')->cannotBeEmpty()->defaultValue('SonataUserBundle')->end()
                             ->end()
@@ -84,7 +89,7 @@ class Configuration implements ConfigurationInterface
                         ->arrayNode('user')
                             ->addDefaultsIfNotSet()
                             ->children()
-                                ->scalarNode('class')->cannotBeEmpty()->end()
+                                ->scalarNode('class')->cannotBeEmpty()->defaultValue(UserAdmin::class)->end()
                                 ->scalarNode('controller')->cannotBeEmpty()->defaultValue('SonataAdminBundle:CRUD')->end()
                                 ->scalarNode('translation')->cannotBeEmpty()->defaultValue('SonataUserBundle')->end()
                             ->end()

--- a/Tests/Admin/Document/GroupAdmin.php
+++ b/Tests/Admin/Document/GroupAdmin.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Tests\Admin\Document;
+
+use Sonata\UserBundle\Admin\Document\GroupAdmin as BaseGroupAdmin;
+
+/**
+ * @author Anton Dyshkant <vyshkant@gmail.com>
+ */
+class GroupAdmin extends BaseGroupAdmin
+{
+}

--- a/Tests/Admin/Document/UserAdmin.php
+++ b/Tests/Admin/Document/UserAdmin.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Tests\Admin\Document;
+
+use Sonata\UserBundle\Admin\Document\UserAdmin as BaseUserAdmin;
+
+/**
+ * @author Anton Dyshkant <vyshkant@gmail.com>
+ */
+class UserAdmin extends BaseUserAdmin
+{
+}

--- a/Tests/Admin/Entity/UserAdmin.php
+++ b/Tests/Admin/Entity/UserAdmin.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Tests\Admin\Entity;
+
+use Sonata\UserBundle\Admin\Entity\UserAdmin as BaseUserAdmin;
+
+/**
+ * @author Anton Dyshkant <vyshkant@gmail.com>
+ */
+class UserAdmin extends BaseUserAdmin
+{
+}

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -37,12 +37,18 @@ class ConfigurationTest extends TestCase
                 'enabled' => false,
             ],
             'manager_type' => 'orm',
+            'class' => [
+                'user' => 'Sonata\UserBundle\Entity\BaseUser',
+                'group' => 'Sonata\UserBundle\Entity\BaseGroup',
+            ],
             'admin' => [
                 'user' => [
+                    'class' => 'Sonata\UserBundle\Admin\Entity\UserAdmin',
                     'controller' => 'SonataAdminBundle:CRUD',
                     'translation' => 'SonataUserBundle',
                 ],
                 'group' => [
+                    'class' => 'Sonata\UserBundle\Admin\Entity\GroupAdmin',
                     'controller' => 'SonataAdminBundle:CRUD',
                     'translation' => 'SonataUserBundle',
                 ],

--- a/Tests/DependencyInjection/SonataUserExtensionTest.php
+++ b/Tests/DependencyInjection/SonataUserExtensionTest.php
@@ -12,8 +12,10 @@
 namespace Sonata\UserBundle\Tests\DependencyInjection;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+use Sonata\UserBundle\DependencyInjection\Configuration;
 use Sonata\UserBundle\DependencyInjection\SonataUserExtension;
 use Symfony\Bundle\TwigBundle\DependencyInjection\TwigExtension;
+use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 
@@ -29,12 +31,11 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
     {
         parent::setUp();
 
-        $this->container->setParameter('kernel.bundles', ['SonataAdminBundle' => true]);
+        $this->setParameter('kernel.bundles', ['SonataAdminBundle' => true]);
     }
 
     public function testLoadDefault()
     {
-        $this->setParameter('twig.form.resources', []);
         $this->load();
 
         $this->assertContainerBuilderHasAlias(
@@ -72,7 +73,9 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
 
     public function testTwigConfigParameterIsSet()
     {
-        $fakeTwigExtension = $this->getMockBuilder(TwigExtension::class)->setMethods(['load', 'getAlias'])->getMock();
+        $fakeTwigExtension = $this->getMockBuilder(TwigExtension::class)
+            ->setMethods(['load', 'getAlias'])
+            ->getMock();
 
         $fakeTwigExtension->expects($this->any())
             ->method('getAlias')
@@ -86,7 +89,10 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
 
         $this->assertArrayHasKey(0, $twigConfigurations);
         $this->assertArrayHasKey('form_themes', $twigConfigurations[0]);
-        $this->assertEquals(['SonataUserBundle:Form:form_admin_fields.html.twig'], $twigConfigurations[0]['form_themes']);
+        $this->assertEquals(
+            ['SonataUserBundle:Form:form_admin_fields.html.twig'],
+            $twigConfigurations[0]['form_themes']
+        );
     }
 
     public function testTwigConfigParameterIsNotSet()
@@ -96,6 +102,64 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
         $twigConfigurations = $this->container->getExtensionConfig('twig');
 
         $this->assertArrayNotHasKey(0, $twigConfigurations);
+    }
+
+    public function testCorrectModelClass()
+    {
+        $this->load(['class' => ['user' => 'Sonata\UserBundle\Tests\Entity\User']]);
+    }
+
+    public function testCorrectModelClassWithLeadingSlash()
+    {
+        $this->load(['class' => ['user' => '\Sonata\UserBundle\Tests\Entity\User']]);
+    }
+
+    public function testCorrectAdminClass()
+    {
+        $this->load(['admin' => ['user' => ['class' => '\Sonata\UserBundle\Tests\Admin\Entity\UserAdmin']]]);
+    }
+
+    public function testCorrectModelClassWithNotDefaultManagerType()
+    {
+        $this->load([
+            'manager_type' => 'mongodb',
+            'class' => [
+                'user' => 'Sonata\UserBundle\Tests\Document\User',
+                'group' => 'Sonata\UserBundle\Tests\Document\Group',
+            ],
+            'admin' => [
+                'user' => ['class' => 'Sonata\UserBundle\Tests\Admin\Document\UserAdmin'],
+                'group' => ['class' => 'Sonata\UserBundle\Tests\Admin\Document\GroupAdmin'],
+            ],
+        ]);
+    }
+
+    public function testIncorrectModelClass()
+    {
+        $this->expectException('InvalidArgumentException');
+
+        $this->expectExceptionMessage('Model class "Foo\User" does not correspond to manager type "orm".');
+
+        $this->load(['class' => ['user' => 'Foo\User']]);
+    }
+
+    public function testNotCorrespondingModelClass()
+    {
+        $this->expectException('InvalidArgumentException');
+
+        $this->expectExceptionMessage(
+            'Model class "Sonata\UserBundle\Admin\Entity\UserAdmin" does not correspond to manager type "mongodb".'
+        );
+
+        $this->load(['manager_type' => 'mongodb', 'class' => ['user' => 'Sonata\UserBundle\Admin\Entity\UserAdmin']]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getMinimalConfiguration()
+    {
+        return (new Processor())->process((new Configuration())->getConfigTreeBuilder()->buildTree(), []);
     }
 
     /**
@@ -108,6 +172,9 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
         ];
     }
 
+    /**
+     * {@inheritdoc}
+     */
     protected function load(array $configurationValues = [])
     {
         $configs = [$this->getMinimalConfiguration(), $configurationValues];

--- a/Tests/Document/Group.php
+++ b/Tests/Document/Group.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Tests\Document;
+
+use Sonata\UserBundle\Document\BaseGroup;
+
+/**
+ * @author Anton Dyshkant <vyshkant@gmail.com>
+ */
+class Group extends BaseGroup
+{
+}

--- a/Tests/Document/User.php
+++ b/Tests/Document/User.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Tests\Document;
+
+use Sonata\UserBundle\Document\BaseUser;
+
+/**
+ * @author Anton Dyshkant <vyshkant@gmail.com>
+ */
+class User extends BaseUser
+{
+}

--- a/Tests/Entity/User.php
+++ b/Tests/Entity/User.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Tests\Entity;
+
+use Sonata\UserBundle\Entity\BaseUser;
+
+/**
+ * @author Anton Dyshkant <vyshkant@gmail.com>
+ */
+class User extends BaseUser
+{
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this PR breaks BC

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #927

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- default values moved to the Configuration class
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [x] Update the tests
- [ ] Update the documentation

## Subject

Configuration default values moved from `SonataUserExtension::load` to the `Configuration` class.
