### PR TITLE
Changed SonataUserExtension consistency check

### DIFF
--- a/DependencyInjection/SonataUserExtension.php
+++ b/DependencyInjection/SonataUserExtension.php
@@ -12,10 +12,6 @@
 namespace Sonata\UserBundle\DependencyInjection;
 
 use Sonata\EasyExtendsBundle\Mapper\DoctrineCollector;
-use Sonata\UserBundle\Admin\Document\GroupAdmin as DocumentGroupAdmin;
-use Sonata\UserBundle\Admin\Document\UserAdmin as DocumentUserAdmin;
-use Sonata\UserBundle\Admin\Entity\GroupAdmin as EntityGroupAdmin;
-use Sonata\UserBundle\Admin\Entity\UserAdmin as EntityUserAdmin;
 use Sonata\UserBundle\Document\BaseGroup as DocumentGroup;
 use Sonata\UserBundle\Document\BaseUser as DocumentUser;
 use Sonata\UserBundle\Entity\BaseGroup as EntityGroup;
@@ -268,23 +264,17 @@ class SonataUserExtension extends Extension implements PrependExtensionInterface
         $actualModelClasses = [
             $config['class']['user'],
             $config['class']['group'],
-            $config['admin']['user']['class'],
-            $config['admin']['group']['class'],
         ];
 
         if ('orm' === $managerType) {
             $expectedModelClasses = [
                 EntityUser::class,
                 EntityGroup::class,
-                EntityUserAdmin::class,
-                EntityGroupAdmin::class,
             ];
         } elseif ('mongodb' === $managerType) {
             $expectedModelClasses = [
                 DocumentUser::class,
                 DocumentGroup::class,
-                DocumentUserAdmin::class,
-                DocumentGroupAdmin::class,
             ];
         } else {
             throw new \InvalidArgumentException(sprintf('Invalid manager type "%s".', $managerType));


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a fix of created in this branch method.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #944

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed bug with inability to use custom admin class
```

## Subject

<!-- Describe your Pull Request content here -->

Existing consistency checks (`SonataUserExtension::checkManagerTypeToModelTypeMapping`) led to the inability to use custom (not inherited from our base) admin class.