### PR TITLE
[Bug] Gender list - flip values

### DIFF
--- a/src/Entity/BaseUser.php
+++ b/src/Entity/BaseUser.php
@@ -46,9 +46,9 @@ class BaseUser extends AbstractedUser
     public static function getGenderList()
     {
         return [
-            'gender_unknown' => UserInterface::GENDER_UNKNOWN,
-            'gender_female' => UserInterface::GENDER_FEMALE,
-            'gender_male' => UserInterface::GENDER_MALE,
+            UserInterface::GENDER_UNKNOWN => 'gender_unknown',
+            UserInterface::GENDER_FEMALE => 'gender_female',
+            UserInterface::GENDER_MALE => 'gender_male',
         ];
     }
 }


### PR DESCRIPTION
I am targeting this branch, because o there **is BC-break**

## Subject

There was an change in BaseUser.php https://github.com/sonata-project/SonataUserBundle/commit/c69d51bdd72c50340aa04c9b14a95b18e8600336#diff-0b70ecd19ebc26172322781dd1061c2fL47 which caused flip optionValues with optionLabel. - It generate error because of extending `https://github.com/sonata-project/SonataCoreBundle/blob/master/src/Form/Type/BaseStatusType.php` which set `flip` to true.

It could be updated aswell by adding fourth argument to `https://github.com/sonata-project/SonataUserBundle/blob/4.x/src/Resources/config/form.xml#L7` set to `false`, however as mentioned in comment it will be removed in `v4`

## Changelog

```markdown
### Fixed
Fix problem with flipped values in `getGenderList` method to match expected arguments in `BaseStatusType`
```