### PR TITLE
Allow usage of JMS SerializerBundle 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
     },
     "conflict": {
         "friendsofsymfony/rest-bundle": "<2.1 || >=3.0",
-        "jms/serializer": "<0.13 || >=2.0",
+        "jms/serializer": "<0.13 || >=3.0",
         "nelmio/api-doc-bundle": "<2.4",
         "sonata-project/block-bundle": "<3.11",
         "sonata-project/doctrine-orm-admin-bundle": "<3.0",
@@ -53,7 +53,7 @@
     "require-dev": {
         "doctrine/orm": "^2.0",
         "friendsofsymfony/rest-bundle": "^2.1",
-        "jms/serializer-bundle": "^1.0 || ^2.0",
+        "jms/serializer-bundle": "^1.0 || ^2.0 || ^3.0",
         "matthiasnoback/symfony-config-test": "^4.0",
         "matthiasnoback/symfony-dependency-injection-test": "^3.0",
         "nelmio/api-doc-bundle": "^2.4",


### PR DESCRIPTION
## Subject

I am targeting this branch, because it's a backwards compatible version constraint modification.
None of the BC breaks of a new major version of JMS SerializerBundle seem to affect common use cases found in SonataUserBundle. Therefore no special code modifications are required.

Closes #1082

## Changelog
```markdown
### Added
- Added compatibility with jms/serializer-bundle:^3.0 and jms/serializer:^2.0
```