### PR TITLE
Fix the get_class() error in php 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,14 @@ php:
   - 5.3
   - 5.4
   - 5.5
+  - 7.2
   - hhvm
 
 env:
   - SYMFONY_VERSION=2.2.*
   - SYMFONY_VERSION=2.3.*
   - SYMFONY_VERSION=2.4.*
+  - SYMFONY_VERSION=2.8.*
   - SYMFONY_VERSION=dev-master
 
 before_script:

--- a/Security/Authorization/Voter/UserAclVoter.php
+++ b/Security/Authorization/Voter/UserAclVoter.php
@@ -41,7 +41,7 @@ class UserAclVoter extends AclVoter
      */
     public function vote(TokenInterface $token, $object, array $attributes)
     {
-        if (!$this->supportsClass(get_class($object))) {
+        if (is_object($object) && !$this->supportsClass(get_class($object))) {
             return self::ACCESS_ABSTAIN;
         }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch to Fix the get_class() error in php 7.2 in version 2.x .

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #{put_issue_number_here}

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataUserBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Add a is_object() condition in `UserAclVoter::vote` to Fix the get_class() error in php 7.2 

### Changed

### Deprecated

### Removed

### Fixed

### Security
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->
