### PR TITLE
fix #1028 - Fixed getGenderList method not being available for mongodb installations

### DIFF
--- a/src/Entity/BaseUser.php
+++ b/src/Entity/BaseUser.php
@@ -37,18 +37,4 @@ class BaseUser extends AbstractedUser
     {
         $this->updatedAt = new \DateTime();
     }
-
-    /**
-     * Returns the gender list.
-     *
-     * @return array
-     */
-    public static function getGenderList()
-    {
-        return [
-            'gender_unknown' => UserInterface::GENDER_UNKNOWN,
-            'gender_female' => UserInterface::GENDER_FEMALE,
-            'gender_male' => UserInterface::GENDER_MALE,
-        ];
-    }
 }

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -573,4 +573,18 @@ abstract class User extends AbstractedUser implements UserInterface
 
         return $this;
     }
+
+    /**
+     * Returns the gender list.
+     *
+     * @return array
+     */
+    public static function getGenderList()
+    {
+        return [
+            'gender_unknown' => UserInterface::GENDER_UNKNOWN,
+            'gender_female' => UserInterface::GENDER_FEMALE,
+            'gender_male' => UserInterface::GENDER_MALE,
+        ];
+    }
 }


### PR DESCRIPTION
…

I am targeting this branch because this is a fix.

Closes #1028

## Changelog

```markdown
### Added
- Added `getGenderList` method to `Sonata\UserBundle\Model\User` and removed the one in `Sonata\UserBundle\Entity\BaseUser`
```

## Subject

Moved the `getGenderList` method so that it can be accessible in both mongodb installs and orm installs. 
