### PR TITLE
Set choices_as_values to true in SecurityRolesType

### DIFF
--- a/src/Form/Type/SecurityRolesType.php
+++ b/src/Form/Type/SecurityRolesType.php
@@ -133,6 +133,11 @@ class SecurityRolesType extends AbstractType
 
             'data_class' => null,
         ]);
+
+        // Symfony 2.8 BC
+        if ($resolver->isDefined('choices_as_values')) {
+            $resolver->setDefault('choices_as_values', true);
+        }
     }
 
     /**

--- a/tests/Form/Type/SecurityRolesTypeTest.php
+++ b/tests/Form/Type/SecurityRolesTypeTest.php
@@ -94,6 +94,25 @@ class SecurityRolesTypeTest extends TypeTestCase
         $this->assertContains('ROLE_SUPER_ADMIN', $form->getData());
     }
 
+    public function testChoicesAsValues(): void
+    {
+        $resolver = new OptionsResolver();
+        $type = new SecurityRolesType($this->roleBuilder);
+
+        // If 'choices_as_values' option is not defined (Symfony >= 3.0), default value should not be set.
+        $type->configureOptions($resolver);
+
+        $this->assertFalse($resolver->hasDefault('choices_as_values'));
+
+        // If 'choices_as_values' option is defined (Symfony 2.8), default value should be set to true.
+        $resolver->setDefined(['choices_as_values']);
+        $type->configureOptions($resolver);
+        $options = $resolver->resolve();
+
+        $this->assertTrue($resolver->hasDefault('choices_as_values'));
+        $this->assertTrue($options['choices_as_values']);
+    }
+
     protected function getExtensions()
     {
         $this->roleBuilder = $roleBuilder = $this->createMock(EditableRolesBuilder::class);


### PR DESCRIPTION
## Changelog

```markdown
### Fixed
- Fixed flipped choices values/labels in SecurityRolesType when using symfony 2.8
```

## To do
- [x] Update the tests

## Subject

On the 4.x branch, `SecurityRolesType` choices are now flipped, but as this branch is compatible with symfony 2.8, we must set the `choices_as_values` option to `true` (if defined).
