### PR TITLE
Replace usages of deprecated `spaceless` Twig tag

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
         "symfony/options-resolver": "^2.8 || ^3.2 || ^4.0",
         "symfony/security-acl": "^2.8 || ^3.0",
         "symfony/security-core": "^2.8 || ^3.2 || ^4.0",
-        "symfony/translation": "^2.8 || ^3.2 || ^4.0"
+        "symfony/translation": "^2.8 || ^3.2 || ^4.0",
+        "twig/twig": "^2.9"
     },
     "conflict": {
         "friendsofsymfony/rest-bundle": "<2.1 || >=3.0",

--- a/src/Resources/views/Form/form_admin_fields.html.twig
+++ b/src/Resources/views/Form/form_admin_fields.html.twig
@@ -10,7 +10,7 @@ file that was distributed with this source code.
 #}
 
 {% block sonata_security_roles_widget %}
-{% spaceless %}
+{% apply spaceless %}
     <div class="editable">
         <h4>{{ 'field.label_roles_editable'|trans({}, "SonataUserBundle") }}</h4>
         {{ block('choice_widget') }}
@@ -25,14 +25,14 @@ file that was distributed with this source code.
         </ul>
     </div>
     {% endif %}
-{% endspaceless %}
+{% endapply %}
 {% endblock sonata_security_roles_widget %}
 
 {% block sonata_roles_matrix_widget %}
-{% spaceless %}
+{% apply spaceless %}
     {{ renderMatrix(form)|raw }}
     <ul class="list-unstyled">
         {{ renderRolesList(form)|raw }}
     </ul>
-{% endspaceless %}
+{% endapply %}
 {% endblock sonata_roles_matrix_widget %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Replace usages of deprecated `spaceless` Twig tag.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because the changes are considered BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Add missing dependency against "twig/twig";
- Changed usages of `{% spaceless %}` tag, which is deprecated as of Twig 1.38 with `{% apply spaceless %}` filter;
```

Follow up of sonata-project/SonataAdminBundle#5576.
