### PR TITLE
Fix google authenticator uses

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,6 @@
         "nelmio/api-doc-bundle": "<2.4",
         "sonata-project/block-bundle": "<3.11",
         "sonata-project/doctrine-orm-admin-bundle": "<3.0",
-        "sonata-project/google-authenticator": "<1.0",
         "sonata-project/seo-bundle": "<2.0"
     },
     "require-dev": {
@@ -58,7 +57,7 @@
         "matthiasnoback/symfony-dependency-injection-test": "^1.1",
         "nelmio/api-doc-bundle": "^2.4",
         "sonata-project/block-bundle": "^3.11",
-        "sonata-project/google-authenticator": "^1.0 || ^2.0",
+        "sonata-project/google-authenticator": "^2.1",
         "sonata-project/seo-bundle": "^2.0",
         "symfony/phpunit-bridge": "^4.0"
     },

--- a/src/DependencyInjection/SonataUserExtension.php
+++ b/src/DependencyInjection/SonataUserExtension.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\UserBundle\DependencyInjection;
 
 use Sonata\EasyExtendsBundle\Mapper\DoctrineCollector;
+use Sonata\GoogleAuthenticator\GoogleAuthenticator;
 use Sonata\UserBundle\Document\BaseGroup as DocumentGroup;
 use Sonata\UserBundle\Document\BaseUser as DocumentUser;
 use Sonata\UserBundle\Entity\BaseGroup as EntityGroup;
@@ -66,15 +67,7 @@ class SonataUserExtension extends Extension implements PrependExtensionInterface
 
         $loader->load('form.xml');
 
-        if (class_exists('Google\Authenticator\GoogleAuthenticator')) {
-            @trigger_error(
-                'The \'Google\Authenticator\' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.',
-                E_USER_DEPRECATED
-            );
-        }
-
-        if (class_exists('Google\Authenticator\GoogleAuthenticator') ||
-            class_exists('Sonata\GoogleAuthenticator\GoogleAuthenticator')) {
+        if (class_exists(GoogleAuthenticator::class)) {
             $loader->load('google_authenticator.xml');
         }
 
@@ -164,8 +157,7 @@ class SonataUserExtension extends Extension implements PrependExtensionInterface
             return;
         }
 
-        if (!class_exists('Google\Authenticator\GoogleAuthenticator')
-            && !class_exists('Sonata\GoogleAuthenticator\GoogleAuthenticator')) {
+        if (!class_exists(GoogleAuthenticator::class)) {
             throw new \RuntimeException('Please add ``sonata-project/google-authenticator`` package');
         }
 

--- a/src/EventListener/TwoFactorLoginSuccessHandler.php
+++ b/src/EventListener/TwoFactorLoginSuccessHandler.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\UserBundle\EventListener;
 
+use Sonata\GoogleAuthenticator\GoogleQrUrl;
 use Sonata\UserBundle\GoogleAuthenticator\Helper;
 use Sonata\UserBundle\Model\User;
 use Sonata\UserBundle\Model\UserManagerInterface;
@@ -70,7 +71,7 @@ final class TwoFactorLoginSuccessHandler implements AuthenticationSuccessHandler
             $secret = $this->googleAuthenticator->generateSecret();
             $user->setTwoStepVerificationCode($secret);
 
-            $qrCodeUrl = $this->googleAuthenticator->getUrl($user);
+            $qrCodeUrl = GoogleQrUrl::generate($user->getUsername(), $secret);
             $this->userManager->updateUser($user);
 
             return $this->engine->renderResponse(

--- a/src/GoogleAuthenticator/Helper.php
+++ b/src/GoogleAuthenticator/Helper.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\UserBundle\GoogleAuthenticator;
 
-use Google\Authenticator\GoogleAuthenticator as BaseGoogleAuthenticator;
+use Sonata\GoogleAuthenticator\GoogleAuthenticator as BaseGoogleAuthenticator;
 use Sonata\UserBundle\Model\UserInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;

--- a/src/Resources/config/google_authenticator.xml
+++ b/src/Resources/config/google_authenticator.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="sonata.user.google.authenticator" class="Google\Authenticator\GoogleAuthenticator">
+        <service id="sonata.user.google.authenticator" class="Sonata\GoogleAuthenticator\GoogleAuthenticator">
 
         </service>
         <service id="sonata.user.google.authenticator.provider" class="Sonata\UserBundle\GoogleAuthenticator\Helper">

--- a/tests/DependencyInjection/SonataUserExtensionTest.php
+++ b/tests/DependencyInjection/SonataUserExtensionTest.php
@@ -36,10 +36,6 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
         $this->setParameter('kernel.bundles', ['SonataAdminBundle' => true]);
     }
 
-    /**
-     * @group legacy
-     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
-     */
     public function testLoadDefault(): void
     {
         $this->load();
@@ -53,6 +49,31 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
             'sonata.user.group_manager',
             'sonata.user.orm.group_manager'
         );
+    }
+
+    public function testFixImpersonatingWithWrongConfig(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('you can\'t have `impersonating` and `impersonating_route` keys defined at the same time');
+
+        $this->load(['impersonating' => ['route' => 'foo'], 'impersonating_route' => 'bar']);
+    }
+
+    /**
+     * @dataProvider fixImpersonatingDataProvider
+     */
+    public function testFixImpersonatingWithImpersonatingConfig(array $expectedConfig, array $providedConfig): void
+    {
+        $extension = new SonataUserExtension();
+
+        $this->assertSame($expectedConfig, $extension->fixImpersonating($providedConfig));
+    }
+
+    public function fixImpersonatingDataProvider(): \Generator
+    {
+        yield 'with impersonating with route' => [['impersonating' => ['route' => 'foo', 'parameters' => []]], ['impersonating' => ['route' => 'foo', 'parameters' => []]]];
+        yield 'with impersonating without route' => [['impersonating' => false], ['impersonating' => ['parameters' => []]]];
+        yield 'with impersonating_route' => [['impersonating_route' => 'foo', 'impersonating' => ['route' => 'foo', 'parameters' => []]], ['impersonating_route' => 'foo']];
     }
 
     public function testTwigConfigParameterIsSetting(): void
@@ -77,10 +98,6 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
         }
     }
 
-    /**
-     * @group legacy
-     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
-     */
     public function testTwigConfigParameterIsSet(): void
     {
         $fakeTwigExtension = $this->getMockBuilder(TwigExtension::class)
@@ -105,10 +122,6 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
         );
     }
 
-    /**
-     * @group legacy
-     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
-     */
     public function testTwigConfigParameterIsNotSet(): void
     {
         $this->load();
@@ -118,37 +131,21 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
         $this->assertArrayNotHasKey(0, $twigConfigurations);
     }
 
-    /**
-     * @group legacy
-     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
-     */
     public function testCorrectModelClass(): void
     {
         $this->load(['class' => ['user' => 'Sonata\UserBundle\Tests\Entity\User']]);
     }
 
-    /**
-     * @group legacy
-     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
-     */
     public function testCorrectModelClassWithLeadingSlash(): void
     {
         $this->load(['class' => ['user' => '\Sonata\UserBundle\Tests\Entity\User']]);
     }
 
-    /**
-     * @group legacy
-     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
-     */
     public function testCorrectAdminClass(): void
     {
         $this->load(['admin' => ['user' => ['class' => '\Sonata\UserBundle\Tests\Admin\Entity\UserAdmin']]]);
     }
 
-    /**
-     * @group legacy
-     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
-     */
     public function testCorrectModelClassWithNotDefaultManagerType(): void
     {
         $this->load([
@@ -164,10 +161,6 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
         ]);
     }
 
-    /**
-     * @group legacy
-     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
-     */
     public function testIncorrectModelClass(): void
     {
         $this->expectException('InvalidArgumentException');
@@ -177,10 +170,6 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
         $this->load(['class' => ['user' => 'Foo\User']]);
     }
 
-    /**
-     * @group legacy
-     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
-     */
     public function testNotCorrespondingModelClass(): void
     {
         $this->expectException('InvalidArgumentException');
@@ -192,10 +181,6 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
         $this->load(['manager_type' => 'mongodb', 'class' => ['user' => 'Sonata\UserBundle\Admin\Entity\UserAdmin']]);
     }
 
-    /**
-     * @group legacy
-     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
-     */
     public function testConfigureGoogleAuthenticatorDisabled(): void
     {
         $this->load(['google_authenticator' => ['enabled' => false]]);
@@ -207,10 +192,6 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderNotHasService('sonata.user.google.authenticator.request_listener');
     }
 
-    /**
-     * @group legacy
-     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
-     */
     public function testConfigureGoogleAuthenticatorEnabled(): void
     {
         $this->load(['google_authenticator' => ['enabled' => true, 'forced_for_role' => ['ROLE_USER'], 'ip_white_list' => ['0.0.0.1'],

--- a/tests/EventListener/TwoFactorLoginSuccessHandlerTest.php
+++ b/tests/EventListener/TwoFactorLoginSuccessHandlerTest.php
@@ -11,8 +11,8 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-use Google\Authenticator\GoogleAuthenticator;
 use PHPUnit\Framework\TestCase;
+use Sonata\GoogleAuthenticator\GoogleAuthenticator;
 use Sonata\UserBundle\Entity\BaseUser;
 use Sonata\UserBundle\EventListener\TwoFactorLoginSuccessHandler;
 use Sonata\UserBundle\GoogleAuthenticator\Helper;
@@ -86,7 +86,7 @@ class TwoFactorLoginSuccessHandlerTest extends TestCase
 
     private function createTestClass(string $secret, string $userRole, string $remoteAddr, bool $needSession): void
     {
-        $this->user = new BaseUser();
+        $this->user = (new BaseUser())->setUsername('username');
         if ($secret) {
             $this->user->setTwoStepVerificationCode($secret);
         }


### PR DESCRIPTION
I am targeting this branch, because it is BC break. It is the following of https://github.com/sonata-project/SonataUserBundle/pull/1038

## Changelog

```markdown
### Changed
- Upgrade requirement of sonata-project/google-authenticator to 2.1
```

## Subject

Upgrading sonata-project/google-authenticator dependency to 2.1 and change namespace uses of GoogleAuthenticator
