### PR TITLE
Add invalid_username in response when username not found in sendEmailAction

### DIFF
--- a/src/Controller/AdminResettingController.php
+++ b/src/Controller/AdminResettingController.php
@@ -55,9 +55,11 @@ class AdminResettingController extends Controller
         $user = $userManager->findUserByUsernameOrEmail($username);
 
         if (null === $user) {
+            $sonataAdminPool = $this->get('sonata.admin.pool');
+
             return $this->render('@SonataUser/Admin/Security/Resetting/request.html.twig', [
-                'base_template' => $this->get('sonata.admin.pool')->getTemplate('layout'),
-                'admin_pool' => $this->get('sonata.admin.pool'),
+                'base_template' => $sonataAdminPool->getTemplate('layout'),
+                'admin_pool' => $sonataAdminPool,
                 'invalid_username' => $username,
             ]);
         }

--- a/src/Controller/AdminResettingController.php
+++ b/src/Controller/AdminResettingController.php
@@ -54,6 +54,14 @@ class AdminResettingController extends Controller
 
         $user = $userManager->findUserByUsernameOrEmail($username);
 
+        if (null === $user) {
+            return $this->render('@SonataUser/Admin/Security/Resetting/request.html.twig', [
+                'base_template' => $this->get('sonata.admin.pool')->getTemplate('layout'),
+                'admin_pool' => $this->get('sonata.admin.pool'),
+                'invalid_username' => $username,
+            ]);
+        }
+
         $ttl = $this->container->getParameter('fos_user.resetting.retry_ttl');
 
         if (null !== $user && !$user->isPasswordRequestNonExpired($ttl)) {

--- a/tests/Controller/AdminResettingControllerTest.php
+++ b/tests/Controller/AdminResettingControllerTest.php
@@ -21,6 +21,7 @@ use Symfony\Bundle\TwigBundle\TwigEngine;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Kernel;
 
 class AdminResettingControllerTest extends TestCase
 {
@@ -37,10 +38,10 @@ class AdminResettingControllerTest extends TestCase
     protected function setUp(): void
     {
         $this->controller = new AdminResettingController();
-        $this->container = $this->getMockBuilder(ContainerBuilder::class)->getMock();
-        $this->twig = $this->getMockBuilder(TwigEngine::class)->disableOriginalConstructor()->getMock();
-        $this->userManager = $this->getMockBuilder(UserManager::class)->disableOriginalConstructor()->getMock();
-        $this->adminPool = $this->getMockBuilder(Pool::class)->disableOriginalConstructor()->getMock();
+        $this->container = $this->createMock(ContainerBuilder::class);
+        $this->twig = $this->createMock(TwigEngine::class);
+        $this->userManager = $this->createMock(UserManager::class);
+        $this->adminPool = $this->createMock(Pool::class);
     }
 
     public function testItIsInstantiable(): void
@@ -86,7 +87,7 @@ class AdminResettingControllerTest extends TestCase
             ->willReturn($this->twig);
 
         $this->twig->expects($this->once())
-            ->method('render')
+            ->method(Kernel::VERSION_ID < 30000 ? 'renderResponse' : 'render')
             ->with('@SonataUser/Admin/Security/Resetting/request.html.twig', [
                 'base_template' => '@SonataAdmin/standard_layout.html.twig',
                 'admin_pool' => $this->adminPool,


### PR DESCRIPTION
## Changelog

```markdown
### Fixed
 - A case when user was not found in sendEmailAction
```
## Subject
On reset password, in case the user does not exist, then the controller will not work as expected. To fix it I add a test on `$user` variable and render the original template with `invalid_username` defined.
