### PR TITLE
Change public status of sonata_security_roles

### DIFF
--- a/src/Resources/config/admin.xml
+++ b/src/Resources/config/admin.xml
@@ -10,7 +10,7 @@
                 <argument type="service" id="translator"/>
             </call>
         </service>
-        <service id="sonata.user.form.type.security_roles" class="Sonata\UserBundle\Form\Type\SecurityRolesType" public="false">
+        <service id="sonata.user.form.type.security_roles" class="Sonata\UserBundle\Form\Type\SecurityRolesType" public="true">
             <tag name="form.type" alias="sonata_security_roles"/>
             <argument type="service" id="sonata.user.editable_role_builder"/>
         </service>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/4.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because i want to close #1030 .

## Changelog
```markdown
### Fixed
- `sonata.user.form.type.security_roles` form type needs to public, as it is lazy loaded
```