### PR TITLE
Add configurable mailer

### DIFF
--- a/docs/reference/advanced_configuration.rst
+++ b/docs/reference/advanced_configuration.rst
@@ -53,6 +53,8 @@ Full configuration options:
         profile:
             default_avatar: 'bundles/sonatauser/default_avatar.png' # Default avatar displayed if the user doesn't have one
 
+        mailer: sonata.user.mailer.default # Service used to send emails
+
     # override FOSUser default serialization
     jms_serializer:
         metadata:

--- a/docs/reference/installation.rst
+++ b/docs/reference/installation.rst
@@ -166,6 +166,19 @@ Add these config lines to your FOSUserBundle configuration:
             address: "%mailer_user%"
             sender_name: "%mailer_user%"
 
+Mailer Configuration
+~~~~~~~~~~~~~~~~~~~~
+
+You can define a custom mailer to send reset password emails.
+Your mailer will have to implement ``FOS\UserBundle\Mailer\MailerInterface``.
+
+.. code-block:: yaml
+
+    # config/packages/sonata.yaml
+
+    sonata_user:
+        mailer: custom.mailer.service.id
+
 Integrating the bundle into the Sonata Admin Bundle
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -115,6 +115,7 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('default_avatar')->defaultValue('bundles/sonatauser/default_avatar.png')->end()
                     ->end()
                 ->end()
+                ->scalarNode('mailer')->defaultValue('sonata.user.mailer.default')->info('Custom mailer used to send reset password emails')->end()
             ->end()
         ;
 

--- a/src/DependencyInjection/SonataUserExtension.php
+++ b/src/DependencyInjection/SonataUserExtension.php
@@ -81,6 +81,7 @@ class SonataUserExtension extends Extension implements PrependExtensionInterface
         $loader->load('twig.xml');
         $loader->load('command.xml');
         $loader->load('actions.xml');
+        $loader->load('mailer.xml');
 
         if ('orm' === $config['manager_type'] && isset(
             $bundles['FOSRestBundle'],
@@ -105,6 +106,7 @@ class SonataUserExtension extends Extension implements PrependExtensionInterface
 
         $this->configureTranslationDomain($config, $container);
         $this->configureController($config, $container);
+        $this->configureMailer($config, $container);
 
         $container->setParameter('sonata.user.default_avatar', $config['profile']['default_avatar']);
 
@@ -114,8 +116,6 @@ class SonataUserExtension extends Extension implements PrependExtensionInterface
     }
 
     /**
-     * @param array $config
-     *
      * @throws \RuntimeException
      *
      * @return array
@@ -264,7 +264,7 @@ class SonataUserExtension extends Extension implements PrependExtensionInterface
      * Adds aliases for user & group managers depending on $managerType.
      *
      * @param ContainerBuilder $container
-     * @param                  $managerType
+     * @param string           $managerType
      */
     protected function aliasManagers(ContainerBuilder $container, $managerType): void
     {
@@ -276,9 +276,6 @@ class SonataUserExtension extends Extension implements PrependExtensionInterface
         $container->getAlias('sonata.user.group_manager')->setPublic(true);
     }
 
-    /**
-     * @param array $config
-     */
     private function checkManagerTypeToModelTypeMapping(array $config): void
     {
         $managerType = $config['manager_type'];
@@ -319,5 +316,10 @@ class SonataUserExtension extends Extension implements PrependExtensionInterface
                 );
             }
         }
+    }
+
+    private function configureMailer(array $config, ContainerBuilder $container): void
+    {
+        $container->setAlias('sonata.user.mailer', $config['mailer']);
     }
 }

--- a/src/Mailer/Mailer.php
+++ b/src/Mailer/Mailer.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Mailer;
+
+use FOS\UserBundle\Mailer\MailerInterface;
+use FOS\UserBundle\Model\UserInterface;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+final class Mailer implements MailerInterface
+{
+    /**
+     * @var UrlGeneratorInterface
+     */
+    private $urlGenerator;
+
+    /**
+     * @var EngineInterface
+     */
+    private $templating;
+
+    /**
+     * @var \Swift_Mailer
+     */
+    private $mailer;
+
+    /**
+     * @var array
+     */
+    private $fromEmail;
+
+    /**
+     * @var string
+     */
+    private $emailTemplate;
+
+    public function __construct(UrlGeneratorInterface $urlGenerator, EngineInterface $templating, \Swift_Mailer $mailer, array $fromEmail, string $emailTemplate)
+    {
+        $this->urlGenerator = $urlGenerator;
+        $this->templating = $templating;
+        $this->mailer = $mailer;
+        $this->fromEmail = $fromEmail;
+        $this->emailTemplate = $emailTemplate;
+    }
+
+    public function sendResettingEmailMessage(UserInterface $user): void
+    {
+        $url = $this->urlGenerator->generate('sonata_user_admin_resetting_reset', [
+            'token' => $user->getConfirmationToken(),
+        ], UrlGeneratorInterface::ABSOLUTE_URL);
+
+        $rendered = $this->templating->render($this->emailTemplate, [
+            'user' => $user,
+            'confirmationUrl' => $url,
+        ]);
+
+        // Render the email, use the first line as the subject, and the rest as the body
+        $renderedLines = explode(PHP_EOL, trim($rendered));
+        $subject = array_shift($renderedLines);
+        $body = implode(PHP_EOL, $renderedLines);
+        $message = (new \Swift_Message())
+            ->setSubject($subject)
+            ->setFrom($this->fromEmail)
+            ->setTo((string) $user->getEmail())
+            ->setBody($body);
+
+        $this->mailer->send($message);
+    }
+
+    public function sendConfirmationEmailMessage(UserInterface $user): void
+    {
+        throw new \LogicException('This method is not implemented.');
+    }
+}

--- a/src/Resources/config/actions.xml
+++ b/src/Resources/config/actions.xml
@@ -15,11 +15,9 @@
             <argument type="service" id="sonata.admin.pool"/>
             <argument type="service" id="sonata.admin.global_template_registry"/>
             <argument type="service" id="fos_user.user_manager"/>
-            <argument type="service" id="mailer"/>
+            <argument type="service" id="sonata.user.mailer"/>
             <argument type="service" id="fos_user.util.token_generator"/>
             <argument>%fos_user.resetting.retry_ttl%</argument>
-            <argument>%fos_user.resetting.email.from_email%</argument>
-            <argument>%fos_user.resetting.email.template%</argument>
         </service>
         <service id="Sonata\UserBundle\Action\CheckEmailAction" class="Sonata\UserBundle\Action\CheckEmailAction" public="true">
             <argument type="service" id="templating"/>

--- a/src/Resources/config/mailer.xml
+++ b/src/Resources/config/mailer.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="sonata.user.mailer.default" class="Sonata\UserBundle\Mailer\Mailer">
+            <argument type="service" id="router"/>
+            <argument type="service" id="sonata.templating"/>
+            <argument type="service" id="mailer"/>
+            <argument>%fos_user.resetting.email.from_email%</argument>
+            <argument>%fos_user.resetting.email.template%</argument>
+        </service>
+    </services>
+</container>

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -60,6 +60,7 @@ class ConfigurationTest extends TestCase
             'profile' => [
                 'default_avatar' => 'bundles/sonatauser/default_avatar.png',
             ],
+            'mailer' => 'sonata.user.mailer.default',
         ]);
     }
 }

--- a/tests/DependencyInjection/SonataUserExtensionTest.php
+++ b/tests/DependencyInjection/SonataUserExtensionTest.php
@@ -227,6 +227,28 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
     }
 
     /**
+     * @group legacy
+     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
+     */
+    public function testMailerConfigParameterIfNotSet(): void
+    {
+        $this->load();
+
+        $this->assertContainerBuilderHasAlias('sonata.user.mailer', 'sonata.user.mailer.default');
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
+     */
+    public function testMailerConfigParameter(): void
+    {
+        $this->load(['mailer' => 'custom.mailer.service.id']);
+
+        $this->assertContainerBuilderHasAlias('sonata.user.mailer', 'custom.mailer.service.id');
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function getMinimalConfiguration()

--- a/tests/Mailer/MailerTest.php
+++ b/tests/Mailer/MailerTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Tests\DependencyInjection;
+
+use FOS\UserBundle\Model\UserInterface;
+use PHPUnit\Framework\TestCase;
+use Sonata\UserBundle\Mailer\Mailer;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\Routing\RouterInterface;
+
+class MailerTest extends TestCase
+{
+    /**
+     * @var RouterInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $router;
+
+    /**
+     * @var EngineInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $templating;
+
+    /**
+     * @var \Swift_Mailer|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $mailer;
+
+    /**
+     * @var array
+     */
+    private $emailFrom;
+
+    /**
+     * @var string
+     */
+    private $template;
+
+    public function setUp(): void
+    {
+        $this->router = $this->createMock(RouterInterface::class);
+        $this->templating = $this->createMock(EngineInterface::class);
+        $this->mailer = $this->createMock(\Swift_Mailer::class);
+        $this->emailFrom = ['noreply@sonata-project.org'];
+        $this->template = 'foo';
+    }
+
+    public function testSendConfirmationEmailMessage(): void
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('This method is not implemented.');
+
+        $user = $this->createMock(UserInterface::class);
+
+        $this->getMailer()->sendConfirmationEmailMessage($user);
+    }
+
+    public function testSendResettingEmailMessage(): void
+    {
+        $user = $this->createMock(UserInterface::class);
+        $user->expects($this->any())
+            ->method('getConfirmationToken')
+            ->willReturn('user-token');
+        $user->expects($this->any())
+            ->method('getEmail')
+            ->willReturn('user@sonata-project.org');
+
+        $this->router->expects($this->once())
+            ->method('generate')
+            ->with('sonata_user_admin_resetting_reset', ['token' => 'user-token'])
+            ->willReturn('/foo');
+
+        $this->templating->expects($this->once())
+            ->method('render')
+            ->with('foo', ['user' => $user, 'confirmationUrl' => '/foo'])
+            ->willReturn("Subject\nMail content");
+
+        $this->mailer->expects($this->once())
+            ->method('send')
+            ->willReturnCallback(function (\Swift_Message $message): void {
+                $this->assertEquals('Subject', $message->getSubject());
+                $this->assertEquals('Mail content', $message->getBody());
+                $this->assertArrayHasKey($this->emailFrom[0], $message->getFrom());
+                $this->assertArrayHasKey('user@sonata-project.org', $message->getTo());
+            });
+
+        $this->getMailer()->sendResettingEmailMessage($user);
+    }
+
+    private function getMailer(): Mailer
+    {
+        return new Mailer($this->router, $this->templating, $this->mailer, $this->emailFrom, $this->template);
+    }
+}


### PR DESCRIPTION
I am targeting this branch, because this is a new feature with no breaking change.

## Changelog

```markdown
### Added
- Added an optional `mailer` config option to use a custom mailer implementation
```
## Subject

By default, SonataUserBundle is using the `mailer` service to send the account password reset email and keep the email building logic in a controller private method. It makes it hard to use a custom implementation like using another mailer than the default one or updating the email creation process.

This PR adds a `Mailer` class implementing the FOS `MailerInterface` and doing the same things the `AdminResettingController` class was. This default class can be replaced by any other user service implementing the `MailerInterface` by setting corresponding service id uner the `mailer` config key:

```yaml
# config/package/sonata.yaml

sonata_user:
    mailer: custom.mailer.service.id
```
