### PR TITLE
Ensure subject is an object in UserAclVoter

### DIFF
--- a/Security/Authorization/Voter/UserAclVoter.php
+++ b/Security/Authorization/Voter/UserAclVoter.php
@@ -41,7 +41,7 @@ class UserAclVoter extends AclVoter
      */
     public function vote(TokenInterface $token, $object, array $attributes)
     {
-        if (!$this->supportsClass(get_class($object))) {
+        if (!is_object($object) || !$this->supportsClass(get_class($object))) {
             return self::ACCESS_ABSTAIN;
         }
 


### PR DESCRIPTION
I am targeting this branch, because it is the lowest branch where the issue exists.

## Changelog

```markdown
### Fixed
- Added a check to the UserAclVoter class to ensure the subject is an object
```
## Subject

The `UserAclVoter` currently expects the subject to always be an object, but that isn't always the case. In the Symfony CMF ResourceRestBundle, subject is an array, which causes an error with the `get_class` method. So this adds a check to ensure the subject on the voter is an object before continuing with the rest of the checks