### PR TITLE
Add check to ensure subject is an object in UserAclVoter

### DIFF
--- a/src/Security/Authorization/Voter/UserAclVoter.php
+++ b/src/Security/Authorization/Voter/UserAclVoter.php
@@ -39,7 +39,7 @@ class UserAclVoter extends AclVoter
      */
     public function vote(TokenInterface $token, $object, array $attributes)
     {
-        if (!$this->supportsClass(get_class($object))) {
+        if (!is_object($object) || !$this->supportsClass(get_class($object))) {
             return self::ACCESS_ABSTAIN;
         }
 

--- a/src/Security/Authorization/Voter/UserAclVoter.php
+++ b/src/Security/Authorization/Voter/UserAclVoter.php
@@ -37,15 +37,15 @@ class UserAclVoter extends AclVoter
     /**
      * {@inheritdoc}
      */
-    public function vote(TokenInterface $token, $object, array $attributes)
+    public function vote(TokenInterface $token, $subject, array $attributes)
     {
-        if (!is_object($object) || !$this->supportsClass(get_class($object))) {
+        if (!is_object($subject) || !$this->supportsClass(get_class($subject))) {
             return self::ACCESS_ABSTAIN;
         }
 
         foreach ($attributes as $attribute) {
-            if ($this->supportsAttribute($attribute) && $object instanceof UserInterface && $token->getUser() instanceof UserInterface) {
-                if ($object->isSuperAdmin() && !$token->getUser()->isSuperAdmin()) {
+            if ($this->supportsAttribute($attribute) && $subject instanceof UserInterface && $token->getUser() instanceof UserInterface) {
+                if ($subject->isSuperAdmin() && !$token->getUser()->isSuperAdmin()) {
                     // deny a non super admin user to edit or delete a super admin user
                     return self::ACCESS_DENIED;
                 }


### PR DESCRIPTION
I am targeting this branch, because it is the lowest branch where the issue exists.

## Changelog

```markdown
### Fixed
- Added a check to the UserAclVoter class to ensure the subject is an object
```
## Subject

The `UserAclVoter` currently expects the subject to always be an object, but that isn't always the case. In the Symfony CMF ResourceRestBundle, subject is an array, which causes an error with the `get_class` method. So this adds a check to ensure the subject on the voter is an object before continuing with the rest of the checks