### PR TITLE
Decouple from Templating Component, Stage 1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "friendsofsymfony/rest-bundle": "<1.1",
         "jms/serializer": "<0.13 || >=2.0",
         "nelmio/api-doc-bundle": "<2.4",
-        "sonata-project/block-bundle": "<3.2",
+        "sonata-project/block-bundle": "<3.11",
         "sonata-project/doctrine-orm-admin-bundle": "<3.0",
         "sonata-project/google-authenticator": "<1.0",
         "sonata-project/seo-bundle": "<2.0"
@@ -52,7 +52,7 @@
         "matthiasnoback/symfony-config-test": "^2.1",
         "matthiasnoback/symfony-dependency-injection-test": "^1.1",
         "nelmio/api-doc-bundle": "^2.4",
-        "sonata-project/block-bundle": "^3.2",
+        "sonata-project/block-bundle": "^3.11",
         "sonata-project/google-authenticator": "^1.0 || ^2.0",
         "sonata-project/seo-bundle": "^2.0",
         "symfony/phpunit-bridge": "^4.0"

--- a/src/Admin/Model/UserAdmin.php
+++ b/src/Admin/Model/UserAdmin.php
@@ -103,7 +103,7 @@ class UserAdmin extends AbstractAdmin
 
         if ($this->isGranted('ROLE_ALLOWED_TO_SWITCH')) {
             $listMapper
-                ->add('impersonating', 'string', ['template' => 'SonataUserBundle:Admin:Field/impersonating.html.twig'])
+                ->add('impersonating', 'string', ['template' => '@SonataUser/Admin/Field/impersonating.html.twig'])
             ;
         }
     }

--- a/src/DependencyInjection/SonataUserExtension.php
+++ b/src/DependencyInjection/SonataUserExtension.php
@@ -37,7 +37,7 @@ class SonataUserExtension extends Extension implements PrependExtensionInterface
     {
         if ($container->hasExtension('twig')) {
             // add custom form widgets
-            $container->prependExtensionConfig('twig', ['form_themes' => ['SonataUserBundle:Form:form_admin_fields.html.twig']]);
+            $container->prependExtensionConfig('twig', ['form_themes' => ['@SonataUser/Form/form_admin_fields.html.twig']]);
         }
     }
 

--- a/src/Resources/config/google_authenticator.xml
+++ b/src/Resources/config/google_authenticator.xml
@@ -19,10 +19,10 @@
             <tag name="kernel.event_listener" event="kernel.request" method="onCoreRequest" priority="-1"/>
             <argument type="service" id="sonata.user.google.authenticator.provider"/>
             <argument type="service" id="security.token_storage"/>
-            <argument type="service" id="templating"/>
+            <argument type="service" id="sonata.templating"/>
         </service>
         <service id="sonata.user.google.authenticator.success_handler" class="Sonata\UserBundle\EventListener\TwoFactorLoginSuccessHandler" public="false">
-            <argument type="service" id="templating.engine.twig"/>
+            <argument type="service" id="sonata.templating"/>
             <argument type="service" id="sonata.user.google.authenticator.provider"/>
             <argument type="service" id="FOS\UserBundle\Model\UserManagerInterface"/>
         </service>

--- a/src/Resources/views/Admin/Field/impersonating.html.twig
+++ b/src/Resources/views/Admin/Field/impersonating.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{% extends 'SonataAdminBundle:CRUD:base_list_field.html.twig' %}
+{% extends '@SonataAdmin/CRUD/base_list_field.html.twig' %}
 
 {% block field %}
     {% if app.user and object.username != app.user.username and sonata_user.impersonating %}

--- a/tests/DependencyInjection/SonataUserExtensionTest.php
+++ b/tests/DependencyInjection/SonataUserExtensionTest.php
@@ -64,7 +64,7 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
 
         $fakeContainer->expects($this->once())
             ->method('prependExtensionConfig')
-            ->with('twig', ['form_themes' => ['SonataUserBundle:Form:form_admin_fields.html.twig']]);
+            ->with('twig', ['form_themes' => ['@SonataUser/Form/form_admin_fields.html.twig']]);
 
         foreach ($this->getContainerExtensions() as $extension) {
             if ($extension instanceof PrependExtensionInterface) {
@@ -92,7 +92,7 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
         $this->assertArrayHasKey(0, $twigConfigurations);
         $this->assertArrayHasKey('form_themes', $twigConfigurations[0]);
         $this->assertEquals(
-            ['SonataUserBundle:Form:form_admin_fields.html.twig'],
+            ['@SonataUser/Form/form_admin_fields.html.twig'],
             $twigConfigurations[0]['form_themes']
         );
     }


### PR DESCRIPTION
I am targeting this branch, because this is a patch.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Switch all templates references to Twig namespaced syntax
- Switch from templating service to sonata.templating
```

## To do

- [X] Switch all templates references to Twig namespaced syntax. Update docs, src and tests
- [x] Add `sonata-project/block-bundle` to composer.json
- [x] Switch from `templating` service to `sonata.templating`

## Subject

This PR is a part of a big plan of decoupling sonata-project bundles from Templating Component. See sonata-project/dev-kit#380 for details