### PR TITLE
[WIP] Removed configuration default values for user and group

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -15,8 +15,6 @@ namespace Sonata\UserBundle\DependencyInjection;
 
 use Sonata\UserBundle\Admin\Entity\GroupAdmin;
 use Sonata\UserBundle\Admin\Entity\UserAdmin;
-use Sonata\UserBundle\Entity\BaseGroup;
-use Sonata\UserBundle\Entity\BaseUser;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -71,10 +69,10 @@ class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
                 ->arrayNode('class')
-                    ->addDefaultsIfNotSet()
+                    ->isRequired()
                     ->children()
-                        ->scalarNode('group')->cannotBeEmpty()->defaultValue(BaseGroup::class)->end()
-                        ->scalarNode('user')->cannotBeEmpty()->defaultValue(BaseUser::class)->end()
+                        ->scalarNode('group')->isRequired()->cannotBeEmpty()->end()
+                        ->scalarNode('user')->isRequired()->cannotBeEmpty()->end()
                     ->end()
                 ->end()
                 ->arrayNode('admin')

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -26,10 +26,30 @@ class ConfigurationTest extends TestCase
         return new Configuration();
     }
 
+    public function testWithoutClassNode(): void
+    {
+        $this->assertConfigurationIsInvalid([[]], 'The child node "class" at path "sonata_user" must be configured.');
+    }
+
+    public function testWithClassNode(): void
+    {
+        $this->assertConfigurationIsValid([[
+            'class' => [
+                'user' => 'FooBundle\User',
+                'group' => 'FooBundle\Group',
+            ],
+        ]]);
+    }
+
     public function testDefault(): void
     {
         $this->assertProcessedConfigurationEquals([
-            [],
+            [
+                'class' => [
+                    'user' => 'FooBundle\User',
+                    'group' => 'FooBundle\Group',
+                ],
+            ],
         ], [
             'security_acl' => false,
             'table' => [
@@ -40,8 +60,8 @@ class ConfigurationTest extends TestCase
             ],
             'manager_type' => 'orm',
             'class' => [
-                'user' => 'Sonata\UserBundle\Entity\BaseUser',
-                'group' => 'Sonata\UserBundle\Entity\BaseGroup',
+                'user' => 'FooBundle\User',
+                'group' => 'FooBundle\Group',
             ],
             'admin' => [
                 'user' => [

--- a/tests/DependencyInjection/SonataUserExtensionTest.php
+++ b/tests/DependencyInjection/SonataUserExtensionTest.php
@@ -106,11 +106,6 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
         $this->assertArrayNotHasKey(0, $twigConfigurations);
     }
 
-    public function testCorrectModelClass(): void
-    {
-        $this->load(['class' => ['user' => 'Sonata\UserBundle\Tests\Entity\User']]);
-    }
-
     public function testCorrectModelClassWithLeadingSlash(): void
     {
         $this->load(['class' => ['user' => '\Sonata\UserBundle\Tests\Entity\User']]);
@@ -161,7 +156,12 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
      */
     protected function getMinimalConfiguration()
     {
-        return (new Processor())->process((new Configuration())->getConfigTreeBuilder()->buildTree(), []);
+        return (new Processor())->process((new Configuration())->getConfigTreeBuilder()->buildTree(), [[
+            'class' => [
+                'user' => 'Sonata\UserBundle\Tests\Entity\User',
+                'group' => 'Sonata\UserBundle\Tests\Entity\Group',
+            ],
+        ]]);
     }
 
     /**

--- a/tests/Entity/Group.php
+++ b/tests/Entity/Group.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Tests\Entity;
+
+use Sonata\UserBundle\Entity\BaseGroup;
+
+/**
+ * @author Anton Dyshkant <vyshkant@gmail.com>
+ */
+class Group extends BaseGroup
+{
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/4.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC for the working configuration.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Removed configuration default values for `class.user` and `class.group`
### Fixed
- Fixed a bug with invalid default values for `class.user` and `class.group`
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [x] Update the tests
- [ ] Update the documentation
- [ ] Add an upgrade note

## Subject

Previous default values of class.user and class.group were invalid. See https://github.com/sonata-project/SonataUserBundle/pull/930#issuecomment-342327896
