### PR TITLE
Change admin_pool variable in resetting templates

### DIFF
--- a/src/Resources/views/Admin/Security/Resetting/checkEmail.html.twig
+++ b/src/Resources/views/Admin/Security/Resetting/checkEmail.html.twig
@@ -28,12 +28,12 @@ file that was distributed with this source code.
         {% block login_box_header %}
             <div class="login-logo">
                 <a href="{{ path('sonata_admin_dashboard') }}">
-                    {% if adminPool.getOption('title_mode') in ['single_image', 'both'] %}
+                    {% if admin_pool.getOption('title_mode') in ['single_image', 'both'] %}
                         <div>
-                            <img style="width:64px;" src="{{ asset(adminPool.titlelogo) }}" alt="{{ adminPool.title }}">
+                            <img style="width:64px;" src="{{ asset(admin_pool.titlelogo) }}" alt="{{ admin_pool.title }}">
                         </div>
                     {% endif %}
-                    {% if adminPool.getOption('title_mode') in ['single_text', 'both'] %}
+                    {% if admin_pool.getOption('title_mode') in ['single_text', 'both'] %}
                         <span>{{ admin_pool.title }}</span>
                     {% endif %}
                 </a>
@@ -41,7 +41,9 @@ file that was distributed with this source code.
         {% endblock %}
         <div class="login-box-body">
             <p>{{ 'resetting.check_email'|trans({'%tokenLifetime%': tokenLifetime}, 'FOSUserBundle')|nl2br }}</p>
-            <a href="{{ path('sonata_user_admin_security_login') }}">{{ 'title_user_authentication'|trans({}, 'SonataUserBundle') }}</a>
+            <a href="{{ path('sonata_user_admin_security_login') }}">
+                {{ 'title_user_authentication'|trans({}, 'SonataUserBundle') }}
+            </a>
         </div>
     </div>
 

--- a/src/Resources/views/Admin/Security/Resetting/request.html.twig
+++ b/src/Resources/views/Admin/Security/Resetting/request.html.twig
@@ -28,12 +28,12 @@ file that was distributed with this source code.
         {% block login_box_header %}
             <div class="login-logo">
                 <a href="{{ path('sonata_admin_dashboard') }}">
-                    {% if adminPool.getOption('title_mode') in ['single_image', 'both'] %}
+                    {% if admin_pool.getOption('title_mode') in ['single_image', 'both'] %}
                         <div>
-                            <img style="width:64px;" src="{{ asset(adminPool.titlelogo) }}" alt="{{ adminPool.title }}">
+                            <img style="width:64px;" src="{{ asset(admin_pool.titlelogo) }}" alt="{{ admin_pool.title }}">
                         </div>
                     {% endif %}
-                    {% if adminPool.getOption('title_mode') in ['single_text', 'both'] %}
+                    {% if admin_pool.getOption('title_mode') in ['single_text', 'both'] %}
                         <span>{{ admin_pool.title }}</span>
                     {% endif %}
                 </a>
@@ -43,24 +43,31 @@ file that was distributed with this source code.
             {% block sonata_user_reset_request_form %}
                 {% block sonata_user_reset_request_error %}
                     {% if invalid_username is defined %}
-                        <div class="alert alert-danger">{{ 'resetting.request.invalid_username'|trans({'%username%': invalid_username}, 'FOSUserBundle') }}</div>
+                        <div class="alert alert-danger">
+                            {{ 'resetting.request.invalid_username'|trans({'%username%': invalid_username}, 'FOSUserBundle') }}
+                        </div>
                     {% endif %}
                 {% endblock %}
                 <p class="login-box-msg">{{ 'resetting.request.submit'|trans({}, 'FOSUserBundle') }}</p>
                 <form action="{{ path('sonata_user_admin_resetting_send_email') }}" method="post" role="form">
                     <div class="form-group has-feedback">
-                        <input type="text" class="form-control" id="username"  name="username" required="required" placeholder="{{ 'resetting.request.username'|trans({}, 'FOSUserBundle')|replace({':': ''}) }}"/>
+                        <input type="text" class="form-control" id="username"  name="username" required="required"
+                            placeholder="{{ 'resetting.request.username'|trans({}, 'FOSUserBundle')|replace({':': ''}) }}"/>
                         <span class="glyphicon glyphicon-user form-control-feedback"></span>
                     </div>
 
                     <div class="row">
                         <div class="col-xs-12">
-                            <button type="submit" class="btn btn-primary btn-block btn-flat">{{ 'resetting.request.submit'|trans({}, 'FOSUserBundle') }}</button>
+                            <button type="submit" class="btn btn-primary btn-block btn-flat">
+                                {{ 'resetting.request.submit'|trans({}, 'FOSUserBundle') }}
+                            </button>
                         </div>
                     </div>
                 </form>
 
-                <a href="{{ path('sonata_user_admin_security_login') }}">{{ 'title_user_authentication'|trans({}, 'SonataUserBundle') }}</a>
+                <a href="{{ path('sonata_user_admin_security_login') }}">
+                    {{ 'title_user_authentication'|trans({}, 'SonataUserBundle') }}
+                </a>
             {% endblock %}
         </div>
     </div>

--- a/src/Resources/views/Admin/Security/Resetting/reset.html.twig
+++ b/src/Resources/views/Admin/Security/Resetting/reset.html.twig
@@ -28,12 +28,12 @@ file that was distributed with this source code.
         {% block login_box_header %}
             <div class="login-logo">
                 <a href="{{ path('sonata_admin_dashboard') }}">
-                    {% if adminPool.getOption('title_mode') in ['single_image', 'both'] %}
+                    {% if admin_pool.getOption('title_mode') in ['single_image', 'both'] %}
                         <div>
-                            <img style="width:64px;" src="{{ asset(adminPool.titlelogo) }}" alt="{{ adminPool.title }}">
+                            <img style="width:64px;" src="{{ asset(admin_pool.titlelogo) }}" alt="{{ admin_pool.title }}">
                         </div>
                     {% endif %}
-                    {% if adminPool.getOption('title_mode') in ['single_text', 'both'] %}
+                    {% if admin_pool.getOption('title_mode') in ['single_text', 'both'] %}
                         <span>{{ admin_pool.title }}</span>
                     {% endif %}
                 </a>
@@ -57,11 +57,12 @@ file that was distributed with this source code.
                     </div>
                     <div class="row">
                         <div class="col-xs-12">
-                            <button type="submit" class="btn btn-primary btn-block btn-flat">{{ 'resetting.reset.submit'|trans({}, 'FOSUserBundle') }}</button>
+                            <button type="submit" class="btn btn-primary btn-block btn-flat">
+                                {{ 'resetting.reset.submit'|trans({}, 'FOSUserBundle') }}
+                            </button>
                         </div>
                     </div>
                 {{ form_end(form) }}
-                </form>
             {% endblock %}
         </div>
     </div>


### PR DESCRIPTION
The admin pool variable is passed as `admin_pool` to templates, but templates use `adminPool`, throwing and error and making the reset functionality completly broken.

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/4.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because is a serious bug.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #982 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Admin pool variable in admin resetting templates
```
