### PR TITLE
Fix locale orm db field length

### DIFF
--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -8,3 +8,7 @@ All the deprecated code introduced on 4.x is removed on 5.0.
 Please read [4.x](https://github.com/sonata-project/SonataUserBundle/tree/4.x) upgrade guides for more information.
 
 See also the [diff code](https://github.com/sonata-project/SonataUserBundle/compare/4.x...5.0.0).
+
+## BaseUser DB structure
+
+The locale field definition changed. Please make sure you run your migrations.

--- a/src/Resources/config/doctrine/BaseUser.orm.xml
+++ b/src/Resources/config/doctrine/BaseUser.orm.xml
@@ -10,7 +10,7 @@
         <field name="website" type="string" column="website" length="64" nullable="true"/>
         <field name="biography" type="string" column="biography" length="1000" nullable="true"/>
         <field name="gender" type="string" column="gender" length="1" nullable="true"/>
-        <field name="locale" type="string" column="locale" length="8" nullable="true"/>
+        <field name="locale" type="string" column="locale" length="15" nullable="true"/>
         <field name="timezone" type="string" column="timezone" length="64" nullable="true"/>
         <field name="phone" type="string" column="phone" length="64" nullable="true"/>
         <!-- social fields -->


### PR DESCRIPTION
I am targeting this branch, because it fixes the locale db field length and it's considered as a BC break.

## Changelog
```markdown
### Fixed
 - Fixed locale db field length
```
## Subject
When we try to create a user with the 'sr_Latn_RS' it fails due to the locale db field length.
