### PR TITLE
Allow using external model classes

### DIFF
--- a/tests/Controller/Api/GroupControllerTest.php
+++ b/tests/Controller/Api/GroupControllerTest.php
@@ -26,13 +26,13 @@ class GroupControllerTest extends TestCase
     {
         $group = $this->createMock('FOS\UserBundle\Model\GroupInterface');
         $groupManager = $this->createMock('Sonata\UserBundle\Model\GroupManagerInterface');
-        $groupManager->expects($this->once())->method('getPager')->will($this->returnValue([$group]));
+        $groupManager->expects($this->once())->method('getPager')->willReturn([$group]);
 
         $paramFetcher = $this->getMockBuilder('FOS\RestBundle\Request\ParamFetcher')
             ->disableOriginalConstructor()
             ->getMock();
         $paramFetcher->expects($this->exactly(3))->method('get');
-        $paramFetcher->expects($this->once())->method('all')->will($this->returnValue([]));
+        $paramFetcher->expects($this->once())->method('all')->willReturn([]);
 
         $this->assertSame([$group], $this->createGroupController(null, $groupManager)->getGroupsAction($paramFetcher));
     }
@@ -56,16 +56,16 @@ class GroupControllerTest extends TestCase
         $group = $this->createMock('FOS\UserBundle\Model\GroupInterface');
 
         $groupManager = $this->createMock('Sonata\UserBundle\Model\GroupManagerInterface');
-        $groupManager->expects($this->once())->method('getClass')->will($this->returnValue('Sonata\UserBundle\Entity\BaseGroup'));
-        $groupManager->expects($this->once())->method('updateGroup')->will($this->returnValue($group));
+        $groupManager->expects($this->once())->method('getClass')->willReturn('Sonata\UserBundle\Entity\BaseGroup');
+        $groupManager->expects($this->once())->method('updateGroup')->willReturn($group);
 
         $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
         $form->expects($this->once())->method('handleRequest');
-        $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
-        $form->expects($this->once())->method('getData')->will($this->returnValue($group));
+        $form->expects($this->once())->method('isValid')->willReturn(true);
+        $form->expects($this->once())->method('getData')->willReturn($group);
 
         $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
-        $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
+        $formFactory->expects($this->once())->method('createNamed')->willReturn($form);
 
         $view = $this->createGroupController(null, $groupManager, $formFactory)->postGroupAction(new Request());
 
@@ -75,14 +75,14 @@ class GroupControllerTest extends TestCase
     public function testPostGroupInvalidAction(): void
     {
         $groupManager = $this->createMock('Sonata\UserBundle\Model\GroupManagerInterface');
-        $groupManager->expects($this->once())->method('getClass')->will($this->returnValue('Sonata\UserBundle\Entity\BaseGroup'));
+        $groupManager->expects($this->once())->method('getClass')->willReturn('Sonata\UserBundle\Entity\BaseGroup');
 
         $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
         $form->expects($this->once())->method('handleRequest');
-        $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
+        $form->expects($this->once())->method('isValid')->willReturn(false);
 
         $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
-        $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
+        $formFactory->expects($this->once())->method('createNamed')->willReturn($form);
 
         $view = $this->createGroupController(null, $groupManager, $formFactory)->postGroupAction(new Request());
 
@@ -94,17 +94,17 @@ class GroupControllerTest extends TestCase
         $group = $this->createMock('FOS\UserBundle\Model\GroupInterface');
 
         $groupManager = $this->createMock('Sonata\UserBundle\Model\GroupManagerInterface');
-        $groupManager->expects($this->once())->method('getClass')->will($this->returnValue('Sonata\UserBundle\Entity\BaseGroup'));
-        $groupManager->expects($this->once())->method('findGroupBy')->will($this->returnValue($group));
-        $groupManager->expects($this->once())->method('updateGroup')->will($this->returnValue($group));
+        $groupManager->expects($this->once())->method('getClass')->willReturn('Sonata\UserBundle\Entity\BaseGroup');
+        $groupManager->expects($this->once())->method('findGroupBy')->willReturn($group);
+        $groupManager->expects($this->once())->method('updateGroup')->willReturn($group);
 
         $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
         $form->expects($this->once())->method('handleRequest');
-        $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
-        $form->expects($this->once())->method('getData')->will($this->returnValue($group));
+        $form->expects($this->once())->method('isValid')->willReturn(true);
+        $form->expects($this->once())->method('getData')->willReturn($group);
 
         $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
-        $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
+        $formFactory->expects($this->once())->method('createNamed')->willReturn($form);
 
         $view = $this->createGroupController($group, $groupManager, $formFactory)->putGroupAction(1, new Request());
 
@@ -116,15 +116,15 @@ class GroupControllerTest extends TestCase
         $group = $this->createMock('FOS\UserBundle\Model\GroupInterface');
 
         $groupManager = $this->createMock('Sonata\UserBundle\Model\GroupManagerInterface');
-        $groupManager->expects($this->once())->method('getClass')->will($this->returnValue('Sonata\UserBundle\Entity\BaseGroup'));
-        $groupManager->expects($this->once())->method('findGroupBy')->will($this->returnValue($group));
+        $groupManager->expects($this->once())->method('getClass')->willReturn('Sonata\UserBundle\Entity\BaseGroup');
+        $groupManager->expects($this->once())->method('findGroupBy')->willReturn($group);
 
         $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
         $form->expects($this->once())->method('handleRequest');
-        $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
+        $form->expects($this->once())->method('isValid')->willReturn(false);
 
         $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
-        $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
+        $formFactory->expects($this->once())->method('createNamed')->willReturn($form);
 
         $view = $this->createGroupController($group, $groupManager, $formFactory)->putGroupAction(1, new Request());
 
@@ -136,8 +136,8 @@ class GroupControllerTest extends TestCase
         $group = $this->createMock('FOS\UserBundle\Model\GroupInterface');
 
         $groupManager = $this->createMock('Sonata\UserBundle\Model\GroupManagerInterface');
-        $groupManager->expects($this->once())->method('findGroupBy')->will($this->returnValue($group));
-        $groupManager->expects($this->once())->method('deleteGroup')->will($this->returnValue($group));
+        $groupManager->expects($this->once())->method('findGroupBy')->willReturn($group);
+        $groupManager->expects($this->once())->method('deleteGroup')->willReturn($group);
 
         $view = $this->createGroupController($group, $groupManager)->deleteGroupAction(1);
 
@@ -149,7 +149,7 @@ class GroupControllerTest extends TestCase
         $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
 
         $groupManager = $this->createMock('Sonata\UserBundle\Model\GroupManagerInterface');
-        $groupManager->expects($this->once())->method('findGroupBy')->will($this->returnValue(null));
+        $groupManager->expects($this->once())->method('findGroupBy')->willReturn(null);
         $groupManager->expects($this->never())->method('deleteGroup');
 
         $this->createGroupController(null, $groupManager)->deleteGroupAction(1);
@@ -168,7 +168,7 @@ class GroupControllerTest extends TestCase
             $groupManager = $this->createMock('Sonata\UserBundle\Model\GroupManagerInterface');
         }
         if (null !== $group) {
-            $groupManager->expects($this->once())->method('findGroupBy')->will($this->returnValue($group));
+            $groupManager->expects($this->once())->method('findGroupBy')->willReturn($group);
         }
         if (null === $formFactory) {
             $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');

--- a/tests/Controller/Api/UserControllerTest.php
+++ b/tests/Controller/Api/UserControllerTest.php
@@ -25,13 +25,13 @@ class UserControllerTest extends TestCase
     public function testGetUsersAction(): void
     {
         $userManager = $this->createMock('Sonata\UserBundle\Model\UserManagerInterface');
-        $userManager->expects($this->once())->method('getPager')->will($this->returnValue([]));
+        $userManager->expects($this->once())->method('getPager')->willReturn([]);
 
         $paramFetcher = $this->getMockBuilder('FOS\RestBundle\Request\ParamFetcher')
             ->disableOriginalConstructor()
             ->getMock();
         $paramFetcher->expects($this->exactly(3))->method('get');
-        $paramFetcher->expects($this->once())->method('all')->will($this->returnValue([]));
+        $paramFetcher->expects($this->once())->method('all')->willReturn([]);
 
         $this->assertSame([], $this->createUserController(null, $userManager)->getUsersAction($paramFetcher));
     }
@@ -55,15 +55,15 @@ class UserControllerTest extends TestCase
         $user = $this->createMock('FOS\UserBundle\Model\UserInterface');
 
         $userManager = $this->createMock('Sonata\UserBundle\Model\UserManagerInterface');
-        $userManager->expects($this->once())->method('updateUser')->will($this->returnValue($user));
+        $userManager->expects($this->once())->method('updateUser')->willReturn($user);
 
         $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
         $form->expects($this->once())->method('handleRequest');
-        $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
-        $form->expects($this->once())->method('getData')->will($this->returnValue($user));
+        $form->expects($this->once())->method('isValid')->willReturn(true);
+        $form->expects($this->once())->method('getData')->willReturn($user);
 
         $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
-        $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
+        $formFactory->expects($this->once())->method('createNamed')->willReturn($form);
 
         $view = $this->createUserController(null, $userManager, null, $formFactory)->postUserAction(new Request());
 
@@ -76,10 +76,10 @@ class UserControllerTest extends TestCase
 
         $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
         $form->expects($this->once())->method('handleRequest');
-        $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
+        $form->expects($this->once())->method('isValid')->willReturn(false);
 
         $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
-        $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
+        $formFactory->expects($this->once())->method('createNamed')->willReturn($form);
 
         $view = $this->createUserController(null, $userManager, null, $formFactory)->postUserAction(new Request());
 
@@ -91,16 +91,16 @@ class UserControllerTest extends TestCase
         $user = $this->createMock('FOS\UserBundle\Model\UserInterface');
 
         $userManager = $this->createMock('Sonata\UserBundle\Model\UserManagerInterface');
-        $userManager->expects($this->once())->method('findUserBy')->will($this->returnValue($user));
-        $userManager->expects($this->once())->method('updateUser')->will($this->returnValue($user));
+        $userManager->expects($this->once())->method('findUserBy')->willReturn($user);
+        $userManager->expects($this->once())->method('updateUser')->willReturn($user);
 
         $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
         $form->expects($this->once())->method('handleRequest');
-        $form->expects($this->once())->method('isValid')->will($this->returnValue(true));
-        $form->expects($this->once())->method('getData')->will($this->returnValue($user));
+        $form->expects($this->once())->method('isValid')->willReturn(true);
+        $form->expects($this->once())->method('getData')->willReturn($user);
 
         $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
-        $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
+        $formFactory->expects($this->once())->method('createNamed')->willReturn($form);
 
         $view = $this->createUserController($user, $userManager, null, $formFactory)->putUserAction(1, new Request());
 
@@ -112,14 +112,14 @@ class UserControllerTest extends TestCase
         $user = $this->createMock('FOS\UserBundle\Model\UserInterface');
 
         $userManager = $this->createMock('Sonata\UserBundle\Model\UserManagerInterface');
-        $userManager->expects($this->once())->method('findUserBy')->will($this->returnValue($user));
+        $userManager->expects($this->once())->method('findUserBy')->willReturn($user);
 
         $form = $this->getMockBuilder('Symfony\Component\Form\Form')->disableOriginalConstructor()->getMock();
         $form->expects($this->once())->method('handleRequest');
-        $form->expects($this->once())->method('isValid')->will($this->returnValue(false));
+        $form->expects($this->once())->method('isValid')->willReturn(false);
 
         $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');
-        $formFactory->expects($this->once())->method('createNamed')->will($this->returnValue($form));
+        $formFactory->expects($this->once())->method('createNamed')->willReturn($form);
 
         $view = $this->createUserController($user, $userManager, null, $formFactory)->putUserAction(1, new Request());
 
@@ -129,16 +129,16 @@ class UserControllerTest extends TestCase
     public function testPostUserGroupAction(): void
     {
         $user = $this->createMock('Sonata\UserBundle\Entity\BaseUser');
-        $user->expects($this->once())->method('hasGroup')->will($this->returnValue(false));
+        $user->expects($this->once())->method('hasGroup')->willReturn(false);
 
         $group = $this->createMock('FOS\UserBundle\Model\GroupInterface');
 
         $userManager = $this->createMock('Sonata\UserBundle\Model\UserManagerInterface');
-        $userManager->expects($this->once())->method('findUserBy')->will($this->returnValue($user));
-        $userManager->expects($this->once())->method('updateUser')->will($this->returnValue($user));
+        $userManager->expects($this->once())->method('findUserBy')->willReturn($user);
+        $userManager->expects($this->once())->method('updateUser')->willReturn($user);
 
         $groupManager = $this->createMock('Sonata\UserBundle\Model\GroupManagerInterface');
-        $groupManager->expects($this->once())->method('findGroupBy')->will($this->returnValue($group));
+        $groupManager->expects($this->once())->method('findGroupBy')->willReturn($group);
 
         $view = $this->createUserController($user, $userManager, $groupManager)->postUserGroupAction(1, 1);
 
@@ -148,15 +148,15 @@ class UserControllerTest extends TestCase
     public function testPostUserGroupInvalidAction(): void
     {
         $user = $this->createMock('Sonata\UserBundle\Entity\BaseUser');
-        $user->expects($this->once())->method('hasGroup')->will($this->returnValue(true));
+        $user->expects($this->once())->method('hasGroup')->willReturn(true);
 
         $group = $this->createMock('FOS\UserBundle\Model\GroupInterface');
 
         $userManager = $this->createMock('Sonata\UserBundle\Model\UserManagerInterface');
-        $userManager->expects($this->once())->method('findUserBy')->will($this->returnValue($user));
+        $userManager->expects($this->once())->method('findUserBy')->willReturn($user);
 
         $groupManager = $this->createMock('Sonata\UserBundle\Model\GroupManagerInterface');
-        $groupManager->expects($this->once())->method('findGroupBy')->will($this->returnValue($group));
+        $groupManager->expects($this->once())->method('findGroupBy')->willReturn($group);
 
         $view = $this->createUserController($user, $userManager, $groupManager)->postUserGroupAction(1, 1);
 
@@ -171,16 +171,16 @@ class UserControllerTest extends TestCase
     public function testDeleteUserGroupAction(): void
     {
         $user = $this->createMock('Sonata\UserBundle\Entity\BaseUser');
-        $user->expects($this->once())->method('hasGroup')->will($this->returnValue(true));
+        $user->expects($this->once())->method('hasGroup')->willReturn(true);
 
         $group = $this->createMock('FOS\UserBundle\Model\GroupInterface');
 
         $userManager = $this->createMock('Sonata\UserBundle\Model\UserManagerInterface');
-        $userManager->expects($this->once())->method('findUserBy')->will($this->returnValue($user));
-        $userManager->expects($this->once())->method('updateUser')->will($this->returnValue($user));
+        $userManager->expects($this->once())->method('findUserBy')->willReturn($user);
+        $userManager->expects($this->once())->method('updateUser')->willReturn($user);
 
         $groupManager = $this->createMock('Sonata\UserBundle\Model\GroupManagerInterface');
-        $groupManager->expects($this->once())->method('findGroupBy')->will($this->returnValue($group));
+        $groupManager->expects($this->once())->method('findGroupBy')->willReturn($group);
 
         $view = $this->createUserController($user, $userManager, $groupManager)->deleteUserGroupAction(1, 1);
 
@@ -190,15 +190,15 @@ class UserControllerTest extends TestCase
     public function testDeleteUserGroupInvalidAction(): void
     {
         $user = $this->createMock('Sonata\UserBundle\Entity\BaseUser');
-        $user->expects($this->once())->method('hasGroup')->will($this->returnValue(false));
+        $user->expects($this->once())->method('hasGroup')->willReturn(false);
 
         $group = $this->createMock('FOS\UserBundle\Model\GroupInterface');
 
         $userManager = $this->createMock('Sonata\UserBundle\Model\UserManagerInterface');
-        $userManager->expects($this->once())->method('findUserBy')->will($this->returnValue($user));
+        $userManager->expects($this->once())->method('findUserBy')->willReturn($user);
 
         $groupManager = $this->createMock('Sonata\UserBundle\Model\GroupManagerInterface');
-        $groupManager->expects($this->once())->method('findGroupBy')->will($this->returnValue($group));
+        $groupManager->expects($this->once())->method('findGroupBy')->willReturn($group);
 
         $view = $this->createUserController($user, $userManager, $groupManager)->deleteUserGroupAction(1, 1);
 
@@ -215,8 +215,8 @@ class UserControllerTest extends TestCase
         $user = $this->createMock('FOS\UserBundle\Model\UserInterface');
 
         $userManager = $this->createMock('Sonata\UserBundle\Model\UserManagerInterface');
-        $userManager->expects($this->once())->method('findUserBy')->will($this->returnValue($user));
-        $userManager->expects($this->once())->method('deleteUser')->will($this->returnValue($user));
+        $userManager->expects($this->once())->method('findUserBy')->willReturn($user);
+        $userManager->expects($this->once())->method('deleteUser')->willReturn($user);
 
         $view = $this->createUserController($user, $userManager)->deleteUserAction(1);
 
@@ -228,7 +228,7 @@ class UserControllerTest extends TestCase
         $this->expectException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException');
 
         $userManager = $this->createMock('Sonata\UserBundle\Model\UserManagerInterface');
-        $userManager->expects($this->once())->method('findUserBy')->will($this->returnValue(null));
+        $userManager->expects($this->once())->method('findUserBy')->willReturn(null);
         $userManager->expects($this->never())->method('deleteUser');
 
         $this->createUserController(null, $userManager)->deleteUserAction(1);
@@ -251,7 +251,7 @@ class UserControllerTest extends TestCase
             $groupManager = $this->createMock('Sonata\UserBundle\Model\GroupManagerInterface');
         }
         if (null !== $user) {
-            $userManager->expects($this->once())->method('findUserBy')->will($this->returnValue($user));
+            $userManager->expects($this->once())->method('findUserBy')->willReturn($user);
         }
         if (null === $formFactory) {
             $formFactory = $this->createMock('Symfony\Component\Form\FormFactoryInterface');

--- a/tests/DependencyInjection/SonataUserExtensionTest.php
+++ b/tests/DependencyInjection/SonataUserExtensionTest.php
@@ -168,28 +168,45 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
      * @group legacy
      * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
      */
-    public function testIncorrectModelClass(): void
+    public function testFosUserBundleModelClasses(): void
     {
-        $this->expectException('InvalidArgumentException');
-
-        $this->expectExceptionMessage('Model class "Foo\User" does not correspond to manager type "orm".');
-
-        $this->load(['class' => ['user' => 'Foo\User']]);
+        $this->load(['manager_type' => 'orm', 'class' => [
+            'user' => 'FOS\UserBundle\Model\UserInterface',
+            'group' => 'FOS\UserBundle\Model\GroupInterface',
+        ]]);
     }
 
     /**
      * @group legacy
      * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
      */
-    public function testNotCorrespondingModelClass(): void
+    public function testNotCorrespondingUserClass(): void
     {
         $this->expectException('InvalidArgumentException');
 
         $this->expectExceptionMessage(
-            'Model class "Sonata\UserBundle\Admin\Entity\UserAdmin" does not correspond to manager type "mongodb".'
+            'Model class "Sonata\UserBundle\Entity\BaseUser" does not correspond to manager type "mongodb".'
         );
 
-        $this->load(['manager_type' => 'mongodb', 'class' => ['user' => 'Sonata\UserBundle\Admin\Entity\UserAdmin']]);
+        $this->load(['manager_type' => 'mongodb', 'class' => ['user' => 'Sonata\UserBundle\Entity\BaseUser']]);
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
+     */
+    public function testNotCorrespondingGroupClass(): void
+    {
+        $this->expectException('InvalidArgumentException');
+
+        $this->expectExceptionMessage(
+            'Model class "Sonata\UserBundle\Entity\BaseGroup" does not correspond to manager type "mongodb".'
+        );
+
+        $this->load(['manager_type' => 'mongodb', 'class' => [
+            'user' => 'Sonata\UserBundle\Document\BaseUser',
+            'group' => 'Sonata\UserBundle\Entity\BaseGroup',
+        ]]);
     }
 
     /**

--- a/tests/Document/BaseUserTest.php
+++ b/tests/Document/BaseUserTest.php
@@ -76,9 +76,9 @@ class BaseUserTest extends TestCase
         // Given
         $user = new BaseUser();
         $group1 = $this->createMock('FOS\UserBundle\Model\GroupInterface');
-        $group1->expects($this->any())->method('getName')->will($this->returnValue('Group 1'));
+        $group1->expects($this->any())->method('getName')->willReturn('Group 1');
         $group2 = $this->createMock('FOS\UserBundle\Model\GroupInterface');
-        $group2->expects($this->any())->method('getName')->will($this->returnValue('Group 2'));
+        $group2->expects($this->any())->method('getName')->willReturn('Group 2');
 
         // When
         $user->setGroups([$group1, $group2]);

--- a/tests/Entity/BaseUserTest.php
+++ b/tests/Entity/BaseUserTest.php
@@ -76,9 +76,9 @@ class BaseUserTest extends TestCase
         // Given
         $user = new BaseUser();
         $group1 = $this->createMock('FOS\UserBundle\Model\GroupInterface');
-        $group1->expects($this->any())->method('getName')->will($this->returnValue('Group 1'));
+        $group1->expects($this->any())->method('getName')->willReturn('Group 1');
         $group2 = $this->createMock('FOS\UserBundle\Model\GroupInterface');
-        $group2->expects($this->any())->method('getName')->will($this->returnValue('Group 2'));
+        $group2->expects($this->any())->method('getName')->willReturn('Group 2');
 
         // When
         $user->setGroups([$group1, $group2]);

--- a/tests/Form/Transformer/RestoreRolesTransformerTest.php
+++ b/tests/Form/Transformer/RestoreRolesTransformerTest.php
@@ -55,7 +55,7 @@ class RestoreRolesTransformerTest extends TestCase
     {
         $roleBuilder = $this->createMock(EditableRolesBuilder::class);
 
-        $roleBuilder->expects($this->once())->method('getRoles')->will($this->returnValue([]));
+        $roleBuilder->expects($this->once())->method('getRoles')->willReturn([]);
 
         $transformer = new RestoreRolesTransformer($roleBuilder);
         $transformer->setOriginalRoles(['ROLE_HIDDEN']);
@@ -81,7 +81,7 @@ class RestoreRolesTransformerTest extends TestCase
     {
         $roleBuilder = $this->createMock(EditableRolesBuilder::class);
 
-        $roleBuilder->expects($this->once())->method('getRoles')->will($this->returnValue([]));
+        $roleBuilder->expects($this->once())->method('getRoles')->willReturn([]);
 
         $transformer = new RestoreRolesTransformer($roleBuilder);
         $transformer->setOriginalRoles(null);
@@ -102,7 +102,7 @@ class RestoreRolesTransformerTest extends TestCase
             'ROLE_COMPANY_BOOKKEEPER' => 'ROLE_COMPANY_BOOKKEEPER: ROLE_COMPANY_USER',
             'ROLE_USER' => 'ROLE_USER',
         ];
-        $roleBuilder->expects($this->once())->method('getRoles')->will($this->returnValue($availableRoles));
+        $roleBuilder->expects($this->once())->method('getRoles')->willReturn($availableRoles);
 
         // user roles
         $userRoles = ['ROLE_COMPANY_PERSONAL_MODERATOR', 'ROLE_COMPANY_NEWS_MODERATOR', 'ROLE_COMPANY_BOOKKEEPER'];
@@ -124,7 +124,7 @@ class RestoreRolesTransformerTest extends TestCase
             'ROLE_SONATA_ADMIN' => 'ROLE_SONATA_ADMIN',
             'ROLE_ADMIN' => 'ROLE_ADMIN: ROLE_USER ROLE_COMPANY_ADMIN',
         ];
-        $roleBuilder->expects($this->once())->method('getRoles')->will($this->returnValue($availableRoles));
+        $roleBuilder->expects($this->once())->method('getRoles')->willReturn($availableRoles);
 
         // user roles
         $userRoles = ['ROLE_USER', 'ROLE_SUPER_ADMIN'];

--- a/tests/Form/Type/RolesMatrixTypeTest.php
+++ b/tests/Form/Type/RolesMatrixTypeTest.php
@@ -100,11 +100,11 @@ final class RolesMatrixTypeTest extends TypeTestCase
     {
         $this->roleBuilder = $this->createMock(ExpandableRolesBuilderInterface::class);
 
-        $this->roleBuilder->expects($this->any())->method('getRoles')->will($this->returnValue([
+        $this->roleBuilder->expects($this->any())->method('getRoles')->willReturn([
           'ROLE_FOO' => 'ROLE_FOO',
           'ROLE_USER' => 'ROLE_USER',
           'ROLE_ADMIN' => 'ROLE_ADMIN: ROLE_USER',
-        ]));
+        ]);
 
         $childType = new RolesMatrixType($this->roleBuilder);
 

--- a/tests/Form/Type/SecurityRolesTypeTest.php
+++ b/tests/Form/Type/SecurityRolesTypeTest.php
@@ -102,13 +102,13 @@ class SecurityRolesTypeTest extends TypeTestCase
     {
         $this->roleBuilder = $roleBuilder = $this->createMock(EditableRolesBuilder::class);
 
-        $this->roleBuilder->expects($this->any())->method('getRoles')->will($this->returnValue([
+        $this->roleBuilder->expects($this->any())->method('getRoles')->willReturn([
           'ROLE_FOO' => 'ROLE_FOO',
           'ROLE_USER' => 'ROLE_USER',
           'ROLE_ADMIN' => 'ROLE_ADMIN: ROLE_USER',
-        ]));
+        ]);
 
-        $this->roleBuilder->expects($this->any())->method('getRolesReadOnly')->will($this->returnValue([]));
+        $this->roleBuilder->expects($this->any())->method('getRolesReadOnly')->willReturn([]);
 
         $childType = new SecurityRolesType($this->roleBuilder);
 

--- a/tests/Security/Authorization/Voter/UserAclVoterTest.php
+++ b/tests/Security/Authorization/Voter/UserAclVoterTest.php
@@ -24,13 +24,13 @@ class UserAclVoterTest extends TestCase
     {
         // Given
         $user = $this->createMock('FOS\UserBundle\Model\UserInterface');
-        $user->expects($this->any())->method('isSuperAdmin')->will($this->returnValue(true));
+        $user->expects($this->any())->method('isSuperAdmin')->willReturn(true);
 
         $loggedInUser = $this->createMock('FOS\UserBundle\Model\UserInterface');
-        $loggedInUser->expects($this->any())->method('isSuperAdmin')->will($this->returnValue(true));
+        $loggedInUser->expects($this->any())->method('isSuperAdmin')->willReturn(true);
 
         $token = $this->createMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
-        $token->expects($this->any())->method('getUser')->will($this->returnValue($loggedInUser));
+        $token->expects($this->any())->method('getUser')->willReturn($loggedInUser);
 
         $aclProvider = $this->createMock('Symfony\Component\Security\Acl\Model\AclProviderInterface');
         $oidRetrievalStrategy = $this->createMock('Symfony\Component\Security\Acl\Model\ObjectIdentityRetrievalStrategyInterface');
@@ -50,13 +50,13 @@ class UserAclVoterTest extends TestCase
     {
         // Given
         $user = $this->createMock('FOS\UserBundle\Model\UserInterface');
-        $user->expects($this->any())->method('isSuperAdmin')->will($this->returnValue(true));
+        $user->expects($this->any())->method('isSuperAdmin')->willReturn(true);
 
         $loggedInUser = $this->createMock('FOS\UserBundle\Model\UserInterface');
-        $loggedInUser->expects($this->any())->method('isSuperAdmin')->will($this->returnValue(false));
+        $loggedInUser->expects($this->any())->method('isSuperAdmin')->willReturn(false);
 
         $token = $this->createMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
-        $token->expects($this->any())->method('getUser')->will($this->returnValue($loggedInUser));
+        $token->expects($this->any())->method('getUser')->willReturn($loggedInUser);
 
         $aclProvider = $this->createMock('Symfony\Component\Security\Acl\Model\AclProviderInterface');
         $oidRetrievalStrategy = $this->createMock('Symfony\Component\Security\Acl\Model\ObjectIdentityRetrievalStrategyInterface');
@@ -76,12 +76,12 @@ class UserAclVoterTest extends TestCase
     {
         // Given
         $user = $this->createMock('FOS\UserBundle\Model\UserInterface');
-        $user->expects($this->any())->method('isSuperAdmin')->will($this->returnValue(true));
+        $user->expects($this->any())->method('isSuperAdmin')->willReturn(true);
 
         $loggedInUser = null;
 
         $token = $this->createMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
-        $token->expects($this->any())->method('getUser')->will($this->returnValue($loggedInUser));
+        $token->expects($this->any())->method('getUser')->willReturn($loggedInUser);
 
         $aclProvider = $this->createMock('Symfony\Component\Security\Acl\Model\AclProviderInterface');
         $oidRetrievalStrategy = $this->createMock('Symfony\Component\Security\Acl\Model\ObjectIdentityRetrievalStrategyInterface');
@@ -101,12 +101,12 @@ class UserAclVoterTest extends TestCase
     {
         // Given
         $user = $this->createMock('FOS\UserBundle\Model\UserInterface');
-        $user->expects($this->any())->method('isSuperAdmin')->will($this->returnValue(true));
+        $user->expects($this->any())->method('isSuperAdmin')->willReturn(true);
 
         $loggedInUser = $this->createMock(UserInterface::class);
 
         $token = $this->createMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
-        $token->expects($this->any())->method('getUser')->will($this->returnValue($loggedInUser));
+        $token->expects($this->any())->method('getUser')->willReturn($loggedInUser);
 
         $aclProvider = $this->createMock('Symfony\Component\Security\Acl\Model\AclProviderInterface');
         $oidRetrievalStrategy = $this->createMock('Symfony\Component\Security\Acl\Model\ObjectIdentityRetrievalStrategyInterface');

--- a/tests/Security/EditableRolesBuilderTest.php
+++ b/tests/Security/EditableRolesBuilderTest.php
@@ -28,16 +28,16 @@ class EditableRolesBuilderTest extends TestCase
         $token = $this->createMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
 
         $tokenStorage = $this->createMock(TokenStorageInterface::class);
-        $tokenStorage->expects($this->any())->method('getToken')->will($this->returnValue($token));
+        $tokenStorage->expects($this->any())->method('getToken')->willReturn($token);
 
         $authorizationChecker = $this->createMock(AuthorizationCheckerInterface::class);
-        $authorizationChecker->expects($this->any())->method('isGranted')->will($this->returnValue(true));
+        $authorizationChecker->expects($this->any())->method('isGranted')->willReturn(true);
 
         $pool = $this->getMockBuilder('Sonata\AdminBundle\Admin\Pool')
                 ->disableOriginalConstructor()
                 ->getMock();
 
-        $pool->expects($this->exactly(2))->method('getAdminServiceIds')->will($this->returnValue([]));
+        $pool->expects($this->exactly(2))->method('getAdminServiceIds')->willReturn([]);
 
         $rolesHierarchy = [
             'ROLE_ADMIN' => [
@@ -76,27 +76,27 @@ class EditableRolesBuilderTest extends TestCase
     public function testRolesFromAdminWithMasterAdmin(): void
     {
         $securityHandler = $this->createMock('Sonata\AdminBundle\Security\Handler\SecurityHandlerInterface');
-        $securityHandler->expects($this->exactly(2))->method('getBaseRole')->will($this->returnValue('ROLE_FOO_%s'));
+        $securityHandler->expects($this->exactly(2))->method('getBaseRole')->willReturn('ROLE_FOO_%s');
 
         $admin = $this->createMock('Sonata\AdminBundle\Admin\AdminInterface');
-        $admin->expects($this->exactly(2))->method('isGranted')->will($this->returnValue(true));
-        $admin->expects($this->exactly(2))->method('getSecurityInformation')->will($this->returnValue(['GUEST' => [0 => 'VIEW', 1 => 'LIST'], 'STAFF' => [0 => 'EDIT', 1 => 'LIST', 2 => 'CREATE'], 'EDITOR' => [0 => 'OPERATOR', 1 => 'EXPORT'], 'ADMIN' => [0 => 'MASTER']]));
-        $admin->expects($this->exactly(2))->method('getSecurityHandler')->will($this->returnValue($securityHandler));
+        $admin->expects($this->exactly(2))->method('isGranted')->willReturn(true);
+        $admin->expects($this->exactly(2))->method('getSecurityInformation')->willReturn(['GUEST' => [0 => 'VIEW', 1 => 'LIST'], 'STAFF' => [0 => 'EDIT', 1 => 'LIST', 2 => 'CREATE'], 'EDITOR' => [0 => 'OPERATOR', 1 => 'EXPORT'], 'ADMIN' => [0 => 'MASTER']]);
+        $admin->expects($this->exactly(2))->method('getSecurityHandler')->willReturn($securityHandler);
 
         $token = $this->createMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
 
         $tokenStorage = $this->createMock(TokenStorageInterface::class);
-        $tokenStorage->expects($this->any())->method('getToken')->will($this->returnValue($token));
+        $tokenStorage->expects($this->any())->method('getToken')->willReturn($token);
 
         $authorizationChecker = $this->createMock(AuthorizationCheckerInterface::class);
-        $authorizationChecker->expects($this->any())->method('isGranted')->will($this->returnValue(true));
+        $authorizationChecker->expects($this->any())->method('isGranted')->willReturn(true);
 
         $pool = $this->getMockBuilder('Sonata\AdminBundle\Admin\Pool')
                 ->disableOriginalConstructor()
                 ->getMock();
 
-        $pool->expects($this->exactly(2))->method('getInstance')->will($this->returnValue($admin));
-        $pool->expects($this->exactly(2))->method('getAdminServiceIds')->will($this->returnValue(['myadmin']));
+        $pool->expects($this->exactly(2))->method('getInstance')->willReturn($admin);
+        $pool->expects($this->exactly(2))->method('getAdminServiceIds')->willReturn(['myadmin']);
 
         $builder = new EditableRolesBuilder($tokenStorage, $authorizationChecker, $pool, []);
 
@@ -116,10 +116,10 @@ class EditableRolesBuilderTest extends TestCase
     public function testWithNoSecurityToken(): void
     {
         $tokenStorage = $this->createMock(TokenStorageInterface::class);
-        $tokenStorage->expects($this->any())->method('getToken')->will($this->returnValue(null));
+        $tokenStorage->expects($this->any())->method('getToken')->willReturn(null);
 
         $authorizationChecker = $this->createMock(AuthorizationCheckerInterface::class);
-        $authorizationChecker->expects($this->any())->method('isGranted')->will($this->returnValue(false));
+        $authorizationChecker->expects($this->any())->method('isGranted')->willReturn(false);
 
         $pool = $this->getMockBuilder('Sonata\AdminBundle\Admin\Pool')
                 ->disableOriginalConstructor()


### PR DESCRIPTION
## Subject

Allow using external model classes.

See #980 for the previous conversation.

I am targeting this branch, because this is BC since commit 505de3e.

Closes #967

## Changelog

```markdown
### Fixed
- Fixed a bug with inability to use external model classes
```
