### PR TITLE
fix(authenticator): fix namespace from sonata-project/GoogleAuthenticator

### DIFF
--- a/src/DependencyInjection/SonataUserExtension.php
+++ b/src/DependencyInjection/SonataUserExtension.php
@@ -67,6 +67,14 @@ class SonataUserExtension extends Extension implements PrependExtensionInterface
         $loader->load('form.xml');
 
         if (class_exists('Google\Authenticator\GoogleAuthenticator')) {
+            @trigger_error(
+                'The \'Google\Authenticator\' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.',
+                E_USER_DEPRECATED
+            );
+        }
+
+        if (class_exists('Google\Authenticator\GoogleAuthenticator') ||
+            class_exists('Sonata\GoogleAuthenticator\GoogleAuthenticator')) {
             $loader->load('google_authenticator.xml');
         }
 
@@ -156,7 +164,8 @@ class SonataUserExtension extends Extension implements PrependExtensionInterface
             return;
         }
 
-        if (!class_exists('Google\Authenticator\GoogleAuthenticator')) {
+        if (!class_exists('Google\Authenticator\GoogleAuthenticator')
+            && !class_exists('Sonata\GoogleAuthenticator\GoogleAuthenticator')) {
             throw new \RuntimeException('Please add ``sonata-project/google-authenticator`` package');
         }
 

--- a/tests/DependencyInjection/SonataUserExtensionTest.php
+++ b/tests/DependencyInjection/SonataUserExtensionTest.php
@@ -36,6 +36,10 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
         $this->setParameter('kernel.bundles', ['SonataAdminBundle' => true]);
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
+     */
     public function testLoadDefault(): void
     {
         $this->load();
@@ -73,6 +77,10 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
         }
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
+     */
     public function testTwigConfigParameterIsSet(): void
     {
         $fakeTwigExtension = $this->getMockBuilder(TwigExtension::class)
@@ -97,6 +105,10 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
         );
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
+     */
     public function testTwigConfigParameterIsNotSet(): void
     {
         $this->load();
@@ -106,21 +118,37 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
         $this->assertArrayNotHasKey(0, $twigConfigurations);
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
+     */
     public function testCorrectModelClass(): void
     {
         $this->load(['class' => ['user' => 'Sonata\UserBundle\Tests\Entity\User']]);
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
+     */
     public function testCorrectModelClassWithLeadingSlash(): void
     {
         $this->load(['class' => ['user' => '\Sonata\UserBundle\Tests\Entity\User']]);
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
+     */
     public function testCorrectAdminClass(): void
     {
         $this->load(['admin' => ['user' => ['class' => '\Sonata\UserBundle\Tests\Admin\Entity\UserAdmin']]]);
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
+     */
     public function testCorrectModelClassWithNotDefaultManagerType(): void
     {
         $this->load([
@@ -136,6 +164,10 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
         ]);
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
+     */
     public function testIncorrectModelClass(): void
     {
         $this->expectException('InvalidArgumentException');
@@ -145,6 +177,10 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
         $this->load(['class' => ['user' => 'Foo\User']]);
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
+     */
     public function testNotCorrespondingModelClass(): void
     {
         $this->expectException('InvalidArgumentException');
@@ -154,6 +190,40 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
         );
 
         $this->load(['manager_type' => 'mongodb', 'class' => ['user' => 'Sonata\UserBundle\Admin\Entity\UserAdmin']]);
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
+     */
+    public function testConfigureGoogleAuthenticatorDisabled(): void
+    {
+        $this->load(['google_authenticator' => ['enabled' => false]]);
+
+        $this->assertContainerBuilderHasParameter('sonata.user.google.authenticator.enabled', false);
+        $this->assertContainerBuilderNotHasService('sonata.user.google.authenticator');
+        $this->assertContainerBuilderNotHasService('sonata.user.google.authenticator.provider');
+        $this->assertContainerBuilderNotHasService('sonata.user.google.authenticator.interactive_login_listener');
+        $this->assertContainerBuilderNotHasService('sonata.user.google.authenticator.request_listener');
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
+     */
+    public function testConfigureGoogleAuthenticatorEnabled(): void
+    {
+        $this->load(['google_authenticator' => ['enabled' => true, 'forced_for_role' => ['ROLE_USER'], 'ip_white_list' => ['0.0.0.1'],
+                                                'server' => 'bar', ]]);
+
+        $this->assertContainerBuilderHasParameter('sonata.user.google.authenticator.enabled', true);
+        $this->assertContainerBuilderHasService('sonata.user.google.authenticator');
+        $this->assertContainerBuilderHasService('sonata.user.google.authenticator.provider');
+        $this->assertContainerBuilderHasService('sonata.user.google.authenticator.interactive_login_listener');
+        $this->assertContainerBuilderHasService('sonata.user.google.authenticator.request_listener');
+        $this->assertContainerBuilderHasParameter('sonata.user.google.authenticator.forced_for_role', ['ROLE_ADMIN', 'ROLE_USER']);
+        $this->assertContainerBuilderHasParameter('sonata.user.google.authenticator.ip_white_list', ['127.0.0.1', '0.0.0.1']);
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('sonata.user.google.authenticator.provider', 0, 'bar');
     }
 
     /**


### PR DESCRIPTION
I am targeting this branch, because i don't think it has BC break (i'm not sure because of https://github.com/sonata-project/SonataUserBundle/blob/e0eb6e0c7290f93b5e3ef850483233f7e957c454/composer.json#L61).

## Changelog
```markdown
### Fixed
Replace deprecated use of Google\Authenticator\GoogleAuthenticator by Sonata's namespace
```

## Subject
Calls to Google\Authenticator\GoogleAuthenticator raised errors when using composer with --classmap-authoritative option. 
Not completely sure but it might conflict with version 1 of sonata-project/google-authenticator as this namespace was only introduced in v2 (https://github.com/sonata-project/GoogleAuthenticator/commit/a339606c1ca9e8700ad74e91a8f9ff09bfa526db)
