### PR TITLE
Fix choices_as_values deprecation message

### DIFF
--- a/src/Form/Type/SecurityRolesType.php
+++ b/src/Form/Type/SecurityRolesType.php
@@ -16,10 +16,12 @@ namespace Sonata\UserBundle\Form\Type;
 use Sonata\UserBundle\Form\Transformer\RestoreRolesTransformer;
 use Sonata\UserBundle\Security\EditableRolesBuilder;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -135,7 +137,7 @@ class SecurityRolesType extends AbstractType
         ]);
 
         // Symfony 2.8 BC
-        if ($resolver->isDefined('choices_as_values')) {
+        if (method_exists(FormTypeInterface::class, 'setDefaultOptions')) {
             $resolver->setDefault('choices_as_values', true);
         }
     }
@@ -145,7 +147,7 @@ class SecurityRolesType extends AbstractType
      */
     public function getParent()
     {
-        return 'Symfony\Component\Form\Extension\Core\Type\ChoiceType';
+        return ChoiceType::class;
     }
 
     /**

--- a/tests/Form/Type/SecurityRolesTypeTest.php
+++ b/tests/Form/Type/SecurityRolesTypeTest.php
@@ -15,6 +15,8 @@ namespace Sonata\UserBundle\Tests\Form\Type;
 
 use Sonata\UserBundle\Form\Type\SecurityRolesType;
 use Sonata\UserBundle\Security\EditableRolesBuilder;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\Form\PreloadedExtension;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -35,15 +37,17 @@ class SecurityRolesTypeTest extends TypeTestCase
 
         $options = $optionResolver->resolve();
         $this->assertCount(3, $options['choices']);
+
+        if (method_exists(FormTypeInterface::class, 'setDefaultOptions')) {
+            $this->assertTrue($options['choices_as_values']);
+        }
     }
 
     public function testGetParent(): void
     {
         $type = new SecurityRolesType($this->roleBuilder);
-        $this->assertEquals(
-            'Symfony\Component\Form\Extension\Core\Type\ChoiceType',
-            $type->getParent()
-        );
+
+        $this->assertEquals(ChoiceType::class, $type->getParent());
     }
 
     public function testSubmitValidData(): void
@@ -92,25 +96,6 @@ class SecurityRolesTypeTest extends TypeTestCase
         $this->assertTrue($form->isSynchronized());
         $this->assertCount(2, $form->getData());
         $this->assertContains('ROLE_SUPER_ADMIN', $form->getData());
-    }
-
-    public function testChoicesAsValues(): void
-    {
-        $resolver = new OptionsResolver();
-        $type = new SecurityRolesType($this->roleBuilder);
-
-        // If 'choices_as_values' option is not defined (Symfony >= 3.0), default value should not be set.
-        $type->configureOptions($resolver);
-
-        $this->assertFalse($resolver->hasDefault('choices_as_values'));
-
-        // If 'choices_as_values' option is defined (Symfony 2.8), default value should be set to true.
-        $resolver->setDefined(['choices_as_values']);
-        $type->configureOptions($resolver);
-        $options = $resolver->resolve();
-
-        $this->assertTrue($resolver->hasDefault('choices_as_values'));
-        $this->assertTrue($options['choices_as_values']);
     }
 
     protected function getExtensions()


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/4.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Deprecation message on SecurityRolesType about `choices_as_values`
```

## Subject

<!-- Describe your Pull Request content here -->
Seems like the deprecations build is failing because of this.
Link: https://travis-ci.org/sonata-project/SonataUserBundle/jobs/334884037#L798

Probably this makes this bundle unusable with SF 4, that's why I am tagging it with patch