### PR TITLE
Fix non-existent method call in ResetAction

### DIFF
--- a/src/Action/ResetAction.php
+++ b/src/Action/ResetAction.php
@@ -161,7 +161,7 @@ final class ResetAction
             } catch (AccountStatusException $ex) {
                 // We simply do not authenticate users which do not pass the user
                 // checker (not enabled, expired, etc.).
-                $this->getLogger()->warning(sprintf(
+                $this->logger->warning(sprintf(
                     'Unable to login user %d after password reset',
                     $user->getId()
                 ), ['exception' => $ex]);


### PR DESCRIPTION
## Fix non-existent "getLogger" method call in ResetAction

In ResetAction class there is a call of non-existent method "getLogger". This issue will reproduce if you'll reset a password for disabled user. 

I am targeting this branch, because this is a small bug fix.

```markdown
### Fixed
 - Fixed invocation of non-existent "getLogger" method. Changed to access property.
```