### PR TITLE
Fix gender choices type

### DIFF
--- a/src/Form/Type/UserGenderListType.php
+++ b/src/Form/Type/UserGenderListType.php
@@ -14,19 +14,32 @@ declare(strict_types=1);
 namespace Sonata\UserBundle\Form\Type;
 
 use Sonata\CoreBundle\Form\Type\BaseStatusType;
+use Symfony\Component\Form\FormTypeInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
-@trigger_error(
-    'The '.__NAMESPACE__.'\UserGenderListType class is deprecated since version 4.1 and will be removed in 5.0.'
-    .' Use Symfony\Component\Form\Extension\Core\Type\ChoiceType instead.',
-    E_USER_DEPRECATED
-);
-
-/**
- * NEXT_MAJOR: remove this class.
- *
- * @deprecated since version 4.1, to be removed in 5.0.
- * Use Symfony\Component\Form\Extension\Core\Type\ChoiceType instead
- */
 class UserGenderListType extends BaseStatusType
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        // NEXT_MAJOR: Call the parent to set the choices
+        $choices = \call_user_func([$this->class, $this->getter]);
+
+        // Only flip choice list, if the keys are m/f/u and not labels
+        if (method_exists(FormTypeInterface::class, 'setDefaultOptions') && 1 === \strlen(key($choices))) {
+            $choices = array_flip($choices);
+        }
+
+        $resolver->setDefaults([
+            'choices' => $choices,
+            'choice_translation_domain' => 'SonataUserBundle',
+        ]);
+
+        // NEXT_MAJOR: Remove this when dropping support for SF 2.8
+        if (method_exists(FormTypeInterface::class, 'setDefaultOptions')) {
+            $resolver->setDefault('choices_as_values', true);
+        }
+    }
 }

--- a/src/Resources/config/form.xml
+++ b/src/Resources/config/form.xml
@@ -2,7 +2,6 @@
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <service id="sonata.user.form.gender_list" class="Sonata\UserBundle\Form\Type\UserGenderListType">
-            <deprecated>The "%service_id%" service is deprecated since 4.1 and will be removed in 5.0.</deprecated>
             <argument>%fos_user.model.user.class%</argument>
             <argument>getGenderList</argument>
             <argument>Sonata\UserBundle\Form\Type\UserGenderListType</argument>

--- a/tests/Form/Type/UserGenderListTypeTest.php
+++ b/tests/Form/Type/UserGenderListTypeTest.php
@@ -14,25 +14,42 @@ declare(strict_types=1);
 namespace Sonata\UserBundle\Tests\Form\Type;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\BlockBundle\Util\OptionsResolver;
 use Sonata\UserBundle\Entity\BaseUser;
 use Sonata\UserBundle\Form\Type\UserGenderListType;
+use Sonata\UserBundle\Model\UserInterface;
+use Symfony\Component\Form\FormTypeInterface;
 
 /**
  * @author Jordi Sala <jordism91@gmail.com>
  */
 final class UserGenderListTypeTest extends TestCase
 {
-    /**
-     * @group legacy
-     */
-    public function testDeprecatedUserGenderListType(): void
+    public function testChoices(): void
     {
-        $userGenderListType = new UserGenderListType(
+        $type = new UserGenderListType(
             BaseUser::class,
-            'getGenderLists',
+            'getGenderList',
             UserGenderListType::class
         );
 
-        $this->assertNotNull($userGenderListType);
+        $resolver = new OptionsResolver();
+
+        $type->configureOptions($resolver);
+
+        $choices = [
+            'gender_unknown' => UserInterface::GENDER_UNKNOWN,
+            'gender_female' => UserInterface::GENDER_FEMALE,
+            'gender_male' => UserInterface::GENDER_MALE,
+        ];
+
+        // NEXT_MAJOR: Remove this when dropping support for SF 2.8
+        if (method_exists(FormTypeInterface::class, 'setDefaultOptions')) {
+            $choices = array_flip($choices);
+        }
+
+        $options = $resolver->resolve();
+
+        $this->assertEquals($choices, $options['choices']);
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/4.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- choices for User gender now appears correctly flipped and translated
```

## Subject

This is a bugfix for #1007, so the `UserGenderListType` will work again in symfony 3.x.
