### PR TITLE
Remove support for FOSRest <2.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "symfony/translation": "^2.8 || ^3.2 || ^4.0"
     },
     "conflict": {
-        "friendsofsymfony/rest-bundle": "<1.1",
+        "friendsofsymfony/rest-bundle": "<2.1 || >=3.0",
         "jms/serializer": "<0.13 || >=2.0",
         "nelmio/api-doc-bundle": "<2.4",
         "sonata-project/block-bundle": "<3.11",
@@ -52,8 +52,8 @@
     },
     "require-dev": {
         "doctrine/orm": "^2.0",
-        "friendsofsymfony/rest-bundle": "^1.5 || ^2.0",
-        "jms/serializer-bundle": "^0.13 || ^1.0",
+        "friendsofsymfony/rest-bundle": "^2.1",
+        "jms/serializer-bundle": "^1.0 || ^2.0",
         "matthiasnoback/symfony-config-test": "^2.1",
         "matthiasnoback/symfony-dependency-injection-test": "^1.1",
         "nelmio/api-doc-bundle": "^2.4",

--- a/src/Controller/Api/UserController.php
+++ b/src/Controller/Api/UserController.php
@@ -19,7 +19,6 @@ use FOS\RestBundle\Controller\Annotations\View;
 use FOS\RestBundle\Request\ParamFetcherInterface;
 use FOS\RestBundle\View\View as FOSRestView;
 use FOS\UserBundle\Model\GroupInterface;
-use JMS\Serializer\SerializationContext;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 use Sonata\DatagridBundle\Pager\PagerInterface;
 use Sonata\UserBundle\Model\GroupManagerInterface;
@@ -72,6 +71,7 @@ class UserController
      *
      * @QueryParam(name="page", requirements="\d+", default="1", description="Page for users list pagination (1-indexed)")
      * @QueryParam(name="count", requirements="\d+", default="10", description="Number of users by page")
+     * @QueryParam(name="orderBy", map=true, requirements="ASC|DESC", nullable=true, strict=true, description="Query users order by clause (key is field, value is direction")
      * @QueryParam(name="enabled", requirements="0|1", nullable=true, strict=true, description="Enabled/disabled users only?")
      *
      * @View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
@@ -82,20 +82,6 @@ class UserController
      */
     public function getUsersAction(ParamFetcherInterface $paramFetcher)
     {
-        $orderByQueryParam = new QueryParam();
-        $orderByQueryParam->name = 'orderBy';
-        $orderByQueryParam->requirements = 'ASC|DESC';
-        $orderByQueryParam->nullable = true;
-        $orderByQueryParam->strict = true;
-        $orderByQueryParam->description = 'Query users order by clause (key is field, value is direction)';
-        if (property_exists($orderByQueryParam, 'map')) {
-            $orderByQueryParam->map = true;
-        } else {
-            $orderByQueryParam->array = true;
-        }
-
-        $paramFetcher->addParam($orderByQueryParam);
-
         $supporedCriteria = [
             'enabled' => '',
         ];
@@ -369,18 +355,12 @@ class UserController
             $user = $form->getData();
             $this->userManager->updateUser($user);
 
-            $view = FOSRestView::create($user);
+            $context = new Context();
+            $context->setGroups(['sonata_api_read']);
+            $context->enableMaxDepth();
 
-            if (class_exists('FOS\RestBundle\Context\Context')) {
-                $context = new Context();
-                $context->setGroups(['sonata_api_read']);
-                $view->setContext($context);
-            } else {
-                $serializationContext = SerializationContext::create();
-                $serializationContext->setGroups(['sonata_api_read']);
-                $serializationContext->enableMaxDepthChecks();
-                $view->setSerializationContext($serializationContext);
-            }
+            $view = FOSRestView::create($user);
+            $view->setContext($context);
 
             return $view;
         }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataMediaBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Removed compatibility with older versions of FOSRestBundle (<2.1)
```

## Subject

<!-- Describe your Pull Request content here -->
Since dropping a dependency is not a BC break, this is a good start, because we are doing a lot of code just to keep compat with FOSRest 1.

FOSUserBundle is the only one blocking SF 4 here now.