### PR TITLE
Fixed a bug with inability to use external model classes

### DIFF
--- a/src/DependencyInjection/SonataUserExtension.php
+++ b/src/DependencyInjection/SonataUserExtension.php
@@ -87,7 +87,7 @@ class SonataUserExtension extends Extension implements PrependExtensionInterface
             $loader->load('security_acl.xml');
         }
 
-        $this->checkManagerTypeToModelTypeMapping($config);
+        $this->checkManagerTypeToModelTypesMapping($config);
 
         $this->registerDoctrineMapping($config);
         $this->configureAdminClass($config, $container);
@@ -261,45 +261,42 @@ class SonataUserExtension extends Extension implements PrependExtensionInterface
     /**
      * @param array $config
      */
-    private function checkManagerTypeToModelTypeMapping(array $config): void
+    private function checkManagerTypeToModelTypesMapping(array $config): void
     {
         $managerType = $config['manager_type'];
 
-        $actualModelClasses = [
-            $config['class']['user'],
-            $config['class']['group'],
-        ];
-
-        if ('orm' === $managerType) {
-            $expectedModelClasses = [
-                EntityUser::class,
-                EntityGroup::class,
-            ];
-        } elseif ('mongodb' === $managerType) {
-            $expectedModelClasses = [
-                DocumentUser::class,
-                DocumentGroup::class,
-            ];
-        } else {
+        if (!in_array($managerType, ['orm', 'mongodb'])) {
             throw new \InvalidArgumentException(sprintf('Invalid manager type "%s".', $managerType));
         }
 
-        foreach ($actualModelClasses as $index => $actualModelClass) {
-            if ('\\' === substr($actualModelClass, 0, 1)) {
-                $actualModelClass = substr($actualModelClass, 1);
-            }
+        $this->checkModelTypeMapping(
+            $config['class']['user'],
+            'orm' === $managerType ? DocumentUser::class : EntityUser::class,
+            $managerType
+        );
 
-            $expectedModelClass = $expectedModelClasses[$index];
+        $this->checkModelTypeMapping(
+            $config['class']['group'],
+            'orm' === $managerType ? DocumentGroup::class : EntityGroup::class,
+            $managerType
+        );
+    }
 
-            if ($actualModelClass !== $expectedModelClass && !is_subclass_of($actualModelClass, $expectedModelClass)) {
-                throw new \InvalidArgumentException(
-                    sprintf(
-                        'Model class "%s" does not correspond to manager type "%s".',
-                        $actualModelClass,
-                        $managerType
-                    )
-                );
-            }
+    /**
+     * @param string $actualModelClass
+     * @param string $prohibitedModelClass
+     * @param string $managerType
+     */
+    private function checkModelTypeMapping($actualModelClass, $prohibitedModelClass, $managerType): void
+    {
+        if ($actualModelClass === $prohibitedModelClass || is_subclass_of($actualModelClass, $prohibitedModelClass)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Model class "%s" does not correspond to manager type "%s".',
+                    $actualModelClass,
+                    $managerType
+                )
+            );
         }
     }
 }

--- a/tests/DependencyInjection/SonataUserExtensionTest.php
+++ b/tests/DependencyInjection/SonataUserExtensionTest.php
@@ -116,11 +116,6 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
         $this->load(['class' => ['user' => '\Sonata\UserBundle\Tests\Entity\User']]);
     }
 
-    public function testCorrectAdminClass(): void
-    {
-        $this->load(['admin' => ['user' => ['class' => '\Sonata\UserBundle\Tests\Admin\Entity\UserAdmin']]]);
-    }
-
     public function testCorrectModelClassWithNotDefaultManagerType(): void
     {
         $this->load([
@@ -129,31 +124,45 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
                 'user' => 'Sonata\UserBundle\Tests\Document\User',
                 'group' => 'Sonata\UserBundle\Tests\Document\Group',
             ],
-            'admin' => [
-                'user' => ['class' => 'Sonata\UserBundle\Tests\Admin\Document\UserAdmin'],
-                'group' => ['class' => 'Sonata\UserBundle\Tests\Admin\Document\GroupAdmin'],
-            ],
         ]);
     }
 
-    public function testIncorrectModelClass(): void
+    public function testExternalModelClass(): void
     {
-        $this->expectException('InvalidArgumentException');
-
-        $this->expectExceptionMessage('Model class "Foo\User" does not correspond to manager type "orm".');
-
-        $this->load(['class' => ['user' => 'Foo\User']]);
+        $this->load(['class' => ['user' => 'Foo\User', 'group' => 'Foo\Group']]);
     }
 
-    public function testNotCorrespondingModelClass(): void
+    public function testNotCorrespondingUserClass(): void
     {
         $this->expectException('InvalidArgumentException');
 
         $this->expectExceptionMessage(
-            'Model class "Sonata\UserBundle\Admin\Entity\UserAdmin" does not correspond to manager type "mongodb".'
+            'Model class "Sonata\UserBundle\Tests\Entity\User" does not correspond to manager type "mongodb".'
         );
 
-        $this->load(['manager_type' => 'mongodb', 'class' => ['user' => 'Sonata\UserBundle\Admin\Entity\UserAdmin']]);
+        $this->load(['manager_type' => 'mongodb', 'class' => ['user' => 'Sonata\UserBundle\Tests\Entity\User']]);
+    }
+
+    public function testNotCorrespondingGroupClass(): void
+    {
+        $this->expectException('InvalidArgumentException');
+
+        $this->expectExceptionMessage(
+            'Model class "Sonata\UserBundle\Tests\Entity\Group" does not correspond to manager type "mongodb".'
+        );
+
+        $this->load(['manager_type' => 'mongodb', 'class' => [
+            'user' => 'Sonata\UserBundle\Tests\Document\User',
+            'group' => 'Sonata\UserBundle\Tests\Entity\Group',
+        ]]);
+    }
+
+    public function testFosUserBundleModelClasses(): void
+    {
+        $this->load(['manager_type' => 'orm', 'class' => [
+            'user' => 'Sonata\UserBundle\Tests\Entity\FosUserBundleBasedUser',
+            'group' => 'Sonata\UserBundle\Tests\Entity\FosUserBundleBasedGroup',
+        ]]);
     }
 
     /**

--- a/tests/Entity/FosUserBundleBasedGroup.php
+++ b/tests/Entity/FosUserBundleBasedGroup.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Tests\Entity;
+
+use FOS\UserBundle\Model\Group as BaseGroup;
+
+/**
+ * @author Anton Dyshkant <vyshkant@gmail.com>
+ */
+class FosUserBundleBasedGroup extends BaseGroup
+{
+}

--- a/tests/Entity/FosUserBundleBasedUser.php
+++ b/tests/Entity/FosUserBundleBasedUser.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Tests\Entity;
+
+use FOS\UserBundle\Model\User as BaseUser;
+
+/**
+ * @author Anton Dyshkant <vyshkant@gmail.com>
+ */
+class FosUserBundleBasedUser extends BaseUser
+{
+}

--- a/tests/Entity/Group.php
+++ b/tests/Entity/Group.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Tests\Entity;
+
+use Sonata\UserBundle\Entity\BaseGroup;
+
+/**
+ * @author Anton Dyshkant <vyshkant@gmail.com>
+ */
+class Group extends BaseGroup
+{
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/4.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #967

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed a bug with inability to use external model classes
```

## Subject

Existing consistency checks (SonataUserExtension::checkManagerTypeToModelTypeMapping) led to the inability to use external model class.

The changes consist in the fact that now only the classes inherited from `SonataUserBundle` base models are checked.
