### PR TITLE
Allow using all types of TokenInterface

### DIFF
--- a/src/GoogleAuthenticator/Helper.php
+++ b/src/GoogleAuthenticator/Helper.php
@@ -94,12 +94,12 @@ class Helper
      */
     public function getSessionKey(TokenInterface $token)
     {
-        if (method_exists($token,'getProviderKey')) {
+        if (method_exists($token, 'getProviderKey')) {
             $providerKey = $token->getProviderKey();
         } else {
             $providerKey = '';
         }
-        
+
         return sprintf('sonata_user_google_authenticator_%s_%s', $providerKey, $token->getUsername());
     }
 

--- a/src/GoogleAuthenticator/Helper.php
+++ b/src/GoogleAuthenticator/Helper.php
@@ -16,6 +16,7 @@ namespace Sonata\UserBundle\GoogleAuthenticator;
 use Google\Authenticator\GoogleAuthenticator as BaseGoogleAuthenticator;
 use Sonata\UserBundle\Model\UserInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
@@ -94,7 +95,7 @@ class Helper
      */
     public function getSessionKey(TokenInterface $token)
     {
-        if (method_exists($token, 'getProviderKey')) {
+        if ($token instanceof UsernamePasswordToken) {
             $providerKey = $token->getProviderKey();
         } else {
             $providerKey = '';

--- a/src/GoogleAuthenticator/Helper.php
+++ b/src/GoogleAuthenticator/Helper.php
@@ -16,7 +16,7 @@ namespace Sonata\UserBundle\GoogleAuthenticator;
 use Google\Authenticator\GoogleAuthenticator as BaseGoogleAuthenticator;
 use Sonata\UserBundle\Model\UserInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 class Helper
@@ -92,9 +92,15 @@ class Helper
     /**
      * @return string
      */
-    public function getSessionKey(UsernamePasswordToken $token)
+    public function getSessionKey(TokenInterface $token)
     {
-        return sprintf('sonata_user_google_authenticator_%s_%s', $token->getProviderKey(), $token->getUsername());
+        if (method_exists($token,'getProviderKey')) {
+            $providerKey = $token->getProviderKey();
+        } else {
+            $providerKey = '';
+        }
+        
+        return sprintf('sonata_user_google_authenticator_%s_%s', $providerKey, $token->getUsername());
     }
 
     public function needToHaveGoogle2FACode(Request $request): bool


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

The current implementation of the Google Authenticator Helper only allows the use of `UsernamePasswordToken` (e.g. `form_login`). This prevents combining 2FA with bundles such as https://github.com/hwi/HWIOAuthBundle .

This PR aims to solve this, by allowing all types of TokenInterface to be used.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backward compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/4.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting 4.x, because I'm not sure whether this change is considered backward compatible or not, so I'm targetting the most conservative branch.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataUserBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Changed
- 2FA authentication now supports all types of tokens instead of only UsernamePasswordToken
```
