### PR TITLE
Fix problem with adding sonata-user to symfony recipes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "symfony/console": "^2.8 || ^3.2",
         "symfony/form": "^2.8 || ^3.2",
         "symfony/http-foundation": "^2.8 || ^3.2",
-        "symfony/security": "^2.8 || ^3.2",
+        "symfony/security-acl": "^2.8 || ^3.0",
+        "symfony/security-core": "^2.8 || ^3.2",
         "symfony/translation": "^2.8 || ^3.2"
     },
     "require-dev": {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/4.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because no bc.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- use `symfony/security-core` and `symfony/security-acl` instead of `symfony/security`
```

## Subject
Fixing this [one](https://symfony.sh/r/github.com/symfony/recipes/332)
<!-- Describe your Pull Request content here -->

  
  