### PR TITLE
make Roles in SecurityRolesType translateable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "symfony/console": "^2.8",
         "symfony/form": "^2.8",
         "symfony/http-foundation": "^2.8",
-        "symfony/security": "^2.8"
+        "symfony/security": "^2.8",
+        "symfony/translation": "^2.8"
     },
     "require-dev": {
         "doctrine/orm": "^2.0",

--- a/src/Form/Transformer/RestoreRolesTransformer.php
+++ b/src/Form/Transformer/RestoreRolesTransformer.php
@@ -67,7 +67,7 @@ class RestoreRolesTransformer implements DataTransformerInterface
             throw new \RuntimeException('Invalid state, originalRoles array is not set');
         }
 
-        list($availableRoles) = $this->rolesBuilder->getRoles();
+        $availableRoles = $this->rolesBuilder->getRoles();
 
         $hiddenRoles = array_diff($this->originalRoles, array_keys($availableRoles));
 

--- a/src/Form/Type/SecurityRolesType.php
+++ b/src/Form/Type/SecurityRolesType.php
@@ -76,6 +76,8 @@ class SecurityRolesType extends AbstractType
             $attr['class'] = 'sonata-medium';
         }
 
+        $view->vars['choice_translation_domain'] = false; // RolesBuilder all ready does translate them
+
         $view->vars['attr'] = $attr;
         $view->vars['read_only_choices'] = $options['read_only_choices'];
     }
@@ -97,17 +99,53 @@ class SecurityRolesType extends AbstractType
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        list($roles, $rolesReadOnly) = $this->rolesBuilder->getRoles();
+        $rolesBuilder = $this->rolesBuilder;
 
         $resolver->setDefaults([
-            'choices' => function (Options $options, $parentChoices) use ($roles) {
-                return empty($parentChoices) ? $roles : [];
+            // make expanded default value
+            'expanded' => true,
+
+            'choices' => function (Options $options, $parentChoices) use ($rolesBuilder) {
+                if (!empty($parentChoices)) {
+                    return [];
+                }
+                $roles = $rolesBuilder->getRoles($options['choice_translation_domain'], $options['expanded']);
+
+                /*
+                 * NEXT_MAJOR: array_flip $roles
+                 */
+                return $roles;
             },
 
-            'read_only_choices' => function (Options $options) use ($rolesReadOnly) {
-                return empty($options['choices']) ? $rolesReadOnly : [];
+            'read_only_choices' => function (Options $options) use ($rolesBuilder) {
+                if (!empty($options['choices'])) {
+                    return [];
+                }
+
+                return $rolesBuilder->getRolesReadOnly($options['choice_translation_domain']);
             },
 
+            'choice_translation_domain' => function (Options $options, $value) {
+                // if choice_translation_domain is true, then it's the same as translation_domain
+                if (true === $value) {
+                    $value = $options['translation_domain'];
+                }
+                if (null === $value) {
+                    // no translation domain yet, try to ask sonata admin
+                    $admin = null;
+                    if (isset($options['sonata_admin'])) {
+                        $admin = $options['sonata_admin'];
+                    }
+                    if (null === $admin && isset($options['sonata_field_description'])) {
+                        $admin = $options['sonata_field_description']->getAdmin();
+                    }
+                    if (null !== $admin) {
+                        $value = $admin->getTranslationDomain();
+                    }
+                }
+
+                return $value;
+            },
             'data_class' => null,
         ]);
     }

--- a/src/Resources/config/admin.xml
+++ b/src/Resources/config/admin.xml
@@ -6,6 +6,9 @@
             <argument/>
             <argument type="service" id="sonata.admin.pool"/>
             <argument>%security.role_hierarchy.roles%</argument>
+            <call method="setTranslator">
+                <argument type="service" id="translator"/>
+            </call>
         </service>
         <service id="sonata.user.form.type.security_roles" class="Sonata\UserBundle\Form\Type\SecurityRolesType">
             <tag name="form.type" alias="sonata_security_roles"/>

--- a/src/Security/EditableRolesBuilder.php
+++ b/src/Security/EditableRolesBuilder.php
@@ -15,6 +15,7 @@ use Sonata\AdminBundle\Admin\Pool;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\SecurityContextInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class EditableRolesBuilder
 {
@@ -32,6 +33,11 @@ class EditableRolesBuilder
      * @var Pool
      */
     protected $pool;
+
+    /**
+     * @var TranslatorInterface
+     */
+    protected $translator;
 
     /**
      * @var array
@@ -65,18 +71,83 @@ class EditableRolesBuilder
         $this->rolesHierarchy = $rolesHierarchy;
     }
 
+    /*
+     * @param TranslatorInterface $translator
+     */
+    public function setTranslator(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+    }
+
     /**
+     * @param string|bool|null $domain
+     * @param bool             $expanded
+     *
      * @return array
      */
-    public function getRoles()
+    public function getRoles($domain = false, $expanded = true)
     {
         $roles = [];
+
+        if (!$this->tokenStorage->getToken()) {
+            return $roles;
+        }
+
+        $this->iterateAdminRoles(function ($role, $isMaster) use ($domain, &$roles) {
+            if ($isMaster) {
+                // if the user has the MASTER permission, allow to grant access the admin roles to other users
+                $roles[$role] = $this->translateRole($role, $domain);
+            }
+        });
+
+        $isMaster = $this->authorizationChecker->isGranted(
+            $this->pool->getOption('role_super_admin', 'ROLE_SUPER_ADMIN')
+        );
+
+        // get roles from the service container
+        foreach ($this->rolesHierarchy as $name => $rolesHierarchy) {
+            if ($this->authorizationChecker->isGranted($name) || $isMaster) {
+                $roles[$name] = $this->translateRole($name, $domain);
+                if ($expanded) {
+                    $result = array_map([$this, 'translateRole'], $rolesHierarchy, array_fill(0, count($rolesHierarchy), $domain));
+                    $roles[$name] .= ': '.implode(', ', $result);
+                }
+                foreach ($rolesHierarchy as $role) {
+                    if (!isset($roles[$role])) {
+                        $roles[$role] = $this->translateRole($role, $domain);
+                    }
+                }
+            }
+        }
+
+        return $roles;
+    }
+
+    /**
+     * @param string|bool|null $domain
+     *
+     * @return array
+     */
+    public function getRolesReadOnly($domain = false)
+    {
         $rolesReadOnly = [];
 
         if (!$this->tokenStorage->getToken()) {
-            return [$roles, $rolesReadOnly];
+            return $rolesReadOnly;
         }
 
+        $this->iterateAdminRoles(function ($role, $isMaster) use ($domain, &$rolesReadOnly) {
+            if (!$isMaster && $this->authorizationChecker->isGranted($role)) {
+                // although the user has no MASTER permission, allow the currently logged in user to view the role
+                $rolesReadOnly[$role] = $this->translateRole($role, $domain);
+            }
+        });
+
+        return $rolesReadOnly;
+    }
+
+    private function iterateAdminRoles(callable $func)
+    {
         // get roles from the Admin classes
         foreach ($this->pool->getAdminServiceIds() as $id) {
             try {
@@ -96,34 +167,25 @@ class EditableRolesBuilder
 
             foreach ($admin->getSecurityInformation() as $role => $permissions) {
                 $role = sprintf($baseRole, $role);
-
-                if ($isMaster) {
-                    // if the user has the MASTER permission, allow to grant access the admin roles to other users
-                    $roles[$role] = $role;
-                } elseif ($this->authorizationChecker->isGranted($role)) {
-                    // although the user has no MASTER permission, allow the currently logged in user to view the role
-                    $rolesReadOnly[$role] = $role;
-                }
+                call_user_func($func, $role, $isMaster, $permissions);
             }
         }
+    }
 
-        $isMaster = $this->authorizationChecker->isGranted(
-            $this->pool->getOption('role_super_admin', 'ROLE_SUPER_ADMIN')
-        );
-
-        // get roles from the service container
-        foreach ($this->rolesHierarchy as $name => $rolesHierarchy) {
-            if ($this->authorizationChecker->isGranted($name) || $isMaster) {
-                $roles[$name] = $name.': '.implode(', ', $rolesHierarchy);
-
-                foreach ($rolesHierarchy as $role) {
-                    if (!isset($roles[$role])) {
-                        $roles[$role] = $role;
-                    }
-                }
-            }
+    /*
+     * @param string $role
+     * @param string|bool|null $domain
+     *
+     * @return string
+     */
+    private function translateRole($role, $domain)
+    {
+        // translation domain is false, do not translate it,
+        // null is fallback to message domain
+        if (false === $domain || !isset($this->translator)) {
+            return $role;
         }
 
-        return [$roles, $rolesReadOnly];
+        return $this->translator->trans($role, [], $domain);
     }
 }

--- a/tests/Form/Transformer/RestoreRolesTransformerTest.php
+++ b/tests/Form/Transformer/RestoreRolesTransformerTest.php
@@ -13,6 +13,7 @@ namespace Sonata\UserBundle\Tests\Form\Transformer;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\UserBundle\Form\Transformer\RestoreRolesTransformer;
+use Sonata\UserBundle\Security\EditableRolesBuilder;
 
 class RestoreRolesTransformerTest extends TestCase
 {
@@ -21,9 +22,7 @@ class RestoreRolesTransformerTest extends TestCase
      */
     public function testInvalidStateTransform()
     {
-        $roleBuilder = $this->getMockBuilder('Sonata\UserBundle\Security\EditableRolesBuilder')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $roleBuilder = $this->createMock(EditableRolesBuilder::class);
 
         $transformer = new RestoreRolesTransformer($roleBuilder);
         $transformer->transform([]);
@@ -34,9 +33,7 @@ class RestoreRolesTransformerTest extends TestCase
      */
     public function testInvalidStateReverseTransform()
     {
-        $roleBuilder = $this->getMockBuilder('Sonata\UserBundle\Security\EditableRolesBuilder')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $roleBuilder = $this->createMock(EditableRolesBuilder::class);
 
         $transformer = new RestoreRolesTransformer($roleBuilder);
         $transformer->reverseTransform([]);
@@ -44,9 +41,7 @@ class RestoreRolesTransformerTest extends TestCase
 
     public function testValidTransform()
     {
-        $roleBuilder = $this->getMockBuilder('Sonata\UserBundle\Security\EditableRolesBuilder')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $roleBuilder = $this->createMock(EditableRolesBuilder::class);
 
         $transformer = new RestoreRolesTransformer($roleBuilder);
         $transformer->setOriginalRoles([]);
@@ -58,11 +53,9 @@ class RestoreRolesTransformerTest extends TestCase
 
     public function testValidReverseTransform()
     {
-        $roleBuilder = $this->getMockBuilder('Sonata\UserBundle\Security\EditableRolesBuilder')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $roleBuilder = $this->createMock(EditableRolesBuilder::class);
 
-        $roleBuilder->expects($this->once())->method('getRoles')->will($this->returnValue([[], []]));
+        $roleBuilder->expects($this->once())->method('getRoles')->will($this->returnValue([]));
 
         $transformer = new RestoreRolesTransformer($roleBuilder);
         $transformer->setOriginalRoles(['ROLE_HIDDEN']);
@@ -74,9 +67,7 @@ class RestoreRolesTransformerTest extends TestCase
 
     public function testTransformAllowEmptyOriginalRoles()
     {
-        $roleBuilder = $this->getMockBuilder('Sonata\UserBundle\Security\EditableRolesBuilder')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $roleBuilder = $this->createMock(EditableRolesBuilder::class);
 
         $transformer = new RestoreRolesTransformer($roleBuilder);
         $transformer->setOriginalRoles(null);
@@ -88,11 +79,9 @@ class RestoreRolesTransformerTest extends TestCase
 
     public function testReverseTransformAllowEmptyOriginalRoles()
     {
-        $roleBuilder = $this->getMockBuilder('Sonata\UserBundle\Security\EditableRolesBuilder')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $roleBuilder = $this->createMock(EditableRolesBuilder::class);
 
-        $roleBuilder->expects($this->once())->method('getRoles')->will($this->returnValue([[], []]));
+        $roleBuilder->expects($this->once())->method('getRoles')->will($this->returnValue([]));
 
         $transformer = new RestoreRolesTransformer($roleBuilder);
         $transformer->setOriginalRoles(null);
@@ -104,9 +93,7 @@ class RestoreRolesTransformerTest extends TestCase
 
     public function testReverseTransformRevokedHierarchicalRole()
     {
-        $roleBuilder = $this->getMockBuilder('Sonata\UserBundle\Security\EditableRolesBuilder')
-                            ->disableOriginalConstructor()
-                            ->getMock();
+        $roleBuilder = $this->createMock(EditableRolesBuilder::class);
 
         $availableRoles = [
             'ROLE_SONATA_ADMIN' => 'ROLE_SONATA_ADMIN',
@@ -115,7 +102,7 @@ class RestoreRolesTransformerTest extends TestCase
             'ROLE_COMPANY_BOOKKEEPER' => 'ROLE_COMPANY_BOOKKEEPER: ROLE_COMPANY_USER',
             'ROLE_USER' => 'ROLE_USER',
         ];
-        $roleBuilder->expects($this->once())->method('getRoles')->will($this->returnValue([$availableRoles, []]));
+        $roleBuilder->expects($this->once())->method('getRoles')->will($this->returnValue($availableRoles));
 
         // user roles
         $userRoles = ['ROLE_COMPANY_PERSONAL_MODERATOR', 'ROLE_COMPANY_NEWS_MODERATOR', 'ROLE_COMPANY_BOOKKEEPER'];
@@ -131,15 +118,13 @@ class RestoreRolesTransformerTest extends TestCase
 
     public function testReverseTransformHiddenRole()
     {
-        $roleBuilder = $this->getMockBuilder('Sonata\UserBundle\Security\EditableRolesBuilder')
-                            ->disableOriginalConstructor()
-                            ->getMock();
+        $roleBuilder = $this->createMock(EditableRolesBuilder::class);
 
         $availableRoles = [
             'ROLE_SONATA_ADMIN' => 'ROLE_SONATA_ADMIN',
             'ROLE_ADMIN' => 'ROLE_ADMIN: ROLE_USER ROLE_COMPANY_ADMIN',
         ];
-        $roleBuilder->expects($this->once())->method('getRoles')->will($this->returnValue([$availableRoles, []]));
+        $roleBuilder->expects($this->once())->method('getRoles')->will($this->returnValue($availableRoles));
 
         // user roles
         $userRoles = ['ROLE_USER', 'ROLE_SUPER_ADMIN'];

--- a/tests/Form/Type/SecurityRolesTypeTest.php
+++ b/tests/Form/Type/SecurityRolesTypeTest.php
@@ -12,6 +12,7 @@
 namespace Sonata\UserBundle\Tests\Form\Type;
 
 use Sonata\UserBundle\Form\Type\SecurityRolesType;
+use Sonata\UserBundle\Security\EditableRolesBuilder;
 use Symfony\Component\Form\PreloadedExtension;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -100,18 +101,15 @@ class SecurityRolesTypeTest extends TypeTestCase
 
     protected function getExtensions()
     {
-        $this->roleBuilder = $roleBuilder = $this->getMockBuilder('Sonata\UserBundle\Security\EditableRolesBuilder')
-          ->disableOriginalConstructor()
-          ->getMock();
+        $this->roleBuilder = $roleBuilder = $this->createMock(EditableRolesBuilder::class);
 
         $this->roleBuilder->expects($this->any())->method('getRoles')->will($this->returnValue([
-          0 => [
-            'ROLE_FOO' => 'ROLE_FOO',
-            'ROLE_USER' => 'ROLE_USER',
-            'ROLE_ADMIN' => 'ROLE_ADMIN: ROLE_USER',
-          ],
-          1 => [],
+          'ROLE_FOO' => 'ROLE_FOO',
+          'ROLE_USER' => 'ROLE_USER',
+          'ROLE_ADMIN' => 'ROLE_ADMIN: ROLE_USER',
         ]));
+
+        $this->roleBuilder->expects($this->any())->method('getRolesReadOnly')->will($this->returnValue([]));
 
         $childType = new SecurityRolesType($this->roleBuilder);
 

--- a/tests/Security/EditableRolesBuilderTest.php
+++ b/tests/Security/EditableRolesBuilderTest.php
@@ -55,7 +55,7 @@ class EditableRolesBuilderTest extends TestCase
                 ->disableOriginalConstructor()
                 ->getMock();
 
-        $pool->expects($this->once())->method('getAdminServiceIds')->will($this->returnValue([]));
+        $pool->expects($this->exactly(2))->method('getAdminServiceIds')->will($this->returnValue([]));
 
         $rolesHierarchy = [
             'ROLE_ADMIN' => [
@@ -84,7 +84,8 @@ class EditableRolesBuilderTest extends TestCase
         ];
 
         $builder = new EditableRolesBuilder($tokenStorage, $authorizationChecker, $pool, $rolesHierarchy);
-        list($roles, $rolesReadOnly) = $builder->getRoles();
+        $roles = $builder->getRoles();
+        $rolesReadOnly = $builder->getRolesReadOnly();
 
         $this->assertEmpty($rolesReadOnly);
         $this->assertEquals($expected, $roles);
@@ -93,12 +94,12 @@ class EditableRolesBuilderTest extends TestCase
     public function testRolesFromAdminWithMasterAdmin()
     {
         $securityHandler = $this->createMock('Sonata\AdminBundle\Security\Handler\SecurityHandlerInterface');
-        $securityHandler->expects($this->once())->method('getBaseRole')->will($this->returnValue('ROLE_FOO_%s'));
+        $securityHandler->expects($this->exactly(2))->method('getBaseRole')->will($this->returnValue('ROLE_FOO_%s'));
 
         $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
-        $admin->expects($this->once())->method('isGranted')->will($this->returnValue(true));
-        $admin->expects($this->once())->method('getSecurityInformation')->will($this->returnValue(['GUEST' => [0 => 'VIEW', 1 => 'LIST'], 'STAFF' => [0 => 'EDIT', 1 => 'LIST', 2 => 'CREATE'], 'EDITOR' => [0 => 'OPERATOR', 1 => 'EXPORT'], 'ADMIN' => [0 => 'MASTER']]));
-        $admin->expects($this->once())->method('getSecurityHandler')->will($this->returnValue($securityHandler));
+        $admin->expects($this->exactly(2))->method('isGranted')->will($this->returnValue(true));
+        $admin->expects($this->exactly(2))->method('getSecurityInformation')->will($this->returnValue(['GUEST' => [0 => 'VIEW', 1 => 'LIST'], 'STAFF' => [0 => 'EDIT', 1 => 'LIST', 2 => 'CREATE'], 'EDITOR' => [0 => 'OPERATOR', 1 => 'EXPORT'], 'ADMIN' => [0 => 'MASTER']]));
+        $admin->expects($this->exactly(2))->method('getSecurityHandler')->will($this->returnValue($securityHandler));
 
         $token = $this->createMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
 
@@ -112,8 +113,8 @@ class EditableRolesBuilderTest extends TestCase
                 ->disableOriginalConstructor()
                 ->getMock();
 
-        $pool->expects($this->once())->method('getInstance')->will($this->returnValue($admin));
-        $pool->expects($this->once())->method('getAdminServiceIds')->will($this->returnValue(['myadmin']));
+        $pool->expects($this->exactly(2))->method('getInstance')->will($this->returnValue($admin));
+        $pool->expects($this->exactly(2))->method('getAdminServiceIds')->will($this->returnValue(['myadmin']));
 
         $builder = new EditableRolesBuilder($tokenStorage, $authorizationChecker, $pool, []);
 
@@ -124,7 +125,8 @@ class EditableRolesBuilderTest extends TestCase
           'ROLE_FOO_ADMIN' => 'ROLE_FOO_ADMIN',
         ];
 
-        list($roles, $rolesReadOnly) = $builder->getRoles();
+        $roles = $builder->getRoles();
+        $rolesReadOnly = $builder->getRolesReadOnly();
         $this->assertEmpty($rolesReadOnly);
         $this->assertEquals($expected, $roles);
     }
@@ -143,7 +145,8 @@ class EditableRolesBuilderTest extends TestCase
 
         $builder = new EditableRolesBuilder($tokenStorage, $authorizationChecker, $pool, []);
 
-        list($roles, $rolesReadOnly) = $builder->getRoles();
+        $roles = $builder->getRoles();
+        $rolesReadOnly = $builder->getRolesReadOnly();
 
         $this->assertEmpty($roles);
         $this->assertEmpty($rolesReadOnly);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it most likely not backwards compatible.
I did some big changes with the Role Builder which might not be able to be backwards compatible.
it might not be problematic if it count as internal class.

Also it depends on sonata-project/SonataAdminBundle#4670

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #911

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- make Roles in SecurityRolesType translateable
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [X] Update the tests

## Subject

<!-- Describe your Pull Request content here -->
SecurityRolesType gets option for `choice_translation_domain` to translate the roles.
It is used similar then in ChoiceType.
Its fallback uses `translation_domain` or the `SonataAdmin#getTranslationDomain`
if used inside SonataAdmin. if false is used, it disable the translation.

some changes for how the choice values are made, to prevent translation of the roles if they are not needed.

The RolesBuilder now has extra funtions for getRoles and getRolesReadOnly to prevent the list from generated twice for the choices and read_only_choices.
it uses TranslatorInterface to translate the roles given to the choice_translation_domain
the Expanded parameter is used to check if the choice will be rendered as Checkboxes (expanded) or as Select (not expanded) because the rolesHierarchy doesn't look so good for Select choices.

Because the RolesBuilder already does translate the roles, i disabled `choice_translation_domain` for the view to prevent double translation. (this needs sonata-project/SonataAdminBundle#4670)