### PR TITLE
Removed redundant "required" asterisk

### DIFF
--- a/src/Resources/views/Resetting/request_content.html.twig
+++ b/src/Resources/views/Resetting/request_content.html.twig
@@ -15,7 +15,7 @@ file that was distributed with this source code.
     {% endif %}
 
     <div class="form-group">
-        <label for="username" class="control-label required">{{ 'resetting.request.username'|trans({}, 'FOSUserBundle') }} * </label>
+        <label for="username" class="control-label required">{{ 'resetting.request.username'|trans({}, 'FOSUserBundle') }}</label>
         <input type="text" id="username" name="username" required="required" />
     </div>
 


### PR DESCRIPTION
## Changelog

```markdown

### Changed
- Removed redundant "required" asterisk
```

## Subject

The label contains two asterisks: One hard-coded and one from the class "required", which includes an asterisk in the :after.

