### PR TITLE
fix/roles-matrix-type #1027

### DIFF
--- a/src/Resources/config/admin.xml
+++ b/src/Resources/config/admin.xml
@@ -34,5 +34,9 @@
             <tag name="form.type"/>
             <argument type="service" id="sonata.user.matrix_roles_builder"/>
         </service>
+        <service id="sonata.user.roles_matrix_extension" class="Sonata\UserBundle\Twig\RolesMatrixExtension" public="false">
+            <argument type="service" id="sonata.user.matrix_roles_builder"/>
+            <tag name="twig.extension"/>
+        </service>
     </services>
 </container>

--- a/src/Resources/config/twig.xml
+++ b/src/Resources/config/twig.xml
@@ -4,9 +4,5 @@
         <service id="sonata.user.twig.global" class="Sonata\UserBundle\Twig\GlobalVariables" public="false">
             <argument type="service" id="service_container"/>
         </service>
-        <service id="sonata.user.roles_matrix_extension" class="Sonata\UserBundle\Twig\RolesMatrixExtension" public="false">
-            <argument type="service" id="sonata.user.matrix_roles_builder"/>
-            <tag name="twig.extension"/>
-        </service>
     </services>
 </container>


### PR DESCRIPTION
I am targeting this branch, because this is BC

Closes #1027
## Changelog

```markdown
### Fixed
- load `Sonata\UserBundle\Twig\RolesMatrixExtension` only if UserBundle is used
```