### PR TITLE
Fix AclVoter parameter can be not an object

### DIFF
--- a/Entity/GroupManager.php
+++ b/Entity/GroupManager.php
@@ -45,7 +45,7 @@ class GroupManager extends BaseGroupManager implements GroupManagerInterface
             }
         }
 
-        if (count($sort) == 0) {
+        if (0 == count($sort)) {
             $sort = ['name' => 'ASC'];
         }
 

--- a/Entity/UserManager.php
+++ b/Entity/UserManager.php
@@ -117,7 +117,7 @@ class UserManager extends BaseUserManager implements UserManagerInterface, Manag
                 throw new \RuntimeException(sprintf("Invalid sort field '%s' in '%s' class", $field, $this->class));
             }
         }
-        if (count($sort) == 0) {
+        if (0 == count($sort)) {
             $sort = ['username' => 'ASC'];
         }
         foreach ($sort as $field => $direction) {

--- a/Form/Transformer/RestoreRolesTransformer.php
+++ b/Form/Transformer/RestoreRolesTransformer.php
@@ -47,11 +47,11 @@ class RestoreRolesTransformer implements DataTransformerInterface
      */
     public function transform($value)
     {
-        if ($value === null) {
+        if (null === $value) {
             return $value;
         }
 
-        if ($this->originalRoles === null) {
+        if (null === $this->originalRoles) {
             throw new \RuntimeException('Invalid state, originalRoles array is not set');
         }
 
@@ -63,7 +63,7 @@ class RestoreRolesTransformer implements DataTransformerInterface
      */
     public function reverseTransform($selectedRoles)
     {
-        if ($this->originalRoles === null) {
+        if (null === $this->originalRoles) {
             throw new \RuntimeException('Invalid state, originalRoles array is not set');
         }
 

--- a/GoogleAuthenticator/RequestListener.php
+++ b/GoogleAuthenticator/RequestListener.php
@@ -83,13 +83,13 @@ class RequestListener
             return;
         }
 
-        if ($session->get($key) === true) {
+        if (true === $session->get($key)) {
             return;
         }
 
         $state = 'init';
-        if ($request->getMethod() == 'POST') {
-            if ($this->helper->checkCode($user, $request->get('_code')) == true) {
+        if ('POST' == $request->getMethod()) {
+            if (true == $this->helper->checkCode($user, $request->get('_code'))) {
                 $session->set($key, true);
 
                 return;

--- a/Security/Authorization/Voter/UserAclVoter.php
+++ b/Security/Authorization/Voter/UserAclVoter.php
@@ -39,7 +39,7 @@ class UserAclVoter extends AclVoter
      */
     public function vote(TokenInterface $token, $object, array $attributes)
     {
-        if (!$this->supportsClass(get_class($object))) {
+        if (!is_object($object) || !$this->supportsClass(get_class($object))) {
             return self::ACCESS_ABSTAIN;
         }
 

--- a/Security/Authorization/Voter/UserAclVoter.php
+++ b/Security/Authorization/Voter/UserAclVoter.php
@@ -31,7 +31,7 @@ class UserAclVoter extends AclVoter
      */
     public function supportsAttribute($attribute)
     {
-        return $attribute === 'EDIT' || $attribute === 'DELETE';
+        return 'EDIT' === $attribute || 'DELETE' === $attribute;
     }
 
     /**

--- a/Security/Authorization/Voter/UserAclVoter.php
+++ b/Security/Authorization/Voter/UserAclVoter.php
@@ -37,15 +37,15 @@ class UserAclVoter extends AclVoter
     /**
      * {@inheritdoc}
      */
-    public function vote(TokenInterface $token, $object, array $attributes)
+    public function vote(TokenInterface $token, $subject, array $attributes)
     {
-        if (!is_object($object) || !$this->supportsClass(get_class($object))) {
+        if (!is_object($subject) || !$this->supportsClass(get_class($subject))) {
             return self::ACCESS_ABSTAIN;
         }
 
         foreach ($attributes as $attribute) {
-            if ($this->supportsAttribute($attribute) && $object instanceof UserInterface && $token->getUser() instanceof UserInterface) {
-                if ($object->isSuperAdmin() && !$token->getUser()->isSuperAdmin()) {
+            if ($this->supportsAttribute($attribute) && $subject instanceof UserInterface && $token->getUser() instanceof UserInterface) {
+                if ($subject->isSuperAdmin() && !$token->getUser()->isSuperAdmin()) {
                     // deny a non super admin user to edit or delete a super admin user
                     return self::ACCESS_DENIED;
                 }

--- a/Security/EditableRolesBuilder.php
+++ b/Security/EditableRolesBuilder.php
@@ -90,7 +90,7 @@ class EditableRolesBuilder
             // TODO get the base role from the admin or security handler
             $baseRole = $securityHandler->getBaseRole($admin);
 
-            if (strlen($baseRole) == 0) { // the security handler related to the admin does not provide a valid string
+            if (0 == strlen($baseRole)) { // the security handler related to the admin does not provide a valid string
                 continue;
             }
 


### PR DESCRIPTION
I am targeting this branch, because it is a bug fix.

Closes [#4518](https://github.com/sonata-project/SonataAdminBundle/issues/4518)

## Changelog
```Markdown
### Fixed
- AclVoter parameter can be not an object
```