### PR TITLE
Do not load default mailer service when using custom mailer service

### DIFF
--- a/src/DependencyInjection/SonataUserExtension.php
+++ b/src/DependencyInjection/SonataUserExtension.php
@@ -81,7 +81,10 @@ class SonataUserExtension extends Extension implements PrependExtensionInterface
         $loader->load('twig.xml');
         $loader->load('command.xml');
         $loader->load('actions.xml');
-        $loader->load('mailer.xml');
+
+        if ('sonata.user.mailer.default' === $config['mailer']) {
+            $loader->load('mailer.xml');
+        }
 
         if ('orm' === $config['manager_type'] && isset(
             $bundles['FOSRestBundle'],

--- a/tests/DependencyInjection/SonataUserExtensionTest.php
+++ b/tests/DependencyInjection/SonataUserExtensionTest.php
@@ -266,6 +266,17 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
     }
 
     /**
+     * @group legacy
+     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
+     */
+    public function testDefaultMailerServiceNotRegisteredWhenCustomMailerSet(): void
+    {
+        $this->load(['mailer' => 'sonata.user.mailer.custom']);
+
+        $this->assertContainerBuilderNotHasService('sonata.user.mailer.default');
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function getMinimalConfiguration()


### PR DESCRIPTION
## Subject

The default mailer has a hard dependency on the Symfony "mailer" service which is not available in all use cases. This change prevents loading the default SonataUserBundle mailer service when a custom mailer service is provided.

I am targeting this branch, because this PR is a patch for an issue. I consider the default SonataUser mailer service to be internal and it is unlikely that external code depends on it when an alternative mailer is set. Under that assumption this is not a BC break.

## Changelog

```markdown
### Changed
- Do not register `sonata.user.mailer.default` service when a custom mailer service is defined
```