### PR TITLE
 use forcedRoles and ipWhiteList also on InteractiveLoginListener

### DIFF
--- a/src/GoogleAuthenticator/Helper.php
+++ b/src/GoogleAuthenticator/Helper.php
@@ -15,7 +15,9 @@ namespace Sonata\UserBundle\GoogleAuthenticator;
 
 use Google\Authenticator\GoogleAuthenticator as BaseGoogleAuthenticator;
 use Sonata\UserBundle\Model\UserInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 class Helper
 {
@@ -30,13 +32,36 @@ class Helper
     protected $authenticator;
 
     /**
-     * @param string                  $server
-     * @param BaseGoogleAuthenticator $authenticator
+     * @var string[]
      */
-    public function __construct($server, BaseGoogleAuthenticator $authenticator)
-    {
+    private $forcedForRoles;
+
+    /**
+     * @var string[]
+     */
+    private $ipWhiteList;
+
+    /**
+     * @var AuthorizationCheckerInterface
+     */
+    private $authorizationChecker;
+
+    /**
+     * @param string[] $forcedForRole Roles that require 2FA authorization
+     * @param string[] $ipWhiteList   IPs that will bypass 2FA authorization
+     */
+    public function __construct(
+      $server,
+      BaseGoogleAuthenticator $authenticator,
+      AuthorizationCheckerInterface $authorizationChecker,
+      array $forcedForRoles = [],
+      array $ipWhiteList = []
+      ) {
         $this->server = $server;
         $this->authenticator = $authenticator;
+        $this->authorizationChecker = $authorizationChecker;
+        $this->forcedForRoles = $forcedForRoles;
+        $this->ipWhiteList = $ipWhiteList;
     }
 
     /**
@@ -76,5 +101,24 @@ class Helper
     public function getSessionKey(UsernamePasswordToken $token)
     {
         return sprintf('sonata_user_google_authenticator_%s_%s', $token->getProviderKey(), $token->getUsername());
+    }
+
+    /**
+     * @return bool
+     */
+    public function needToHaveGoogle2FACode(Request $request): bool
+    {
+        $ip = $request->server->get('HTTP_X_FORWARDED_FOR', $request->server->get('REMOTE_ADDR'));
+        if (in_array($ip, $this->ipWhiteList)) {
+            return false;
+        }
+
+        foreach ($this->forcedForRoles as $role) {
+            if ($this->authorizationChecker->isGranted($role)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/GoogleAuthenticator/InteractiveLoginListener.php
+++ b/src/GoogleAuthenticator/InteractiveLoginListener.php
@@ -37,6 +37,10 @@ class InteractiveLoginListener
      */
     public function onSecurityInteractiveLogin(InteractiveLoginEvent $event): void
     {
+        if (!$this->helper->needToHaveGoogle2FACode($event->getRequest())) {
+            return;
+        }
+
         if (!$event->getAuthenticationToken() instanceof UsernamePasswordToken) {
             return;
         }

--- a/src/Resources/config/google_authenticator.xml
+++ b/src/Resources/config/google_authenticator.xml
@@ -7,6 +7,9 @@
         <service id="sonata.user.google.authenticator.provider" class="Sonata\UserBundle\GoogleAuthenticator\Helper">
             <argument type="service" id="security.token_storage"/>
             <argument type="service" id="sonata.user.google.authenticator"/>
+            <argument type="service" id="security.authorization_checker"/>
+            <argument>%sonata.user.google.authenticator.forced_for_role%</argument>
+            <argument>%sonata.user.google.authenticator.ip_white_list%</argument>
         </service>
         <service id="sonata.user.google.authenticator.interactive_login_listener" class="Sonata\UserBundle\GoogleAuthenticator\InteractiveLoginListener">
             <tag name="kernel.event_listener" event="security.interactive_login" method="onSecurityInteractiveLogin"/>
@@ -19,12 +22,9 @@
             <argument type="service" id="templating"/>
         </service>
         <service id="sonata.user.google.authenticator.success_handler" class="Sonata\UserBundle\EventListener\TwoFactorLoginSuccessHandler" public="false">
-            <argument type="service" id="security.authorization_checker"/>
             <argument type="service" id="templating.engine.twig"/>
             <argument type="service" id="sonata.user.google.authenticator.provider"/>
             <argument type="service" id="FOS\UserBundle\Model\UserManagerInterface"/>
-            <argument>%sonata.user.google.authenticator.forced_for_role%</argument>
-            <argument>%sonata.user.google.authenticator.ip_white_list%</argument>
         </service>
     </services>
 </container>

--- a/tests/EventListener/TwoFactorLoginSuccessHandlerTest.php
+++ b/tests/EventListener/TwoFactorLoginSuccessHandlerTest.php
@@ -101,17 +101,14 @@ class TwoFactorLoginSuccessHandlerTest extends TestCase
         $authChecker = new AuthorizationChecker($tokenStorage, $authManagerMock, new AccessDecisionManager([new RoleHierarchyVoter($roleHierarchy)]));
         $templateEngineMock = $this->createMock(EngineInterface::class);
         $templateEngineMock->method('renderResponse')->willReturn(Response::create('Rendered response'));
-        $helper = new Helper('site.tld', new GoogleAuthenticator());
         $userManagerMock = $this->createMock(UserManagerInterface::class);
         $forcedRoles = ['ROLE_ADMIN'];
         $ipWhiteList = ['127.0.0.1'];
+        $helper = new Helper('site.tld', new GoogleAuthenticator(), $authChecker, $forcedRoles, $ipWhiteList);
         $this->testClass = new TwoFactorLoginSuccessHandler(
-            $authChecker,
             $templateEngineMock,
             $helper,
-            $userManagerMock,
-            $forcedRoles,
-            $ipWhiteList
+            $userManagerMock
         );
         $this->request = Request::create('/');
         if ($remoteAddr) {


### PR DESCRIPTION
…Code method to Sonata\UserBundle\GoogleAuthenticator\Helper class

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/4.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because no bc.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- use forcedRoles and ipWhiteList also on InteractiveLoginListener
```