### PR TITLE
Add missing french translation

### DIFF
--- a/src/Resources/translations/SonataUserBundle.en.xliff
+++ b/src/Resources/translations/SonataUserBundle.en.xliff
@@ -246,6 +246,10 @@
                 <source>Management</source>
                 <target>Management</target>
             </trans-unit>
+            <trans-unit id="form_status">
+                <source>Status</source>
+                <target>Status</target>
+            </trans-unit>
             <trans-unit id="field.label_roles_editable">
                 <source>field.label_roles_editable</source>
                 <target>Roles</target>

--- a/src/Resources/translations/SonataUserBundle.fr.xliff
+++ b/src/Resources/translations/SonataUserBundle.fr.xliff
@@ -250,6 +250,10 @@
                 <source>Security</source>
                 <target>Sécurité</target>
             </trans-unit>
+            <trans-unit id="form_status">
+                <source>Status</source>
+                <target>Statut</target>
+            </trans-unit>
             <trans-unit id="field.label_roles_editable">
                 <source>field.label_roles_editable</source>
                 <target>Rôles</target>


### PR DESCRIPTION
I am targeting this branch, because It fixes a missing french translation.

## Changelog

```markdown
### Fixed
 - Fixed missing french translation
```