### PR TITLE
make admin services public

### DIFF
--- a/src/Resources/config/admin_mongodb.xml
+++ b/src/Resources/config/admin_mongodb.xml
@@ -6,7 +6,7 @@
         <parameter key="sonata.user.admin.groupicon"><![CDATA[<i class='fa fa-users'></i>]]></parameter>
     </parameters>
     <services>
-        <service id="sonata.user.admin.user" class="%sonata.user.admin.user.class%">
+        <service id="sonata.user.admin.user" class="%sonata.user.admin.user.class%" public="true">
             <tag name="sonata.admin" label_catalogue="%sonata.user.admin.label_catalogue%" manager_type="doctrine_mongodb" group="%sonata.user.admin.groupname%" label="users" label_translator_strategy="sonata.admin.label.strategy.underscore" icon="%sonata.user.admin.groupicon%"/>
             <argument/>
             <argument>%sonata.user.admin.user.document%</argument>
@@ -18,7 +18,7 @@
                 <argument>%sonata.user.admin.user.translation_domain%</argument>
             </call>
         </service>
-        <service id="sonata.user.admin.group" class="%sonata.user.admin.group.class%">
+        <service id="sonata.user.admin.group" class="%sonata.user.admin.group.class%" public="true">
             <tag name="sonata.admin" label_catalogue="%sonata.user.admin.label_catalogue%" manager_type="doctrine_mongodb" group="%sonata.user.admin.groupname%" label="groups" label_translator_strategy="sonata.admin.label.strategy.underscore"/>
             <argument/>
             <argument>%sonata.user.admin.group.document%</argument>

--- a/src/Resources/config/admin_orm.xml
+++ b/src/Resources/config/admin_orm.xml
@@ -6,7 +6,7 @@
         <parameter key="sonata.user.admin.groupicon"><![CDATA[<i class='fa fa-users'></i>]]></parameter>
     </parameters>
     <services>
-        <service id="sonata.user.admin.user" class="%sonata.user.admin.user.class%">
+        <service id="sonata.user.admin.user" class="%sonata.user.admin.user.class%" public="true">
             <tag name="sonata.admin" manager_type="orm" group="%sonata.user.admin.groupname%" label="users" label_catalogue="%sonata.user.admin.label_catalogue%" label_translator_strategy="sonata.admin.label.strategy.underscore" icon="%sonata.user.admin.groupicon%"/>
             <argument/>
             <argument>%sonata.user.admin.user.entity%</argument>
@@ -18,7 +18,7 @@
                 <argument>%sonata.user.admin.user.translation_domain%</argument>
             </call>
         </service>
-        <service id="sonata.user.admin.group" class="%sonata.user.admin.group.class%">
+        <service id="sonata.user.admin.group" class="%sonata.user.admin.group.class%" public="true">
             <tag name="sonata.admin" manager_type="orm" group="%sonata.user.admin.groupname%" label="groups" label_catalogue="%sonata.user.admin.label_catalogue%" label_translator_strategy="sonata.admin.label.strategy.underscore"/>
             <argument/>
             <argument>%sonata.user.admin.group.entity%</argument>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because release soon. @greg0ire said so

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #965

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Changed
- `sonata.user.admin.user` and `sonata.user.admin.group` are public now
```

<!-- Describe your Pull Request content here -->
