### PR TITLE
Use invokable actions

### DIFF
--- a/src/Action/CheckEmailAction.php
+++ b/src/Action/CheckEmailAction.php
@@ -15,47 +15,63 @@ namespace Sonata\UserBundle\Action;
 
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
-final class CheckEmailAction extends Controller
+final class CheckEmailAction
 {
+    /**
+     * @var EngineInterface
+     */
+    private $templating;
+
+    /**
+     * @var UrlGeneratorInterface
+     */
+    private $urlGenerator;
+
     /**
      * @var Pool
      */
-    protected $adminPool;
+    private $adminPool;
 
     /**
      * @var TemplateRegistryInterface
      */
-    protected $templateRegistry;
+    private $templateRegistry;
 
     /**
      * @var int
      */
-    protected $resetTtl;
+    private $resetTtl;
 
     public function __construct(
+        EngineInterface $templating,
+        UrlGeneratorInterface $urlGenerator,
         Pool $adminPool,
         TemplateRegistryInterface $templateRegistry,
         int $resetTtl
     ) {
+        $this->templating = $templating;
+        $this->urlGenerator = $urlGenerator;
         $this->adminPool = $adminPool;
         $this->templateRegistry = $templateRegistry;
         $this->resetTtl = $resetTtl;
     }
 
-    public function __invoke(Request $request)
+    public function __invoke(Request $request): Response
     {
         $username = $request->query->get('username');
 
         if (empty($username)) {
             // the user does not come from the sendEmail action
-            return new RedirectResponse($this->generateUrl('sonata_user_admin_resetting_request'));
+            return new RedirectResponse($this->urlGenerator->generate('sonata_user_admin_resetting_request'));
         }
 
-        return $this->render('@SonataUser/Admin/Security/Resetting/checkEmail.html.twig', [
+        return $this->templating->renderResponse('@SonataUser/Admin/Security/Resetting/checkEmail.html.twig', [
             'base_template' => $this->templateRegistry->getTemplate('layout'),
             'admin_pool' => $this->adminPool,
             'tokenLifetime' => ceil($this->resetTtl / 3600),

--- a/src/Action/CheckEmailAction.php
+++ b/src/Action/CheckEmailAction.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Action;
+
+use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+final class CheckEmailAction extends Controller
+{
+    /**
+     * @var Pool
+     */
+    protected $adminPool;
+
+    /**
+     * @var TemplateRegistryInterface
+     */
+    protected $templateRegistry;
+
+    /**
+     * @var int
+     */
+    protected $resetTtl;
+
+    public function __construct(
+        Pool $adminPool,
+        TemplateRegistryInterface $templateRegistry,
+        int $resetTtl
+    ) {
+        $this->adminPool = $adminPool;
+        $this->templateRegistry = $templateRegistry;
+        $this->resetTtl = $resetTtl;
+    }
+
+    public function __invoke(Request $request)
+    {
+        $username = $request->query->get('username');
+
+        if (empty($username)) {
+            // the user does not come from the sendEmail action
+            return new RedirectResponse($this->generateUrl('sonata_user_admin_resetting_request'));
+        }
+
+        return $this->render('@SonataUser/Admin/Security/Resetting/checkEmail.html.twig', [
+            'base_template' => $this->templateRegistry->getTemplate('layout'),
+            'admin_pool' => $this->adminPool,
+            'tokenLifetime' => ceil($this->resetTtl / 3600),
+        ]);
+    }
+}

--- a/src/Action/CheckLoginAction.php
+++ b/src/Action/CheckLoginAction.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Action;
+
+final class CheckLoginAction
+{
+    public function __invoke(): void
+    {
+        throw new \RuntimeException('You must configure the check path to be handled by the firewall using form_login in your security firewall configuration.');
+    }
+}

--- a/src/Action/LoginAction.php
+++ b/src/Action/LoginAction.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Action;
+
+use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
+use Sonata\UserBundle\Model\UserInterface;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
+
+final class LoginAction
+{
+    /**
+     * @var EngineInterface
+     */
+    private $templating;
+
+    /**
+     * @var UrlGeneratorInterface
+     */
+    private $urlGenerator;
+
+    /**
+     * @var AuthorizationCheckerInterface
+     */
+    private $authorizationChecker;
+
+    /**
+     * @var Pool
+     */
+    private $adminPool;
+
+    /**
+     * @var TemplateRegistryInterface
+     */
+    private $templateRegistry;
+
+    /**
+     * @var TokenStorageInterface
+     */
+    private $tokenStorage;
+
+    /**
+     * @var Session
+     */
+    private $session;
+
+    /**
+     * @var CsrfTokenManagerInterface
+     */
+    private $csrfTokenManager;
+
+    public function __construct(
+        EngineInterface $templating,
+        UrlGeneratorInterface $urlGenerator,
+        AuthorizationCheckerInterface $authorizationChecker,
+        Pool $adminPool,
+        TemplateRegistryInterface $templateRegistry,
+        TokenStorageInterface $tokenStorage,
+        Session $session
+    ) {
+        $this->templating = $templating;
+        $this->urlGenerator = $urlGenerator;
+        $this->authorizationChecker = $authorizationChecker;
+        $this->adminPool = $adminPool;
+        $this->templateRegistry = $templateRegistry;
+        $this->tokenStorage = $tokenStorage;
+        $this->session = $session;
+    }
+
+    public function __invoke(Request $request): Response
+    {
+        if ($this->isAuthenticated()) {
+            $this->session->getFlashBag()->add('sonata_user_error', 'sonata_user_already_authenticated');
+
+            return new RedirectResponse($this->urlGenerator->generate('sonata_admin_dashboard'));
+        }
+
+        $session = $request->getSession();
+
+        $authErrorKey = Security::AUTHENTICATION_ERROR;
+
+        // get the error if any (works with forward and redirect -- see below)
+        if ($request->attributes->has($authErrorKey)) {
+            $error = $request->attributes->get($authErrorKey);
+        } elseif (null !== $session && $session->has($authErrorKey)) {
+            $error = $session->get($authErrorKey);
+            $session->remove($authErrorKey);
+        } else {
+            $error = null;
+        }
+
+        if (!$error instanceof AuthenticationException) {
+            $error = null; // The value does not come from the security component.
+        }
+
+        if ($this->authorizationChecker->isGranted('ROLE_ADMIN')) {
+            $refererUri = $request->server->get('HTTP_REFERER');
+            $url = $refererUri && $refererUri != $request->getUri() ? $refererUri : $this->urlGenerator->generate('sonata_admin_dashboard');
+
+            return new RedirectResponse($url);
+        }
+
+        $csrfToken = null;
+        if ($this->csrfTokenManager) {
+            $csrfToken = $this->csrfTokenManager->getToken('authenticate')->getValue();
+        }
+
+        return $this->templating->renderResponse('@SonataUser/Admin/Security/login.html.twig', [
+            'admin_pool' => $this->adminPool,
+            'base_template' => $this->templateRegistry->getTemplate('layout'),
+            'csrf_token' => $csrfToken,
+            'error' => $error,
+            'last_username' => (null === $session) ? '' : $session->get(Security::LAST_USERNAME),
+            'reset_route' => $this->urlGenerator->generate('sonata_user_admin_resetting_request'),
+        ]);
+    }
+
+    public function setCsrfTokenManager(CsrfTokenManagerInterface $csrfTokenManager): void
+    {
+        $this->csrfTokenManager = $csrfTokenManager;
+    }
+
+    private function isAuthenticated(): bool
+    {
+        $token = $this->tokenStorage->getToken();
+
+        if (!$token) {
+            return false;
+        }
+
+        $user = $token->getUser();
+
+        return $user instanceof UserInterface;
+    }
+}

--- a/src/Action/LogoutAction.php
+++ b/src/Action/LogoutAction.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Action;
+
+final class LogoutAction
+{
+    public function __invoke(): void
+    {
+        throw new \RuntimeException('You must activate the logout in your security firewall configuration.');
+    }
+}

--- a/src/Action/RequestAction.php
+++ b/src/Action/RequestAction.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Action;
+
+use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+
+final class RequestAction extends Controller
+{
+    /**
+     * @var AuthorizationCheckerInterface
+     */
+    protected $authorizationChecker;
+
+    /**
+     * @var RouterInterface
+     */
+    protected $router;
+
+    /**
+     * @var Pool
+     */
+    protected $adminPool;
+
+    /**
+     * @var TemplateRegistryInterface
+     */
+    protected $templateRegistry;
+
+    public function __construct(AuthorizationCheckerInterface $authorizationChecker, RouterInterface $router, Pool $adminPool, TemplateRegistryInterface $templateRegistry)
+    {
+        $this->authorizationChecker = $authorizationChecker;
+        $this->router = $router;
+        $this->adminPool = $adminPool;
+        $this->templateRegistry = $templateRegistry;
+    }
+
+    public function __invoke(Request $request)
+    {
+        if ($this->authorizationChecker->isGranted('IS_AUTHENTICATED_FULLY')) {
+            return new RedirectResponse($this->router->generate('sonata_admin_dashboard'));
+        }
+
+        return $this->render('@SonataUser/Admin/Security/Resetting/request.html.twig', [
+            'base_template' => $this->templateRegistry->getTemplate('layout'),
+            'admin_pool' => $this->adminPool,
+        ]);
+    }
+}

--- a/src/Action/RequestAction.php
+++ b/src/Action/RequestAction.php
@@ -15,49 +15,61 @@ namespace Sonata\UserBundle\Action;
 
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
-final class RequestAction extends Controller
+final class RequestAction
 {
+    /**
+     * @var EngineInterface
+     */
+    private $templating;
+
+    /**
+     * @var UrlGeneratorInterface
+     */
+    private $urlGenerator;
+
     /**
      * @var AuthorizationCheckerInterface
      */
-    protected $authorizationChecker;
-
-    /**
-     * @var RouterInterface
-     */
-    protected $router;
+    private $authorizationChecker;
 
     /**
      * @var Pool
      */
-    protected $adminPool;
+    private $adminPool;
 
     /**
      * @var TemplateRegistryInterface
      */
-    protected $templateRegistry;
+    private $templateRegistry;
 
-    public function __construct(AuthorizationCheckerInterface $authorizationChecker, RouterInterface $router, Pool $adminPool, TemplateRegistryInterface $templateRegistry)
-    {
+    public function __construct(
+        EngineInterface $templating,
+        UrlGeneratorInterface $urlGenerator,
+        AuthorizationCheckerInterface $authorizationChecker,
+        Pool $adminPool,
+        TemplateRegistryInterface $templateRegistry
+    ) {
+        $this->templating = $templating;
+        $this->urlGenerator = $urlGenerator;
         $this->authorizationChecker = $authorizationChecker;
-        $this->router = $router;
         $this->adminPool = $adminPool;
         $this->templateRegistry = $templateRegistry;
     }
 
-    public function __invoke(Request $request)
+    public function __invoke(Request $request): Response
     {
         if ($this->authorizationChecker->isGranted('IS_AUTHENTICATED_FULLY')) {
-            return new RedirectResponse($this->router->generate('sonata_admin_dashboard'));
+            return new RedirectResponse($this->urlGenerator->generate('sonata_admin_dashboard'));
         }
 
-        return $this->render('@SonataUser/Admin/Security/Resetting/request.html.twig', [
+        return $this->templating->renderResponse('@SonataUser/Admin/Security/Resetting/request.html.twig', [
             'base_template' => $this->templateRegistry->getTemplate('layout'),
             'admin_pool' => $this->adminPool,
         ]);

--- a/src/Action/ResetAction.php
+++ b/src/Action/ResetAction.php
@@ -147,7 +147,7 @@ final class ResetAction extends Controller
                     $this->getLogger()->warning(sprintf(
                         'Unable to login user %d after password reset',
                         $user->getId()
-                    );
+                ), ['exception' => $ex]);
                 }
             }
 

--- a/src/Action/ResetAction.php
+++ b/src/Action/ResetAction.php
@@ -146,7 +146,7 @@ final class ResetAction extends Controller
                 if ($this->logger) {
                     $this->getLogger()->warning(sprintf(
                         'Unable to login user %d after password reset',
-                            $user->getId())
+                        $user->getId()
                     );
                 }
             }

--- a/src/Action/ResetAction.php
+++ b/src/Action/ResetAction.php
@@ -145,7 +145,7 @@ final class ResetAction extends Controller
                 // checker (not enabled, expired, etc.).
                 if ($this->logger) {
                     $this->getLogger()->warning(sprintf(
-                            'Unable to login user %d after password reset',
+                        'Unable to login user %d after password reset',
                             $user->getId())
                     );
                 }

--- a/src/Action/ResetAction.php
+++ b/src/Action/ResetAction.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Action;
+
+use FOS\UserBundle\Form\Factory\FactoryInterface;
+use FOS\UserBundle\Model\UserManagerInterface;
+use FOS\UserBundle\Security\LoginManagerInterface;
+use Psr\Log\LoggerAwareTrait;
+use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Security\Core\Exception\AccountStatusException;
+use Symfony\Component\Translation\TranslatorInterface;
+
+final class ResetAction extends Controller
+{
+    use LoggerAwareTrait;
+
+    /**
+     * @var AuthorizationCheckerInterface
+     */
+    protected $authorizationChecker;
+
+    /**
+     * @var RouterInterface
+     */
+    protected $router;
+
+    /**
+     * @var Pool
+     */
+    protected $adminPool;
+
+    /**
+     * @var TemplateRegistryInterface
+     */
+    protected $templateRegistry;
+
+    /**
+     * @var FactoryInterface
+     */
+    protected $formFactory;
+
+    /**
+     * @var UserManagerInterface
+     */
+    protected $userManager;
+
+    /**
+     * @var LoginManagerInterface
+     */
+    protected $loginManager;
+
+    /**
+     * @var TranslatorInterface
+     */
+    protected $translator;
+
+    /**
+     * @var int
+     */
+    protected $resetTtl;
+
+    /**
+     * @var string
+     */
+    protected $firewallName;
+
+    public function __construct(
+        AuthorizationCheckerInterface $authorizationChecker,
+        RouterInterface $router,
+        Pool $adminPool,
+        TemplateRegistryInterface $templateRegistry,
+        FactoryInterface $formFactory,
+        UserManagerInterface $userManager,
+        LoginManagerInterface $loginManager,
+        TranslatorInterface $translator,
+        int $resetTtl,
+        string $firewallName
+    ) {
+        $this->authorizationChecker = $authorizationChecker;
+        $this->router = $router;
+        $this->adminPool = $adminPool;
+        $this->templateRegistry = $templateRegistry;
+        $this->formFactory = $formFactory;
+        $this->userManager = $userManager;
+        $this->loginManager = $loginManager;
+        $this->translator = $translator;
+        $this->resetTtl = $resetTtl;
+        $this->firewallName = $firewallName;
+    }
+
+    public function __invoke(Request $request, $token)
+    {
+        if ($this->authorizationChecker->isGranted('IS_AUTHENTICATED_FULLY')) {
+            return new RedirectResponse($this->router->generate('sonata_admin_dashboard'));
+        }
+
+        $user = $this->userManager->findUserByConfirmationToken($token);
+
+        if (null === $user) {
+            throw new NotFoundHttpException(sprintf('The user with "confirmation token" does not exist for value "%s"', $token));
+        }
+
+        if (!$user->isPasswordRequestNonExpired($this->resetTtl)) {
+            return new RedirectResponse($this->generateUrl('sonata_user_admin_resetting_request'));
+        }
+
+        $form = $this->formFactory->createForm();
+        $form->setData($user);
+
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $user->setConfirmationToken(null);
+            $user->setPasswordRequestedAt(null);
+            $user->setEnabled(true);
+
+            $message = $this->translator->trans('resetting.flash.success', [], 'FOSUserBundle');
+            $this->addFlash('success', $message);
+
+            $response = new RedirectResponse($this->generateUrl('sonata_admin_dashboard'));
+
+            try {
+                $this->loginManager->logInUser($this->firewallName, $user, $response);
+                $user->setLastLogin(new \DateTime());
+            } catch (AccountStatusException $ex) {
+                // We simply do not authenticate users which do not pass the user
+                // checker (not enabled, expired, etc.).
+                if ($this->logger) {
+                    $this->getLogger()->warning(sprintf(
+                            'Unable to login user %d after password reset',
+                            $user->getId())
+                    );
+                }
+            }
+
+            $this->userManager->updateUser($user);
+
+            return $response;
+        }
+
+        return $this->render('@SonataUser/Admin/Security/Resetting/reset.html.twig', [
+            'token' => $token,
+            'form' => $form->createView(),
+            'base_template' => $this->templateRegistry->getTemplate('layout'),
+            'admin_pool' => $this->adminPool,
+        ]);
+    }
+}

--- a/src/Action/SendEmailAction.php
+++ b/src/Action/SendEmailAction.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Action;
+
+use FOS\UserBundle\Model\UserInterface;
+use FOS\UserBundle\Model\UserManagerInterface;
+use FOS\UserBundle\Util\TokenGeneratorInterface;
+use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\RouterInterface;
+
+final class SendEmailAction extends Controller
+{
+    /**
+     * @var RouterInterface
+     */
+    protected $router;
+
+    /**
+     * @var Pool
+     */
+    protected $adminPool;
+
+    /**
+     * @var TemplateRegistryInterface
+     */
+    protected $templateRegistry;
+
+    /**
+     * @var UserManagerInterface
+     */
+    protected $userManager;
+
+    /**
+     * @var \Swift_Mailer
+     */
+    protected $mailer;
+
+    /**
+     * @var TokenGeneratorInterface
+     */
+    protected $tokenGenerator;
+
+    /**
+     * @var int
+     */
+    protected $resetTtl;
+
+    /**
+     * @var string[]
+     */
+    protected $fromEmail;
+
+    /**
+     * @var string
+     */
+    protected $template;
+
+    public function __construct(
+        RouterInterface $router,
+        Pool $adminPool,
+        TemplateRegistryInterface $templateRegistry,
+        UserManagerInterface $userManager,
+        \Swift_Mailer $mailer,
+        TokenGeneratorInterface $tokenGenerator,
+        int $resetTtl,
+        array $fromEmail,
+        string $template
+    ) {
+        $this->router = $router;
+        $this->adminPool = $adminPool;
+        $this->templateRegistry = $templateRegistry;
+        $this->userManager = $userManager;
+        $this->mailer = $mailer;
+        $this->tokenGenerator = $tokenGenerator;
+        $this->resetTtl = $resetTtl;
+        $this->fromEmail = $fromEmail;
+        $this->template = $template;
+    }
+
+    public function __invoke(Request $request)
+    {
+        $username = $request->request->get('username');
+
+        $user = $this->userManager->findUserByUsernameOrEmail($username);
+
+        if (null === $user) {
+            return $this->render('@SonataUser/Admin/Security/Resetting/request.html.twig', [
+                'base_template' => $this->templateRegistry->getTemplate('layout'),
+                'admin_pool' => $this->adminPool,
+                'invalid_username' => $username,
+            ]);
+        }
+
+        if (null !== $user && !$user->isPasswordRequestNonExpired($this->resetTtl)) {
+            if (!$user->isAccountNonLocked()) {
+                return new RedirectResponse($this->router->generate('sonata_user_admin_resetting_request'));
+            }
+
+            if (null === $user->getConfirmationToken()) {
+                $user->setConfirmationToken($this->tokenGenerator->generateToken());
+            }
+
+            $this->sendResettingEmailMessage($user);
+            $user->setPasswordRequestedAt(new \DateTime());
+            $this->userManager->updateUser($user);
+        }
+
+        return new RedirectResponse($this->generateUrl('sonata_user_admin_resetting_check_email', [
+            'username' => $username,
+        ]));
+    }
+
+    private function sendResettingEmailMessage(UserInterface $user): void
+    {
+        $url = $this->generateUrl('sonata_user_admin_resetting_reset', [
+            'token' => $user->getConfirmationToken(),
+        ], UrlGeneratorInterface::ABSOLUTE_URL);
+
+        $rendered = $this->renderView($this->template, [
+            'user' => $user,
+            'confirmationUrl' => $url,
+        ]);
+
+        // Render the email, use the first line as the subject, and the rest as the body
+        $renderedLines = explode(PHP_EOL, trim($rendered));
+        $subject = array_shift($renderedLines);
+        $body = implode(PHP_EOL, $renderedLines);
+        $message = (new \Swift_Message())
+            ->setSubject($subject)
+            ->setFrom($this->fromEmail)
+            ->setTo((string) $user->getEmail())
+            ->setBody($body);
+
+        $this->mailer->send($message);
+    }
+}

--- a/src/Controller/AdminResettingController.php
+++ b/src/Controller/AdminResettingController.php
@@ -44,7 +44,7 @@ class AdminResettingController extends Controller
     /**
      * @return Response
      */
-    public function sendEmailAction()
+    public function sendEmailAction(Request $request)
     {
         /** @var SendEmailAction $sendEmailAction */
         $sendEmailAction = $this->container->get(SendEmailAction::class);
@@ -55,7 +55,7 @@ class AdminResettingController extends Controller
     /**
      * @return Response
      */
-    public function checkEmailAction()
+    public function checkEmailAction(Request $request)
     {
         /** @var CheckEmailAction $checkEmailAction */
         $checkEmailAction = $this->container->get(CheckEmailAction::class);

--- a/src/Controller/AdminResettingController.php
+++ b/src/Controller/AdminResettingController.php
@@ -13,15 +13,20 @@ declare(strict_types=1);
 
 namespace Sonata\UserBundle\Controller;
 
-use FOS\UserBundle\Model\UserInterface;
-use FOS\UserBundle\Util\TokenGeneratorInterface;
+// NEXT_MAJOR: remove this file
+@trigger_error(
+    'The '.__NAMESPACE__.'\AdminResettingController class is deprecated since version 4.x and will be removed in 5.0.'
+    .' Use '.__NAMESPACE__.'\RequestAction, '.__NAMESPACE__.'\CheckEmailAction, '.__NAMESPACE__.'\ResetAction or '.__NAMESPACE__.'\SendEmailAction instead.',
+    E_USER_DEPRECATED
+);
+
+use Sonata\UserBundle\Action\CheckEmailAction;
+use Sonata\UserBundle\Action\RequestAction;
+use Sonata\UserBundle\Action\ResetAction;
+use Sonata\UserBundle\Action\SendEmailAction;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-use Symfony\Component\Security\Core\Exception\AccountStatusException;
 
 class AdminResettingController extends Controller
 {
@@ -30,181 +35,47 @@ class AdminResettingController extends Controller
      */
     public function requestAction()
     {
-        if ($this->get('security.authorization_checker')->isGranted('IS_AUTHENTICATED_FULLY')) {
-            return new RedirectResponse($this->get('router')->generate('sonata_admin_dashboard'));
-        }
+        /** @var RequestAction $requestAction */
+        $requestAction = $this->container->get(RequestAction::class);
 
-        return $this->render('@SonataUser/Admin/Security/Resetting/request.html.twig', [
-            'base_template' => $this->get('sonata.admin.pool')->getTemplate('layout'),
-            'admin_pool' => $this->get('sonata.admin.pool'),
-        ]);
+        return $requestAction($this->getCurrentRequest());
     }
 
     /**
-     * @param Request $request
-     *
      * @return Response
      */
-    public function sendEmailAction(Request $request)
+    public function sendEmailAction()
     {
-        $username = $request->request->get('username');
+        /** @var SendEmailAction $sendEmailAction */
+        $sendEmailAction = $this->container->get(SendEmailAction::class);
 
-        /** @var $userManager \FOS\UserBundle\Model\UserManagerInterface */
-        $userManager = $this->get('fos_user.user_manager');
-
-        $user = $userManager->findUserByUsernameOrEmail($username);
-
-        if (null === $user) {
-            $sonataAdminPool = $this->get('sonata.admin.pool');
-
-            return $this->render('@SonataUser/Admin/Security/Resetting/request.html.twig', [
-                'base_template' => $sonataAdminPool->getTemplate('layout'),
-                'admin_pool' => $sonataAdminPool,
-                'invalid_username' => $username,
-            ]);
-        }
-
-        $ttl = $this->container->getParameter('fos_user.resetting.retry_ttl');
-
-        if (null !== $user && !$user->isPasswordRequestNonExpired($ttl)) {
-            if (!$user->isAccountNonLocked()) {
-                return new RedirectResponse($this->get('router')->generate('sonata_user_admin_resetting_request'));
-            }
-
-            if (null === $user->getConfirmationToken()) {
-                /** @var $tokenGenerator TokenGeneratorInterface */
-                $tokenGenerator = $this->get('fos_user.util.token_generator');
-                $user->setConfirmationToken($tokenGenerator->generateToken());
-            }
-
-            $this->sendResettingEmailMessage($user);
-            $user->setPasswordRequestedAt(new \DateTime());
-            $userManager->updateUser($user);
-        }
-
-        return new RedirectResponse($this->generateUrl('sonata_user_admin_resetting_check_email', [
-            'username' => $username,
-        ]));
+        return $sendEmailAction($this->getCurrentRequest());
     }
 
     /**
-     * @param Request $request
-     *
      * @return Response
      */
-    public function checkEmailAction(Request $request)
+    public function checkEmailAction()
     {
-        $username = $request->query->get('username');
+        /** @var CheckEmailAction $checkEmailAction */
+        $checkEmailAction = $this->container->get(CheckEmailAction::class);
 
-        if (empty($username)) {
-            // the user does not come from the sendEmail action
-            return new RedirectResponse($this->generateUrl('sonata_user_admin_resetting_request'));
-        }
-
-        return $this->render('@SonataUser/Admin/Security/Resetting/checkEmail.html.twig', [
-            'base_template' => $this->get('sonata.admin.pool')->getTemplate('layout'),
-            'admin_pool' => $this->get('sonata.admin.pool'),
-            'tokenLifetime' => ceil($this->container->getParameter('fos_user.resetting.retry_ttl') / 3600),
-        ]);
+        return $checkEmailAction($this->getCurrentRequest());
     }
 
     /**
-     * @param Request $request
-     * @param string  $token
-     *
      * @return Response
      */
-    public function resetAction(Request $request, $token)
+    public function resetAction(Request $request, string $token)
     {
-        if ($this->get('security.authorization_checker')->isGranted('IS_AUTHENTICATED_FULLY')) {
-            return new RedirectResponse($this->get('router')->generate('sonata_admin_dashboard'));
-        }
+        /** @var ResetAction $resetAction */
+        $resetAction = $this->container->get(ResetAction::class);
 
-        /** @var $formFactory \FOS\UserBundle\Form\Factory\FactoryInterface */
-        $formFactory = $this->get('fos_user.resetting.form.factory');
-        /** @var $userManager \FOS\UserBundle\Model\UserManagerInterface */
-        $userManager = $this->get('fos_user.user_manager');
-        /** @var $loginManager \FOS\UserBundle\Security\LoginManagerInterface */
-        $loginManager = $this->get('fos_user.security.login_manager');
-
-        $user = $userManager->findUserByConfirmationToken($token);
-
-        $firewallName = $this->container->getParameter('fos_user.firewall_name');
-
-        if (null === $user) {
-            throw new NotFoundHttpException(sprintf('The user with "confirmation token" does not exist for value "%s"', $token));
-        }
-
-        if (!$user->isPasswordRequestNonExpired($this->container->getParameter('fos_user.resetting.token_ttl'))) {
-            return new RedirectResponse($this->generateUrl('sonata_user_admin_resetting_request'));
-        }
-
-        $form = $formFactory->createForm();
-        $form->setData($user);
-
-        $form->handleRequest($request);
-
-        if ($form->isSubmitted() && $form->isValid()) {
-            $user->setConfirmationToken(null);
-            $user->setPasswordRequestedAt(null);
-            $user->setEnabled(true);
-
-            $message = $this->get('translator')->trans('resetting.flash.success', [], 'FOSUserBundle');
-            $this->addFlash('success', $message);
-            $response = new RedirectResponse($this->generateUrl('sonata_admin_dashboard'));
-
-            try {
-                $loginManager->logInUser($firewallName, $user, $response);
-                $user->setLastLogin(new \DateTime());
-            } catch (AccountStatusException $ex) {
-                // We simply do not authenticate users which do not pass the user
-                // checker (not enabled, expired, etc.).
-                if ($this->has('logger')) {
-                    $this->get('logger')->warning(sprintf(
-                        'Unable to login user %d after password reset',
-                        $user->getId())
-                    );
-                }
-            }
-
-            $userManager->updateUser($user);
-
-            return $response;
-        }
-
-        return $this->render('@SonataUser/Admin/Security/Resetting/reset.html.twig', [
-            'token' => $token,
-            'form' => $form->createView(),
-            'base_template' => $this->get('sonata.admin.pool')->getTemplate('layout'),
-            'admin_pool' => $this->get('sonata.admin.pool'),
-        ]);
+        return $resetAction($this->getCurrentRequest(), $token);
     }
 
-    /**
-     * Send an email to a user to confirm the password reset.
-     *
-     * @param UserInterface $user
-     */
-    private function sendResettingEmailMessage(UserInterface $user): void
+    private function getCurrentRequest(): Request
     {
-        $url = $this->generateUrl('sonata_user_admin_resetting_reset', [
-            'token' => $user->getConfirmationToken(),
-        ], UrlGeneratorInterface::ABSOLUTE_URL);
-
-        $rendered = $this->renderView($this->container->getParameter('fos_user.resetting.email.template'), [
-            'user' => $user,
-            'confirmationUrl' => $url,
-        ]);
-
-        // Render the email, use the first line as the subject, and the rest as the body
-        $renderedLines = explode(PHP_EOL, trim($rendered));
-        $subject = array_shift($renderedLines);
-        $body = implode(PHP_EOL, $renderedLines);
-        $message = (new \Swift_Message())
-            ->setSubject($subject)
-            ->setFrom($this->container->getParameter('fos_user.resetting.email.from_email'))
-            ->setTo((string) $user->getEmail())
-            ->setBody($body);
-        $this->get('mailer')->send($message);
+        return $this->container->get('request_stack')->getCurrentRequest();
     }
 }

--- a/src/Controller/AdminSecurityController.php
+++ b/src/Controller/AdminSecurityController.php
@@ -13,75 +13,43 @@ declare(strict_types=1);
 
 namespace Sonata\UserBundle\Controller;
 
-use Sonata\UserBundle\Model\UserInterface;
+// NEXT_MAJOR: remove this file
+@trigger_error(
+    'The '.__NAMESPACE__.'\AdminSecurityController class is deprecated since version 4.x and will be removed in 5.0.'
+    .' Use '.__NAMESPACE__.'\CheckLoginAction, '.__NAMESPACE__.'\LoginAction or '.__NAMESPACE__.'\LogoutAction instead.',
+    E_USER_DEPRECATED
+);
+
+use Sonata\UserBundle\Action\CheckLoginAction;
+use Sonata\UserBundle\Action\LoginAction;
+use Sonata\UserBundle\Action\LogoutAction;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Security\Core\Exception\AuthenticationException;
-use Symfony\Component\Security\Core\Security;
 
 class AdminSecurityController extends Controller
 {
-    /**
-     * @param Request $request
-     *
-     * @return Response|RedirectResponse
-     */
-    public function loginAction(Request $request)
+    public function loginAction(Request $request): Response
     {
-        if ($this->getUser() instanceof UserInterface) {
-            $this->addFlash('sonata_user_error', 'sonata_user_already_authenticated');
-            $url = $this->generateUrl('sonata_admin_dashboard');
+        /** @var LoginAction $loginAction */
+        $loginAction = $this->container->get(LoginAction::class);
 
-            return $this->redirect($url);
-        }
-
-        $session = $request->getSession();
-
-        $authErrorKey = Security::AUTHENTICATION_ERROR;
-
-        // get the error if any (works with forward and redirect -- see below)
-        if ($request->attributes->has($authErrorKey)) {
-            $error = $request->attributes->get($authErrorKey);
-        } elseif (null !== $session && $session->has($authErrorKey)) {
-            $error = $session->get($authErrorKey);
-            $session->remove($authErrorKey);
-        } else {
-            $error = null;
-        }
-
-        if (!$error instanceof AuthenticationException) {
-            $error = null; // The value does not come from the security component.
-        }
-
-        if ($this->isGranted('ROLE_ADMIN')) {
-            $refererUri = $request->server->get('HTTP_REFERER');
-
-            return $this->redirect($refererUri && $refererUri != $request->getUri() ? $refererUri : $this->generateUrl('sonata_admin_dashboard'));
-        }
-
-        $csrfToken = $this->has('security.csrf.token_manager')
-            ? $this->get('security.csrf.token_manager')->getToken('authenticate')->getValue()
-            : null;
-
-        return $this->render('@SonataUser/Admin/Security/login.html.twig', [
-            'admin_pool' => $this->get('sonata.admin.pool'),
-            'base_template' => $this->get('sonata.admin.pool')->getTemplate('layout'),
-            'csrf_token' => $csrfToken,
-            'error' => $error,
-            'last_username' => (null === $session) ? '' : $session->get(Security::LAST_USERNAME),
-            'reset_route' => $this->generateUrl('sonata_user_admin_resetting_request'),
-        ]);
+        return $loginAction($request);
     }
 
     public function checkAction(): void
     {
-        throw new \RuntimeException('You must configure the check path to be handled by the firewall using form_login in your security firewall configuration.');
+        /** @var CheckLoginAction $checkLoginAction */
+        $checkLoginAction = $this->container->get(CheckLoginAction::class);
+
+        $checkLoginAction();
     }
 
     public function logoutAction(): void
     {
-        throw new \RuntimeException('You must activate the logout in your security firewall configuration.');
+        /** @var LogoutAction $logoutAction */
+        $logoutAction = $this->container->get(LogoutAction::class);
+
+        $logoutAction();
     }
 }

--- a/src/DependencyInjection/SonataUserExtension.php
+++ b/src/DependencyInjection/SonataUserExtension.php
@@ -80,6 +80,7 @@ class SonataUserExtension extends Extension implements PrependExtensionInterface
 
         $loader->load('twig.xml');
         $loader->load('command.xml');
+        $loader->load('actions.xml');
 
         if ('orm' === $config['manager_type'] && isset(
             $bundles['FOSRestBundle'],

--- a/src/Resources/config/actions.xml
+++ b/src/Resources/config/actions.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <!-- NEXT_MAJOR: remove the "class" and "public" attributes -->
+        <service id="Sonata\UserBundle\Action\RequestAction" class="Sonata\UserBundle\Action\RequestAction" public="true">
+            <argument type="service" id="security.authorization_checker"/>
+            <argument type="service" id="router"/>
+            <argument type="service" id="sonata.admin.pool"/>
+            <argument type="service" id="sonata.admin.global_template_registry"/>
+            <call method="setContainer">
+                <argument type="service" id="service_container"/>
+            </call>
+        </service>
+
+        <service id="Sonata\UserBundle\Action\SendEmailAction" class="Sonata\UserBundle\Action\SendEmailAction" public="true">
+            <argument type="service" id="router"/>
+            <argument type="service" id="sonata.admin.pool"/>
+            <argument type="service" id="sonata.admin.global_template_registry"/>
+            <argument type="service" id="fos_user.user_manager"/>
+            <argument type="service" id="mailer"/>
+            <argument type="service" id="fos_user.util.token_generator"/>
+            <argument>%fos_user.resetting.retry_ttl%</argument>
+            <argument>%fos_user.resetting.email.from_email%</argument>
+            <argument>%fos_user.resetting.email.template%</argument>
+            <call method="setContainer">
+                <argument type="service" id="service_container"/>
+            </call>
+        </service>
+
+        <service id="Sonata\UserBundle\Action\CheckEmailAction" class="Sonata\UserBundle\Action\CheckEmailAction" public="true">
+            <argument type="service" id="sonata.admin.pool"/>
+            <argument type="service" id="sonata.admin.global_template_registry"/>
+            <argument>%fos_user.resetting.retry_ttl%</argument>
+            <call method="setContainer">
+                <argument type="service" id="service_container"/>
+            </call>
+        </service>
+
+        <service id="Sonata\UserBundle\Action\ResetAction" class="Sonata\UserBundle\Action\ResetAction" public="true">
+            <argument type="service" id="security.authorization_checker"/>
+            <argument type="service" id="router"/>
+            <argument type="service" id="sonata.admin.pool"/>
+            <argument type="service" id="sonata.admin.global_template_registry"/>
+            <argument type="service" id="fos_user.resetting.form.factory"/>
+            <argument type="service" id="fos_user.user_manager"/>
+            <argument type="service" id="fos_user.security.login_manager"/>
+            <argument type="service" id="translator"/>
+            <argument>%fos_user.resetting.retry_ttl%</argument>
+            <argument>%fos_user.firewall_name%</argument>
+            <call method="setContainer">
+                <argument type="service" id="service_container"/>
+            </call>
+            <call method="setLogger">
+                <argument type="service" id="logger" on-invalid="ignore"/>
+            </call>
+        </service>
+    </services>
+</container>

--- a/src/Resources/config/actions.xml
+++ b/src/Resources/config/actions.xml
@@ -3,16 +3,14 @@
     <services>
         <!-- NEXT_MAJOR: remove the "class" and "public" attributes -->
         <service id="Sonata\UserBundle\Action\RequestAction" class="Sonata\UserBundle\Action\RequestAction" public="true">
-            <argument type="service" id="security.authorization_checker"/>
+            <argument type="service" id="templating"/>
             <argument type="service" id="router"/>
+            <argument type="service" id="security.authorization_checker"/>
             <argument type="service" id="sonata.admin.pool"/>
             <argument type="service" id="sonata.admin.global_template_registry"/>
-            <call method="setContainer">
-                <argument type="service" id="service_container"/>
-            </call>
         </service>
-
         <service id="Sonata\UserBundle\Action\SendEmailAction" class="Sonata\UserBundle\Action\SendEmailAction" public="true">
+            <argument type="service" id="templating"/>
             <argument type="service" id="router"/>
             <argument type="service" id="sonata.admin.pool"/>
             <argument type="service" id="sonata.admin.global_template_registry"/>
@@ -22,37 +20,44 @@
             <argument>%fos_user.resetting.retry_ttl%</argument>
             <argument>%fos_user.resetting.email.from_email%</argument>
             <argument>%fos_user.resetting.email.template%</argument>
-            <call method="setContainer">
-                <argument type="service" id="service_container"/>
-            </call>
         </service>
-
         <service id="Sonata\UserBundle\Action\CheckEmailAction" class="Sonata\UserBundle\Action\CheckEmailAction" public="true">
+            <argument type="service" id="templating"/>
+            <argument type="service" id="router"/>
             <argument type="service" id="sonata.admin.pool"/>
             <argument type="service" id="sonata.admin.global_template_registry"/>
             <argument>%fos_user.resetting.retry_ttl%</argument>
-            <call method="setContainer">
-                <argument type="service" id="service_container"/>
-            </call>
         </service>
-
         <service id="Sonata\UserBundle\Action\ResetAction" class="Sonata\UserBundle\Action\ResetAction" public="true">
-            <argument type="service" id="security.authorization_checker"/>
+            <argument type="service" id="templating"/>
             <argument type="service" id="router"/>
+            <argument type="service" id="security.authorization_checker"/>
             <argument type="service" id="sonata.admin.pool"/>
             <argument type="service" id="sonata.admin.global_template_registry"/>
             <argument type="service" id="fos_user.resetting.form.factory"/>
             <argument type="service" id="fos_user.user_manager"/>
             <argument type="service" id="fos_user.security.login_manager"/>
             <argument type="service" id="translator"/>
+            <argument type="service" id="session"/>
             <argument>%fos_user.resetting.retry_ttl%</argument>
             <argument>%fos_user.firewall_name%</argument>
-            <call method="setContainer">
-                <argument type="service" id="service_container"/>
-            </call>
             <call method="setLogger">
                 <argument type="service" id="logger" on-invalid="ignore"/>
             </call>
         </service>
+        <service id="Sonata\UserBundle\Action\LoginAction" class="Sonata\UserBundle\Action\LoginAction" public="true">
+            <argument type="service" id="templating"/>
+            <argument type="service" id="router"/>
+            <argument type="service" id="security.authorization_checker"/>
+            <argument type="service" id="sonata.admin.pool"/>
+            <argument type="service" id="sonata.admin.global_template_registry"/>
+            <argument type="service" id="security.token_storage"/>
+            <argument type="service" id="session"/>
+            <call method="setCsrfTokenManager">
+                <argument type="service" id="security.csrf.token_manager" on-invalid="ignore"/>
+            </call>
+        </service>
+        <service id="Sonata\UserBundle\Action\CheckLoginAction" class="Sonata\UserBundle\Action\CheckLoginAction" public="true"/>
+        <service id="Sonata\UserBundle\Action\LogoutAction" class="Sonata\UserBundle\Action\LogoutAction" public="true"/>
     </services>
 </container>

--- a/src/Resources/config/routing/admin_resetting.xml
+++ b/src/Resources/config/routing/admin_resetting.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <routes xmlns="http://symfony.com/schema/routing" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
     <route id="sonata_user_admin_resetting_request" path="/request" methods="GET">
-        <default key="_controller">SonataUserBundle:AdminResetting:request</default>
+        <default key="_controller">Sonata\UserBundle\Action\RequestAction</default>
     </route>
     <route id="sonata_user_admin_resetting_send_email" path="/send-email" methods="POST">
-        <default key="_controller">SonataUserBundle:AdminResetting:sendEmail</default>
+        <default key="_controller">Sonata\UserBundle\Action\SendEmailAction</default>
     </route>
     <route id="sonata_user_admin_resetting_check_email" path="/check-email" methods="GET">
-        <default key="_controller">SonataUserBundle:AdminResetting:checkEmail</default>
+        <default key="_controller">Sonata\UserBundle\Action\CheckEmailAction</default>
     </route>
     <route id="sonata_user_admin_resetting_reset" path="/reset/{token}" methods="GET POST">
-        <default key="_controller">SonataUserBundle:AdminResetting:reset</default>
+        <default key="_controller">Sonata\UserBundle\Action\ResetAction</default>
     </route>
 </routes>

--- a/src/Resources/config/routing/admin_security.xml
+++ b/src/Resources/config/routing/admin_security.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <routes xmlns="http://symfony.com/schema/routing" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
     <route id="sonata_user_admin_security_login" path="/login">
-        <default key="_controller">SonataUserBundle:AdminSecurity:login</default>
+        <default key="_controller">Sonata\UserBundle\Action\LoginAction</default>
     </route>
     <route id="sonata_user_admin_security_check" path="/login_check" methods="POST">
-        <default key="_controller">SonataUserBundle:AdminSecurity:check</default>
+        <default key="_controller">Sonata\UserBundle\Action\CheckLoginAction</default>
     </route>
     <route id="sonata_user_admin_security_logout" path="/logout">
-        <default key="_controller">SonataUserBundle:AdminSecurity:logout</default>
+        <default key="_controller">Sonata\UserBundle\Action\LogoutAction</default>
     </route>
 </routes>

--- a/tests/Action/CheckEmailActionTest.php
+++ b/tests/Action/CheckEmailActionTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Tests\Action;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
+use Sonata\UserBundle\Action\CheckEmailAction;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\RouterInterface;
+
+class CheckEmailActionTest extends TestCase
+{
+    /**
+     * @var Pool|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $pool;
+
+    /**
+     * @var TemplateRegistryInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $templateRegistry;
+
+    /**
+     * @var int
+     */
+    protected $resetTtl;
+
+    /**
+     * @var ContainerBuilder|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $container;
+
+    /**
+     * @var RouterInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $router;
+
+    /**
+     * @var EngineInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $templating;
+
+    public function setUp(): void
+    {
+        $this->pool = $this->createMock(Pool::class);
+        $this->templateRegistry = $this->createMock(TemplateRegistryInterface::class);
+        $this->resetTtl = 60;
+        $this->container = $this->createMock(ContainerBuilder::class);
+        $this->router = $this->createMock(RouterInterface::class);
+        $this->templating = $this->createMock(EngineInterface::class);
+
+        $services = [
+            'router' => $this->router,
+            'templating' => $this->templating,
+        ];
+        $this->container->expects($this->any())
+            ->method('has')
+            ->willReturnCallback(function ($service) use ($services) {
+                return isset($services[$service]);
+            });
+        $this->container->expects($this->any())
+            ->method('get')
+            ->willReturnCallback(function ($service) use ($services) {
+                return $services[$service] ?? null;
+            });
+    }
+
+    public function testWithoutUsername(): void
+    {
+        $request = new Request();
+
+        $this->router->expects($this->once())
+            ->method('generate')
+            ->with('sonata_user_admin_resetting_request')
+            ->willReturn('/foo');
+
+        $action = $this->getAction();
+        $result = $action($request);
+
+        $this->assertInstanceOf(RedirectResponse::class, $result);
+        $this->assertEquals('/foo', $result->getTargetUrl());
+    }
+
+    public function testWithUsername(): void
+    {
+        $request = new Request(['username' => 'bar']);
+
+        $parameters = [
+            'base_template' => 'base.html.twig',
+            'admin_pool' => $this->pool,
+            'tokenLifetime' => 1,
+        ];
+
+        $this->templating->expects($this->once())
+            ->method('render')
+            ->with('@SonataUser/Admin/Security/Resetting/checkEmail.html.twig', $parameters)
+            ->willReturn('Foo Content');
+
+        $this->templateRegistry->expects($this->any())
+            ->method('getTemplate')
+            ->with('layout')
+            ->willReturn('base.html.twig');
+
+        $action = $this->getAction();
+        $result = $action($request);
+
+        $this->assertInstanceOf(Response::class, $result);
+        $this->assertEquals('Foo Content', $result->getContent());
+    }
+
+    private function getAction(): CheckEmailAction
+    {
+        $action = new CheckEmailAction($this->pool, $this->templateRegistry, $this->resetTtl);
+        $action->setContainer($this->container);
+
+        return $action;
+    }
+}

--- a/tests/Action/CheckLoginActionTest.php
+++ b/tests/Action/CheckLoginActionTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Tests\Action;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\UserBundle\Action\CheckLoginAction;
+
+class CheckLoginActionTest extends TestCase
+{
+    public function testAction(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('You must configure the check path to be handled by the firewall using form_login in your security firewall configuration.');
+
+        $action = new CheckLoginAction();
+        $action();
+    }
+}

--- a/tests/Action/LoginActionTest.php
+++ b/tests/Action/LoginActionTest.php
@@ -1,0 +1,264 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Tests\Action;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
+use Sonata\UserBundle\Action\LoginAction;
+use Sonata\UserBundle\Model\UserInterface;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBag;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Csrf\CsrfToken;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
+
+class LoginActionTest extends TestCase
+{
+    /**
+     * @var EngineInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $templating;
+
+    /**
+     * @var UrlGeneratorInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $urlGenerator;
+
+    /**
+     * @var AuthorizationCheckerInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $authorizationChecker;
+
+    /**
+     * @var Pool|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $pool;
+
+    /**
+     * @var TemplateRegistryInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $templateRegistry;
+
+    /**
+     * @var TokenStorageInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $tokenStorage;
+
+    /**
+     * @var Session|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $session;
+
+    /**
+     * @var CsrfTokenManagerInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $csrfTokenManager;
+
+    public function setUp(): void
+    {
+        $this->templating = $this->createMock(EngineInterface::class);
+        $this->urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $this->authorizationChecker = $this->createMock(AuthorizationCheckerInterface::class);
+        $this->pool = $this->createMock(Pool::class);
+        $this->templateRegistry = $this->createMock(TemplateRegistryInterface::class);
+        $this->tokenStorage = $this->createMock(TokenStorageInterface::class);
+        $this->session = $this->createMock(Session::class);
+        $this->csrfTokenManager = $this->createMock(CsrfTokenManagerInterface::class);
+    }
+
+    public function testAlreadyAuthenticated(): void
+    {
+        $request = new Request();
+
+        $user = $this->createMock(UserInterface::class);
+
+        $token = $this->createMock(TokenInterface::class);
+        $token->expects($this->any())
+            ->method('getUser')
+            ->willReturn($user);
+
+        $this->tokenStorage->expects($this->any())
+            ->method('getToken')
+            ->willReturn($token);
+
+        $bag = $this->createMock(FlashBag::class);
+        $bag->expects($this->once())
+            ->method('add')
+            ->with('sonata_user_error', 'sonata_user_already_authenticated');
+
+        $this->session->expects($this->any())
+            ->method('getFlashBag')
+            ->willReturn($bag);
+
+        $this->urlGenerator->expects($this->any())
+            ->method('generate')
+            ->with('sonata_admin_dashboard')
+            ->willReturn('/foo');
+
+        $action = $this->getAction();
+        $result = $action($request);
+
+        $this->assertInstanceOf(RedirectResponse::class, $result);
+        $this->assertEquals('/foo', $result->getTargetUrl());
+    }
+
+    /**
+     * @dataProvider userGrantedAdminProvider
+     */
+    public function testUserGrantedAdmin(string $referer, string $expectedRedirectUrl): void
+    {
+        $session = $this->createMock(Session::class);
+        $request = Request::create('http://some.url.com/exact-request-uri');
+        $request->server->add(['HTTP_REFERER' => $referer]);
+        $request->setSession($session);
+
+        $this->tokenStorage->expects($this->any())
+            ->method('getToken')
+            ->willReturn(null);
+
+        $this->urlGenerator->expects($this->any())
+            ->method('generate')
+            ->with('sonata_admin_dashboard')
+            ->willReturn('/foo');
+
+        $this->authorizationChecker->expects($this->once())
+            ->method('isGranted')
+            ->with('ROLE_ADMIN')
+            ->willReturn(true);
+
+        $action = $this->getAction();
+        $result = $action($request);
+
+        $this->assertInstanceOf(RedirectResponse::class, $result);
+        $this->assertEquals($expectedRedirectUrl, $result->getTargetUrl());
+    }
+
+    public function userGrantedAdminProvider(): array
+    {
+        return [
+            ['', '/foo'],
+            ['http://some.url.com/exact-request-uri', '/foo'],
+            ['http://some.url.com', 'http://some.url.com'],
+        ];
+    }
+
+    /**
+     * @dataProvider unauthenticatedProvider
+     */
+    public function testUnauthenticated(string $lastUsername, AuthenticationException $errorMessage = null): void
+    {
+        $session = $this->createMock(Session::class);
+        $sessionParameters = [
+            '_security.last_error' => $errorMessage,
+            '_security.last_username' => $lastUsername,
+        ];
+        $session->expects($this->any())
+            ->method('get')
+            ->willReturnCallback(function ($key) use ($sessionParameters) {
+                return $sessionParameters[$key] ?? null;
+            });
+        $session->expects($this->any())
+            ->method('has')
+            ->willReturnCallback(function ($key) use ($sessionParameters) {
+                return isset($sessionParameters[$key]);
+            });
+        $request = new Request();
+        $request->setSession($session);
+
+        $response = $this->createMock(Response::class);
+
+        $parameters = [
+            'admin_pool' => $this->pool,
+            'base_template' => 'base.html.twig',
+            'csrf_token' => 'csrf-token',
+            'error' => $errorMessage,
+            'last_username' => $lastUsername,
+            'reset_route' => '/foo',
+        ];
+
+        $csrfToken = $this->createMock(CsrfToken::class);
+        $csrfToken->expects($this->any())
+            ->method('getValue')
+            ->willReturn('csrf-token');
+
+        $this->tokenStorage->expects($this->any())
+            ->method('getToken')
+            ->willReturn(null);
+
+        $this->urlGenerator->expects($this->any())
+            ->method('generate')
+            ->with('sonata_user_admin_resetting_request')
+            ->willReturn('/foo');
+
+        $this->authorizationChecker->expects($this->once())
+            ->method('isGranted')
+            ->with('ROLE_ADMIN')
+            ->willReturn(false);
+
+        $this->csrfTokenManager->expects($this->any())
+            ->method('getToken')
+            ->with('authenticate')
+            ->willReturn($csrfToken);
+
+        $this->templateRegistry->expects($this->any())
+            ->method('getTemplate')
+            ->with('layout')
+            ->willReturn('base.html.twig');
+
+        $this->templating->expects($this->any())
+            ->method('renderResponse')
+            ->with('@SonataUser/Admin/Security/login.html.twig', $parameters)
+            ->willReturn($response);
+
+        $action = $this->getAction();
+        $result = $action($request);
+
+        $this->assertEquals($response, $result);
+    }
+
+    public function unauthenticatedProvider(): array
+    {
+        $error = new AuthenticationException('An error');
+
+        return [
+            ['', null],
+            ['FooUser', $error],
+        ];
+    }
+
+    private function getAction(): LoginAction
+    {
+        $action = new LoginAction(
+            $this->templating,
+            $this->urlGenerator,
+            $this->authorizationChecker,
+            $this->pool,
+            $this->templateRegistry,
+            $this->tokenStorage,
+            $this->session
+        );
+        $action->setCsrfTokenManager($this->csrfTokenManager);
+
+        return $action;
+    }
+}

--- a/tests/Action/LogoutActionTest.php
+++ b/tests/Action/LogoutActionTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Tests\Action;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\UserBundle\Action\LogoutAction;
+
+class LogoutActionTest extends TestCase
+{
+    public function testAction(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('You must activate the logout in your security firewall configuration.');
+
+        $action = new LogoutAction();
+        $action();
+    }
+}

--- a/tests/Action/RequestActionTest.php
+++ b/tests/Action/RequestActionTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Tests\Action;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
+use Sonata\UserBundle\Action\RequestAction;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+
+class RequestActionTest extends TestCase
+{
+    /**
+     * @var AuthorizationCheckerInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $authorizationChecker;
+
+    /**
+     * @var RouterInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $router;
+
+    /**
+     * @var Pool|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $pool;
+
+    /**
+     * @var TemplateRegistryInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $templateRegistry;
+
+    /**
+     * @var ContainerBuilder|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $container;
+
+    /**
+     * @var EngineInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $templating;
+
+    public function setUp(): void
+    {
+        $this->authorizationChecker = $this->createMock(AuthorizationCheckerInterface::class);
+        $this->router = $this->createMock(RouterInterface::class);
+        $this->pool = $this->createMock(Pool::class);
+        $this->templateRegistry = $this->createMock(TemplateRegistryInterface::class);
+        $this->container = $this->createMock(ContainerBuilder::class);
+        $this->templating = $this->createMock(EngineInterface::class);
+
+        $services = [
+            'router' => $this->router,
+            'templating' => $this->templating,
+        ];
+        $this->container->expects($this->any())
+            ->method('has')
+            ->willReturnCallback(function ($service) use ($services) {
+                return isset($services[$service]);
+            });
+        $this->container->expects($this->any())
+            ->method('get')
+            ->willReturnCallback(function ($service) use ($services) {
+                return $services[$service] ?? null;
+            });
+    }
+
+    public function testAuthenticated(): void
+    {
+        $request = new Request();
+
+        $this->authorizationChecker->expects($this->once())
+            ->method('isGranted')
+            ->willReturn(true);
+
+        $this->router->expects($this->any())
+            ->method('generate')
+            ->with('sonata_admin_dashboard')
+            ->willReturn('/foo');
+
+        $action = $this->getAction();
+        $result = $action($request);
+
+        $this->assertInstanceOf(RedirectResponse::class, $result);
+        $this->assertEquals('/foo', $result->getTargetUrl());
+    }
+
+    public function testUnauthenticated(): void
+    {
+        $request = new Request();
+
+        $parameters = [
+            'base_template' => 'base.html.twig',
+            'admin_pool' => $this->pool,
+        ];
+
+        $this->authorizationChecker->expects($this->once())
+            ->method('isGranted')
+            ->willReturn(false);
+
+        $this->templating->expects($this->once())
+            ->method('render')
+            ->with('@SonataUser/Admin/Security/Resetting/request.html.twig', $parameters)
+            ->willReturn('Foo Content');
+
+        $this->templateRegistry->expects($this->any())
+            ->method('getTemplate')
+            ->with('layout')
+            ->willReturn('base.html.twig');
+
+        $action = $this->getAction();
+        $result = $action($request);
+
+        $this->assertInstanceOf(Response::class, $result);
+        $this->assertEquals('Foo Content', $result->getContent());
+    }
+
+    private function getAction(): RequestAction
+    {
+        $action = new RequestAction($this->authorizationChecker, $this->router, $this->pool, $this->templateRegistry);
+        $action->setContainer($this->container);
+
+        return $action;
+    }
+}

--- a/tests/Action/ResetActionTest.php
+++ b/tests/Action/ResetActionTest.php
@@ -1,0 +1,287 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Tests\Action;
+
+use FOS\UserBundle\Form\Factory\FactoryInterface;
+use FOS\UserBundle\Model\User;
+use FOS\UserBundle\Model\UserManagerInterface;
+use FOS\UserBundle\Security\LoginManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
+use Sonata\UserBundle\Action\ResetAction;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Form\Form;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBag;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class ResetActionTest extends TestCase
+{
+    /**
+     * @var AuthorizationCheckerInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $authorizationChecker;
+
+    /**
+     * @var RouterInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $router;
+
+    /**
+     * @var Pool|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $pool;
+
+    /**
+     * @var TemplateRegistryInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $templateRegistry;
+
+    /**
+     * @var FactoryInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $formFactory;
+
+    /**
+     * @var UserManagerInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $userManager;
+
+    /**
+     * @var LoginManagerInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $loginManager;
+
+    /**
+     * @var TranslatorInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $translator;
+
+    /**
+     * @var int
+     */
+    protected $resetTtl;
+
+    /**
+     * @var string
+     */
+    protected $firewallName;
+
+    /**
+     * @var ContainerBuilder|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $container;
+
+    /**
+     * @var EngineInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $templating;
+
+    /**
+     * @var Session|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $session;
+
+    public function setUp(): void
+    {
+        $this->authorizationChecker = $this->createMock(AuthorizationCheckerInterface::class);
+        $this->router = $this->createMock(RouterInterface::class);
+        $this->pool = $this->createMock(Pool::class);
+        $this->templateRegistry = $this->createMock(TemplateRegistryInterface::class);
+        $this->formFactory = $this->createMock(FactoryInterface::class);
+        $this->userManager = $this->createMock(UserManagerInterface::class);
+        $this->loginManager = $this->createMock(LoginManagerInterface::class);
+        $this->translator = $this->createMock(TranslatorInterface::class);
+        $this->resetTtl = 60;
+        $this->firewallName = 'default';
+        $this->container = $this->createMock(ContainerBuilder::class);
+        $this->templating = $this->createMock(EngineInterface::class);
+        $this->session = $this->createMock(Session::class);
+
+        $services = [
+            'router' => $this->router,
+            'templating' => $this->templating,
+            'session' => $this->session,
+        ];
+        $this->container->expects($this->any())
+            ->method('has')
+            ->willReturnCallback(function ($service) use ($services) {
+                return isset($services[$service]);
+            });
+        $this->container->expects($this->any())
+            ->method('get')
+            ->willReturnCallback(function ($service) use ($services) {
+                return $services[$service] ?? null;
+            });
+    }
+
+    public function testAuthenticated(): void
+    {
+        $request = new Request();
+
+        $this->authorizationChecker->expects($this->once())
+            ->method('isGranted')
+            ->willReturn(true);
+
+        $this->router->expects($this->any())
+            ->method('generate')
+            ->with('sonata_admin_dashboard')
+            ->willReturn('/foo');
+
+        $action = $this->getAction();
+        $result = $action($request, 'token');
+
+        $this->assertInstanceOf(RedirectResponse::class, $result);
+        $this->assertEquals('/foo', $result->getTargetUrl());
+    }
+
+    public function testUnknownToken(): void
+    {
+        $this->expectException(\Symfony\Component\HttpKernel\Exception\NotFoundHttpException::class);
+        $this->expectExceptionMessage('The user with "confirmation token" does not exist for value "token"');
+
+        $request = new Request();
+
+        $this->userManager->expects($this->any())
+            ->method('findUserByConfirmationToken')
+            ->with('token')
+            ->willReturn(null);
+
+        $action = $this->getAction();
+        $action($request, 'token');
+    }
+
+    public function testPasswordRequestNonExpired(): void
+    {
+        $request = new Request();
+
+        $user = $this->createMock(User::class);
+        $user->expects($this->any())
+            ->method('isPasswordRequestNonExpired')
+            ->willReturn(false);
+
+        $this->userManager->expects($this->any())
+            ->method('findUserByConfirmationToken')
+            ->with('token')
+            ->willReturn($user);
+
+        $this->router->expects($this->any())
+            ->method('generate')
+            ->with('sonata_user_admin_resetting_request')
+            ->willReturn('/foo');
+
+        $action = $this->getAction();
+        $result = $action($request, 'token');
+
+        $this->assertInstanceOf(RedirectResponse::class, $result);
+        $this->assertEquals('/foo', $result->getTargetUrl());
+    }
+
+    public function testReset(): void
+    {
+        $request = new Request();
+
+        $user = $this->createMock(User::class);
+        $user->expects($this->any())
+            ->method('isPasswordRequestNonExpired')
+            ->willReturn(true);
+        $user->expects($this->once())
+            ->method('setLastLogin');
+        $user->expects($this->once())
+            ->method('setConfirmationToken')
+            ->with(null);
+        $user->expects($this->once())
+            ->method('setPasswordRequestedAt')
+            ->with(null);
+        $user->expects($this->once())
+            ->method('setEnabled')
+            ->with(true);
+
+        $form = $this->createMock(Form::class);
+        $form->expects($this->any())
+            ->method('isValid')
+            ->willReturn(true);
+        $form->expects($this->any())
+            ->method('isSubmitted')
+            ->willReturn(true);
+
+        $this->translator->expects($this->any())
+            ->method('trans')
+            ->willReturnCallback(function ($message) {
+                return $message;
+            });
+
+        $bag = $this->createMock(FlashBag::class);
+        $bag->expects($this->once())
+            ->method('add')
+            ->with('success', 'resetting.flash.success');
+
+        $this->session->expects($this->any())
+            ->method('getFlashBag')
+            ->willReturn($bag);
+
+        $this->userManager->expects($this->any())
+            ->method('findUserByConfirmationToken')
+            ->with('token')
+            ->willReturn($user);
+        $this->userManager->expects($this->once())
+            ->method('updateUser')
+            ->with($user);
+
+        $this->loginManager->expects($this->once())
+            ->method('logInUser')
+            ->with('default', $user, $this->isInstanceOf(Response::class));
+
+        $this->formFactory->expects($this->once())
+            ->method('createForm')
+            ->willReturn($form);
+
+        $this->router->expects($this->any())
+            ->method('generate')
+            ->with('sonata_admin_dashboard')
+            ->willReturn('/foo');
+
+        $action = $this->getAction();
+        $result = $action($request, 'token');
+
+        $this->assertInstanceOf(RedirectResponse::class, $result);
+        $this->assertEquals('/foo', $result->getTargetUrl());
+    }
+
+    private function getAction(): ResetAction
+    {
+        $action = new ResetAction(
+            $this->authorizationChecker,
+            $this->router,
+            $this->pool,
+            $this->templateRegistry,
+            $this->formFactory,
+            $this->userManager,
+            $this->loginManager,
+            $this->translator,
+            $this->resetTtl,
+            $this->firewallName
+        );
+        $action->setContainer($this->container);
+
+        return $action;
+    }
+}

--- a/tests/Action/SendEmailActionTest.php
+++ b/tests/Action/SendEmailActionTest.php
@@ -1,0 +1,303 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Tests\Action;
+
+use FOS\UserBundle\Model\User;
+use FOS\UserBundle\Model\UserManagerInterface;
+use FOS\UserBundle\Util\TokenGeneratorInterface;
+use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
+use Sonata\UserBundle\Action\SendEmailAction;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\RouterInterface;
+
+class SendEmailActionTest extends TestCase
+{
+    /**
+     * @var RouterInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $router;
+
+    /**
+     * @var Pool|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $pool;
+
+    /**
+     * @var TemplateRegistryInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $templateRegistry;
+
+    /**
+     * @var UserManagerInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $userManager;
+
+    /**
+     * @var \Swift_Mailer|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $mailer;
+
+    /**
+     * @var TokenGeneratorInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $tokenGenerator;
+
+    /**
+     * @var int
+     */
+    protected $resetTtl;
+
+    /**
+     * @var string
+     */
+    protected $fromEmail;
+
+    /**
+     * @var string
+     */
+    protected $template;
+
+    /**
+     * @var ContainerBuilder|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $container;
+
+    /**
+     * @var EngineInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $templating;
+
+    public function setUp(): void
+    {
+        $this->router = $this->createMock(RouterInterface::class);
+        $this->pool = $this->createMock(Pool::class);
+        $this->templateRegistry = $this->createMock(TemplateRegistryInterface::class);
+        $this->userManager = $this->createMock(UserManagerInterface::class);
+        $this->mailer = $this->createMock(\Swift_Mailer::class);
+        $this->tokenGenerator = $this->createMock(TokenGeneratorInterface::class);
+        $this->resetTtl = 60;
+        $this->fromEmail = 'noreply@sonata-project.org';
+        $this->template = 'email.txt.twig';
+        $this->container = $this->createMock(ContainerBuilder::class);
+        $this->templating = $this->createMock(EngineInterface::class);
+
+        $services = [
+            'router' => $this->router,
+            'templating' => $this->templating,
+        ];
+        $this->container->expects($this->any())
+            ->method('has')
+            ->willReturnCallback(function ($service) use ($services) {
+                return isset($services[$service]);
+            });
+        $this->container->expects($this->any())
+            ->method('get')
+            ->willReturnCallback(function ($service) use ($services) {
+                return $services[$service] ?? null;
+            });
+    }
+
+    public function testUnknownUsername(): void
+    {
+        $request = new Request([], ['username' => 'bar']);
+
+        $parameters = [
+            'base_template' => 'base.html.twig',
+            'admin_pool' => $this->pool,
+            'invalid_username' => 'bar',
+        ];
+
+        $this->templating->expects($this->once())
+            ->method('render')
+            ->with('@SonataUser/Admin/Security/Resetting/request.html.twig', $parameters)
+            ->willReturn('Foo Content');
+
+        $this->templateRegistry->expects($this->any())
+            ->method('getTemplate')
+            ->with('layout')
+            ->willReturn('base.html.twig');
+
+        $this->userManager->expects($this->any())
+            ->method('findUserByUsernameOrEmail')
+            ->with('bar')
+            ->willReturn(null);
+
+        $action = $this->getAction();
+        $result = $action($request);
+
+        $this->assertInstanceOf(Response::class, $result);
+        $this->assertEquals('Foo Content', $result->getContent());
+    }
+
+    public function testPasswordRequestNonExpired(): void
+    {
+        $request = new Request([], ['username' => 'bar']);
+
+        $user = $this->createMock(User::class);
+        $user->expects($this->any())
+            ->method('isPasswordRequestNonExpired')
+            ->willReturn(true);
+
+        $this->userManager->expects($this->any())
+            ->method('findUserByUsernameOrEmail')
+            ->with('bar')
+            ->willReturn($user);
+
+        $this->mailer->expects($this->never())
+            ->method('send');
+
+        $this->router->expects($this->any())
+            ->method('generate')
+            ->with('sonata_user_admin_resetting_check_email')
+            ->willReturn('/foo');
+
+        $action = $this->getAction();
+        $result = $action($request);
+
+        $this->assertInstanceOf(RedirectResponse::class, $result);
+        $this->assertEquals('/foo', $result->getTargetUrl());
+    }
+
+    public function testAccountLocked(): void
+    {
+        $request = new Request([], ['username' => 'bar']);
+
+        $user = $this->createMock(User::class);
+        $user->expects($this->any())
+            ->method('isPasswordRequestNonExpired')
+            ->willReturn(false);
+        $user->expects($this->any())
+            ->method('isAccountNonLocked')
+            ->willReturn(false);
+
+        $this->userManager->expects($this->any())
+            ->method('findUserByUsernameOrEmail')
+            ->with('bar')
+            ->willReturn($user);
+
+        $this->mailer->expects($this->never())
+            ->method('send');
+
+        $this->router->expects($this->any())
+            ->method('generate')
+            ->with('sonata_user_admin_resetting_request')
+            ->willReturn('/foo');
+
+        $action = $this->getAction();
+        $result = $action($request);
+
+        $this->assertInstanceOf(RedirectResponse::class, $result);
+        $this->assertEquals('/foo', $result->getTargetUrl());
+    }
+
+    public function testEmailSent(): void
+    {
+        $request = new Request([], ['username' => 'bar']);
+
+        $storedToken = null;
+
+        $user = $this->createMock(User::class);
+        $user->expects($this->any())
+            ->method('getEmail')
+            ->willReturn('user@sonata-project.org');
+        $user->expects($this->any())
+            ->method('isPasswordRequestNonExpired')
+            ->willReturn(false);
+        $user->expects($this->any())
+            ->method('isAccountNonLocked')
+            ->willReturn(true);
+        $user->expects($this->any())
+            ->method('setConfirmationToken')
+            ->willReturnCallback(function ($token) use (&$storedToken): void {
+                $storedToken = $token;
+            });
+        $user->expects($this->any())
+            ->method('getConfirmationToken')
+            ->willReturnCallback(function () use (&$storedToken) {
+                return $storedToken;
+            });
+
+        $this->userManager->expects($this->any())
+            ->method('findUserByUsernameOrEmail')
+            ->with('bar')
+            ->willReturn($user);
+
+        $this->tokenGenerator->expects($this->once())
+            ->method('generateToken')
+            ->willReturn('user-token');
+
+        $this->mailer->expects($this->once())
+            ->method('send');
+
+        $this->router->expects($this->any())
+            ->method('generate')
+            ->withConsecutive(
+                ['sonata_user_admin_resetting_reset', ['token' => 'user-token']],
+                ['sonata_user_admin_resetting_check_email', ['username' => 'bar']]
+            )
+            ->willReturnOnConsecutiveCalls(
+                '/reset',
+                '/check-email'
+            );
+
+        $parameters = [
+            'user' => $user,
+            'confirmationUrl' => '/reset',
+        ];
+
+        $this->templating->expects($this->once())
+            ->method('render')
+            ->with($this->template, $parameters)
+            ->willReturn("Subject\nMail content");
+
+        $this->mailer->expects($this->once())
+            ->method('send')
+            ->willReturnCallback(function (\Swift_Message $message): void {
+                $this->assertEquals('Subject', $message->getSubject());
+                $this->assertEquals('Mail content', $message->getBody());
+                $this->assertArrayHasKey($this->fromEmail, $message->getFrom());
+                $this->assertArrayHasKey('user@sonata-project.org', $message->getTo());
+            });
+
+        $action = $this->getAction();
+        $result = $action($request);
+
+        $this->assertInstanceOf(RedirectResponse::class, $result);
+        $this->assertEquals('/check-email', $result->getTargetUrl());
+    }
+
+    private function getAction(): SendEmailAction
+    {
+        $action = new SendEmailAction(
+            $this->router,
+            $this->pool,
+            $this->templateRegistry,
+            $this->userManager,
+            $this->mailer,
+            $this->tokenGenerator,
+            $this->resetTtl,
+            [$this->fromEmail],
+            $this->template
+        );
+        $action->setContainer($this->container);
+
+        return $action;
+    }
+}

--- a/tests/Controller/AdminResettingControllerTest.php
+++ b/tests/Controller/AdminResettingControllerTest.php
@@ -127,7 +127,7 @@ class AdminResettingControllerTest extends TestCase
             ->willReturn($request);
 
         $controller = $this->getController();
-        $result = $controller->sendEmailAction();
+        $result = $controller->sendEmailAction($request);
 
         $this->assertEquals('ok', $result);
     }

--- a/tests/Controller/AdminSecurityControllerTest.php
+++ b/tests/Controller/AdminSecurityControllerTest.php
@@ -14,19 +14,87 @@ declare(strict_types=1);
 namespace Sonata\UserBundle\Tests\Controller;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\UserBundle\Action\CheckLoginAction;
+use Sonata\UserBundle\Action\LoginAction;
+use Sonata\UserBundle\Action\LogoutAction;
 use Sonata\UserBundle\Controller\AdminSecurityController;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 class AdminSecurityControllerTest extends TestCase
 {
-    private $controller;
+    /**
+     * @var TestSecurityAction
+     */
+    private $testAction;
+
+    /**
+     * @var ContainerBuilder|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $container;
 
     protected function setUp(): void
     {
-        $this->controller = new AdminSecurityController();
+        $this->container = $this->createMock(ContainerBuilder::class);
+        $this->testAction = new TestSecurityAction();
+
+        $services = [
+            CheckLoginAction::class => $this->testAction,
+            LoginAction::class => $this->testAction,
+            LogoutAction::class => $this->testAction,
+        ];
+        $this->container->expects($this->any())
+            ->method('has')
+            ->willReturnCallback(function ($service) use ($services) {
+                return isset($services[$service]);
+            });
+        $this->container->expects($this->any())
+            ->method('get')
+            ->willReturnCallback(function ($service) use ($services) {
+                return $services[$service] ?? null;
+            });
     }
 
-    public function testItIsInstantiable(): void
+    public function getController(): AdminSecurityController
     {
-        $this->assertNotNull($this->controller);
+        $controller = new AdminSecurityController();
+        $controller->setContainer($this->container);
+
+        return $controller;
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation The Sonata\UserBundle\Controller\AdminSecurityController class is deprecated since version 4.x and will be removed in 5.0. Use Sonata\UserBundle\Controller\CheckLoginAction, Sonata\UserBundle\Controller\LoginAction or Sonata\UserBundle\Controller\LogoutAction instead.
+     */
+    public function testLogoutAction(): void
+    {
+        $controller = $this->getController();
+        $controller->logoutAction();
+    }
+
+    public function testCheckLoginAction(): void
+    {
+        $controller = $this->getController();
+        $controller->checkAction();
+    }
+
+    public function testLoginAction(): void
+    {
+        $request = new Request();
+
+        $controller = $this->getController();
+        $result = $controller->loginAction($request);
+
+        $this->assertInstanceOf(Response::class, $result);
+    }
+}
+
+final class TestSecurityAction
+{
+    public function __invoke()
+    {
+        return new Response();
     }
 }


### PR DESCRIPTION
I am targeting this branch, because this is backward compatible.

## Changelog

```markdown
### Changed
- `Controller\AdminResettingController` is now deprecated in favor of `Action\{CheckEmail,Request,Reset,SendEmail}Action`
- `Controller\AdminSecurityController` is now deprecated in favor of `Action\{CheckLogin,Login,Logout}Action`
```

## To do
    
- [x] Deprecated `AdminResettingController`
- [x] Deprecated `AdminSecurityController`

## Subject

As discussed in #1052, this PR deprecates `AdminResettingController` in favor of new Actions. Changes are based on the work done on this PR : https://github.com/sonata-project/SonataAdminBundle/pull/5120

This may be a first run, so comments are welcomed :)
~~I think we should also include the deprecation of `AdminSecurityController` to be consistent~~ (done)

