### PR TITLE
remove nelmio >= 3.0 conflict rule

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
     "conflict": {
         "friendsofsymfony/rest-bundle": "<1.1",
         "jms/serializer": "<0.13 || >=2.0",
-        "nelmio/api-doc-bundle": "<2.4 || >= 3.0",
+        "nelmio/api-doc-bundle": "<2.4",
         "sonata-project/block-bundle": "<3.2",
         "sonata-project/doctrine-orm-admin-bundle": "<3.0",
         "sonata-project/google-authenticator": "<1.0",


### PR DESCRIPTION
Hi, guys 
I am targeting this branch, because i have conflict with nelmio/api-doc-bundle. SonataUserBundle has description in composer.json => section conflict. Now, I need to migrate to Symfony4 and want to use latest packages as much as possible

Related: https://github.com/sonata-project/SonataUserBundle/pull/989#issuecomment-358578412

Closes #989
Closes #988

## Changelog

```markdown
Removed
- removed conflict rule for nelmio/api-doc-bundle inside composer.json
```

## Subject
https://www.dropbox.com/s/qf14nqwc07rszqt/Selection_292.jpg?dl=0
Try to install sonata user bundle and received an error message:
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - sonata-project/user-bundle dev-master conflicts with nelmio/api-doc-bundle[v3.0.0].
    - sonata-project/user-bundle dev-master conflicts with nelmio/api-doc-bundle[v3.0.0].
    - Installation request for sonata-project/user-bundle dev-master -> satisfiable by sonata-project/user-bundle[dev-master].
    - Installation request for nelmio/api-doc-bundle ^3.0 -> satisfiable by nelmio/api-doc-bundle[v3.0.0].


Installation failed, reverting ./composer.json to its original content.

> 
