### PR TITLE
[WIP] Remove FOSUserBundle dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
     ],
     "require": {
         "php": "^7.1",
-        "friendsofsymfony/user-bundle": "^2.0",
         "sonata-project/admin-bundle": "^3.34",
         "sonata-project/core-bundle": "^3.12",
         "sonata-project/datagrid-bundle": "^2.2.1",

--- a/src/Action/ResetAction.php
+++ b/src/Action/ResetAction.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sonata\UserBundle\Action;
 
-use FOS\UserBundle\Form\Factory\FactoryInterface;
-use FOS\UserBundle\Model\UserManagerInterface;
-use FOS\UserBundle\Security\LoginManagerInterface;
+use Sonata\UserBundle\Form\Factory\FactoryInterface;
+use Sonata\UserBundle\Model\FOSUserManagerInterface;
+use Sonata\UserBundle\Security\LoginManagerInterface;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\NullLogger;
 use Sonata\AdminBundle\Admin\Pool;
@@ -66,7 +66,7 @@ final class ResetAction
     private $formFactory;
 
     /**
-     * @var UserManagerInterface
+     * @var FOSUserManagerInterface
      */
     private $userManager;
 
@@ -102,7 +102,7 @@ final class ResetAction
         Pool $adminPool,
         TemplateRegistryInterface $templateRegistry,
         FactoryInterface $formFactory,
-        UserManagerInterface $userManager,
+        FOSUserManagerInterface $userManager,
         LoginManagerInterface $loginManager,
         TranslatorInterface $translator,
         Session $session,

--- a/src/Action/SendEmailAction.php
+++ b/src/Action/SendEmailAction.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 
 namespace Sonata\UserBundle\Action;
 
-use FOS\UserBundle\Mailer\MailerInterface;
-use FOS\UserBundle\Model\UserManagerInterface;
-use FOS\UserBundle\Util\TokenGeneratorInterface;
+use Sonata\UserBundle\Mailer\MailerInterface;
+use Sonata\UserBundle\Model\FOSUserManagerInterface;
+use Sonata\UserBundle\Util\TokenGeneratorInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -47,7 +47,7 @@ final class SendEmailAction
     private $templateRegistry;
 
     /**
-     * @var UserManagerInterface
+     * @var FOSUserManagerInterface
      */
     private $userManager;
 
@@ -71,7 +71,7 @@ final class SendEmailAction
         UrlGeneratorInterface $urlGenerator,
         Pool $adminPool,
         TemplateRegistryInterface $templateRegistry,
-        UserManagerInterface $userManager,
+        FOSUserManagerInterface $userManager,
         MailerInterface $mailer,
         TokenGeneratorInterface $tokenGenerator,
         int $resetTtl

--- a/src/Admin/Model/UserAdmin.php
+++ b/src/Admin/Model/UserAdmin.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\UserBundle\Admin\Model;
 
-use FOS\UserBundle\Model\UserManagerInterface;
+use Sonata\UserBundle\Model\FOSUserManagerInterface;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
@@ -32,7 +32,7 @@ use Symfony\Component\Form\FormTypeInterface;
 class UserAdmin extends AbstractAdmin
 {
     /**
-     * @var UserManagerInterface
+     * @var FOSUserManagerInterface
      */
     protected $userManager;
 
@@ -73,13 +73,13 @@ class UserAdmin extends AbstractAdmin
         $this->getUserManager()->updatePassword($user);
     }
 
-    public function setUserManager(UserManagerInterface $userManager): void
+    public function setUserManager(FOSUserManagerInterface $userManager): void
     {
         $this->userManager = $userManager;
     }
 
     /**
-     * @return UserManagerInterface
+     * @return FOSUserManagerInterface
      */
     public function getUserManager()
     {

--- a/src/Command/ActivateUserCommand.php
+++ b/src/Command/ActivateUserCommand.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Command;
+
+use Sonata\UserBundle\Util\UserManipulator;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+
+/**
+ * @author Antoine Hérault <antoine.herault@gmail.com>
+ */
+class ActivateUserCommand extends Command
+{
+    protected static $defaultName = 'fos:user:activate';
+
+    private $userManipulator;
+
+    public function __construct(UserManipulator $userManipulator)
+    {
+        parent::__construct();
+
+        $this->userManipulator = $userManipulator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('fos:user:activate')
+            ->setDescription('Activate a user')
+            ->setDefinition(array(
+                new InputArgument('username', InputArgument::REQUIRED, 'The username'),
+            ))
+            ->setHelp(<<<'EOT'
+The <info>fos:user:activate</info> command activates a user (so they will be able to log in):
+
+  <info>php %command.full_name% matthieu</info>
+EOT
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $username = $input->getArgument('username');
+
+        $this->userManipulator->activate($username);
+
+        $output->writeln(sprintf('User "%s" has been activated.', $username));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function interact(InputInterface $input, OutputInterface $output)
+    {
+        if (!$input->getArgument('username')) {
+            $question = new Question('Please choose a username:');
+            $question->setValidator(function ($username) {
+                if (empty($username)) {
+                    throw new \Exception('Username can not be empty');
+                }
+
+                return $username;
+            });
+            $answer = $this->getHelper('question')->ask($input, $output, $question);
+
+            $input->setArgument('username', $answer);
+        }
+    }
+}

--- a/src/Command/ChangePasswordCommand.php
+++ b/src/Command/ChangePasswordCommand.php
@@ -1,0 +1,111 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Command;
+
+use Sonata\UserBundle\Util\UserManipulator;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+
+class ChangePasswordCommand extends Command
+{
+    protected static $defaultName = 'fos:user:change-password';
+
+    private $userManipulator;
+
+    public function __construct(UserManipulator $userManipulator)
+    {
+        parent::__construct();
+
+        $this->userManipulator = $userManipulator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('fos:user:change-password')
+            ->setDescription('Change the password of a user.')
+            ->setDefinition(array(
+                new InputArgument('username', InputArgument::REQUIRED, 'The username'),
+                new InputArgument('password', InputArgument::REQUIRED, 'The password'),
+            ))
+            ->setHelp(<<<'EOT'
+The <info>fos:user:change-password</info> command changes the password of a user:
+
+  <info>php %command.full_name% matthieu</info>
+
+This interactive shell will first ask you for a password.
+
+You can alternatively specify the password as a second argument:
+
+  <info>php %command.full_name% matthieu mypassword</info>
+
+EOT
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $username = $input->getArgument('username');
+        $password = $input->getArgument('password');
+
+        $this->userManipulator->changePassword($username, $password);
+
+        $output->writeln(sprintf('Changed password for user <comment>%s</comment>', $username));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function interact(InputInterface $input, OutputInterface $output)
+    {
+        $questions = array();
+
+        if (!$input->getArgument('username')) {
+            $question = new Question('Please give the username:');
+            $question->setValidator(function ($username) {
+                if (empty($username)) {
+                    throw new \Exception('Username can not be empty');
+                }
+
+                return $username;
+            });
+            $questions['username'] = $question;
+        }
+
+        if (!$input->getArgument('password')) {
+            $question = new Question('Please enter the new password:');
+            $question->setValidator(function ($password) {
+                if (empty($password)) {
+                    throw new \Exception('Password can not be empty');
+                }
+
+                return $password;
+            });
+            $question->setHidden(true);
+            $questions['password'] = $question;
+        }
+
+        foreach ($questions as $name => $question) {
+            $answer = $this->getHelper('question')->ask($input, $output, $question);
+            $input->setArgument($name, $answer);
+        }
+    }
+}

--- a/src/Command/CreateUserCommand.php
+++ b/src/Command/CreateUserCommand.php
@@ -1,0 +1,143 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Command;
+
+use Sonata\UserBundle\Util\UserManipulator;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+
+/**
+ * @author Matthieu Bontemps <matthieu@knplabs.com>
+ * @author Thibault Duplessis <thibault.duplessis@gmail.com>
+ * @author Luis Cordova <cordoval@gmail.com>
+ */
+class CreateUserCommand extends Command
+{
+    protected static $defaultName = 'fos:user:create';
+
+    private $userManipulator;
+
+    public function __construct(UserManipulator $userManipulator)
+    {
+        parent::__construct();
+
+        $this->userManipulator = $userManipulator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('fos:user:create')
+            ->setDescription('Create a user.')
+            ->setDefinition(array(
+                new InputArgument('username', InputArgument::REQUIRED, 'The username'),
+                new InputArgument('email', InputArgument::REQUIRED, 'The email'),
+                new InputArgument('password', InputArgument::REQUIRED, 'The password'),
+                new InputOption('super-admin', null, InputOption::VALUE_NONE, 'Set the user as super admin'),
+                new InputOption('inactive', null, InputOption::VALUE_NONE, 'Set the user as inactive'),
+            ))
+            ->setHelp(<<<'EOT'
+The <info>fos:user:create</info> command creates a user:
+
+  <info>php %command.full_name% matthieu</info>
+
+This interactive shell will ask you for an email and then a password.
+
+You can alternatively specify the email and password as the second and third arguments:
+
+  <info>php %command.full_name% matthieu matthieu@example.com mypassword</info>
+
+You can create a super admin via the super-admin flag:
+
+  <info>php %command.full_name% admin --super-admin</info>
+
+You can create an inactive user (will not be able to log in):
+
+  <info>php %command.full_name% thibault --inactive</info>
+
+EOT
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $username = $input->getArgument('username');
+        $email = $input->getArgument('email');
+        $password = $input->getArgument('password');
+        $inactive = $input->getOption('inactive');
+        $superadmin = $input->getOption('super-admin');
+
+        $this->userManipulator->create($username, $password, $email, !$inactive, $superadmin);
+
+        $output->writeln(sprintf('Created user <comment>%s</comment>', $username));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function interact(InputInterface $input, OutputInterface $output)
+    {
+        $questions = array();
+
+        if (!$input->getArgument('username')) {
+            $question = new Question('Please choose a username:');
+            $question->setValidator(function ($username) {
+                if (empty($username)) {
+                    throw new \Exception('Username can not be empty');
+                }
+
+                return $username;
+            });
+            $questions['username'] = $question;
+        }
+
+        if (!$input->getArgument('email')) {
+            $question = new Question('Please choose an email:');
+            $question->setValidator(function ($email) {
+                if (empty($email)) {
+                    throw new \Exception('Email can not be empty');
+                }
+
+                return $email;
+            });
+            $questions['email'] = $question;
+        }
+
+        if (!$input->getArgument('password')) {
+            $question = new Question('Please choose a password:');
+            $question->setValidator(function ($password) {
+                if (empty($password)) {
+                    throw new \Exception('Password can not be empty');
+                }
+
+                return $password;
+            });
+            $question->setHidden(true);
+            $questions['password'] = $question;
+        }
+
+        foreach ($questions as $name => $question) {
+            $answer = $this->getHelper('question')->ask($input, $output, $question);
+            $input->setArgument($name, $answer);
+        }
+    }
+}

--- a/src/Command/DeactivateUserCommand.php
+++ b/src/Command/DeactivateUserCommand.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Command;
+
+use Sonata\UserBundle\Util\UserManipulator;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+
+/**
+ * @author Antoine Hérault <antoine.herault@gmail.com>
+ */
+class DeactivateUserCommand extends Command
+{
+    protected static $defaultName = 'fos:user:deactivate';
+
+    private $userManipulator;
+
+    public function __construct(UserManipulator $userManipulator)
+    {
+        parent::__construct();
+
+        $this->userManipulator = $userManipulator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('fos:user:deactivate')
+            ->setDescription('Deactivate a user')
+            ->setDefinition(array(
+                new InputArgument('username', InputArgument::REQUIRED, 'The username'),
+            ))
+            ->setHelp(<<<'EOT'
+The <info>fos:user:deactivate</info> command deactivates a user (will not be able to log in)
+
+  <info>php %command.full_name% matthieu</info>
+EOT
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $username = $input->getArgument('username');
+
+        $this->userManipulator->deactivate($username);
+
+        $output->writeln(sprintf('User "%s" has been deactivated.', $username));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function interact(InputInterface $input, OutputInterface $output)
+    {
+        if (!$input->getArgument('username')) {
+            $question = new Question('Please choose a username:');
+            $question->setValidator(function ($username) {
+                if (empty($username)) {
+                    throw new \Exception('Username can not be empty');
+                }
+
+                return $username;
+            });
+            $answer = $this->getHelper('question')->ask($input, $output, $question);
+
+            $input->setArgument('username', $answer);
+        }
+    }
+}

--- a/src/Command/DemoteUserCommand.php
+++ b/src/Command/DemoteUserCommand.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Command;
+
+use Sonata\UserBundle\Util\UserManipulator;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @author Antoine Hérault <antoine.herault@gmail.com>
+ * @author Lenar Lõhmus <lenar@city.ee>
+ */
+class DemoteUserCommand extends RoleCommand
+{
+    protected static $defaultName = 'fos:user:demote';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        parent::configure();
+
+        $this
+            ->setName('fos:user:demote')
+            ->setDescription('Demote a user by removing a role')
+            ->setHelp(<<<'EOT'
+The <info>fos:user:demote</info> command demotes a user by removing a role
+
+  <info>php %command.full_name% matthieu ROLE_CUSTOM</info>
+  <info>php %command.full_name% --super matthieu</info>
+EOT
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function executeRoleCommand(UserManipulator $manipulator, OutputInterface $output, $username, $super, $role)
+    {
+        if ($super) {
+            $manipulator->demote($username);
+            $output->writeln(sprintf('User "%s" has been demoted as a simple user. This change will not apply until the user logs out and back in again.', $username));
+        } else {
+            if ($manipulator->removeRole($username, $role)) {
+                $output->writeln(sprintf('Role "%s" has been removed from user "%s". This change will not apply until the user logs out and back in again.', $role, $username));
+            } else {
+                $output->writeln(sprintf('User "%s" didn\'t have "%s" role.', $username, $role));
+            }
+        }
+    }
+}

--- a/src/Command/PromoteUserCommand.php
+++ b/src/Command/PromoteUserCommand.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Command;
+
+use Sonata\UserBundle\Util\UserManipulator;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @author Matthieu Bontemps <matthieu@knplabs.com>
+ * @author Thibault Duplessis <thibault.duplessis@gmail.com>
+ * @author Luis Cordova <cordoval@gmail.com>
+ * @author Lenar Lõhmus <lenar@city.ee>
+ */
+class PromoteUserCommand extends RoleCommand
+{
+    protected static $defaultName = 'fos:user:promote';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        parent::configure();
+
+        $this
+            ->setName('fos:user:promote')
+            ->setDescription('Promotes a user by adding a role')
+            ->setHelp(<<<'EOT'
+The <info>fos:user:promote</info> command promotes a user by adding a role
+
+  <info>php %command.full_name% matthieu ROLE_CUSTOM</info>
+  <info>php %command.full_name% --super matthieu</info>
+EOT
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function executeRoleCommand(UserManipulator $manipulator, OutputInterface $output, $username, $super, $role)
+    {
+        if ($super) {
+            $manipulator->promote($username);
+            $output->writeln(sprintf('User "%s" has been promoted as a super administrator. This change will not apply until the user logs out and back in again.', $username));
+        } else {
+            if ($manipulator->addRole($username, $role)) {
+                $output->writeln(sprintf('Role "%s" has been added to user "%s". This change will not apply until the user logs out and back in again.', $role, $username));
+            } else {
+                $output->writeln(sprintf('User "%s" did already have "%s" role.', $username, $role));
+            }
+        }
+    }
+}

--- a/src/Command/RoleCommand.php
+++ b/src/Command/RoleCommand.php
@@ -1,0 +1,117 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Command;
+
+use Sonata\UserBundle\Util\UserManipulator;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+
+/**
+ * @author Lenar Lõhmus <lenar@city.ee>
+ */
+abstract class RoleCommand extends Command
+{
+    private $userManipulator;
+
+    public function __construct(UserManipulator $userManipulator)
+    {
+        parent::__construct();
+
+        $this->userManipulator = $userManipulator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setDefinition(array(
+                new InputArgument('username', InputArgument::REQUIRED, 'The username'),
+                new InputArgument('role', InputArgument::OPTIONAL, 'The role'),
+                new InputOption('super', null, InputOption::VALUE_NONE, 'Instead specifying role, use this to quickly add the super administrator role'),
+            ));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $username = $input->getArgument('username');
+        $role = $input->getArgument('role');
+        $super = (true === $input->getOption('super'));
+
+        if (null !== $role && $super) {
+            throw new \InvalidArgumentException('You can pass either the role or the --super option (but not both simultaneously).');
+        }
+
+        if (null === $role && !$super) {
+            throw new \RuntimeException('Not enough arguments.');
+        }
+
+        $manipulator = $this->userManipulator;
+        $this->executeRoleCommand($manipulator, $output, $username, $super, $role);
+    }
+
+    /**
+     * @see Command
+     *
+     * @param UserManipulator $manipulator
+     * @param OutputInterface $output
+     * @param string          $username
+     * @param bool            $super
+     * @param string          $role
+     */
+    abstract protected function executeRoleCommand(UserManipulator $manipulator, OutputInterface $output, $username, $super, $role);
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function interact(InputInterface $input, OutputInterface $output)
+    {
+        $questions = array();
+
+        if (!$input->getArgument('username')) {
+            $question = new Question('Please choose a username:');
+            $question->setValidator(function ($username) {
+                if (empty($username)) {
+                    throw new \Exception('Username can not be empty');
+                }
+
+                return $username;
+            });
+            $questions['username'] = $question;
+        }
+
+        if ((true !== $input->getOption('super')) && !$input->getArgument('role')) {
+            $question = new Question('Please choose a role:');
+            $question->setValidator(function ($role) {
+                if (empty($role)) {
+                    throw new \Exception('Role can not be empty');
+                }
+
+                return $role;
+            });
+            $questions['role'] = $question;
+        }
+
+        foreach ($questions as $name => $question) {
+            $answer = $this->getHelper('question')->ask($input, $output, $question);
+            $input->setArgument($name, $answer);
+        }
+    }
+}

--- a/src/Command/TwoStepVerificationCommand.php
+++ b/src/Command/TwoStepVerificationCommand.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\UserBundle\Command;
 
-use FOS\UserBundle\Model\UserManagerInterface;
+use Sonata\UserBundle\Model\FOSUserManagerInterface;
 use Sonata\UserBundle\GoogleAuthenticator\Helper;
 use Sonata\UserBundle\Model\UserInterface;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
@@ -33,7 +33,7 @@ class TwoStepVerificationCommand extends ContainerAwareCommand
     private $helper;
 
     /**
-     * @var ?UserManagerInterface
+     * @var ?FOSUserManagerInterface
      */
     private $userManager;
 
@@ -43,7 +43,7 @@ class TwoStepVerificationCommand extends ContainerAwareCommand
     public function __construct(
         ?string $name,
         ?Helper $helper = null,
-        ?UserManagerInterface $userManager = null
+        ?FOSUserManagerInterface $userManager = null
     ) {
         parent::__construct($name);
 
@@ -93,7 +93,7 @@ class TwoStepVerificationCommand extends ContainerAwareCommand
                 __CLASS__
             ), E_USER_DEPRECATED);
             $manager = $this->getContainer()->get('fos_user.user_manager');
-            \assert($manager instanceof UserManagerInterface);
+            \assert($manager instanceof FOSUserManagerInterface);
             $this->userManager = $manager;
         }
 

--- a/src/Controller/Api/GroupController.php
+++ b/src/Controller/Api/GroupController.php
@@ -18,7 +18,7 @@ use FOS\RestBundle\Controller\Annotations\QueryParam;
 use FOS\RestBundle\Controller\Annotations\View;
 use FOS\RestBundle\Request\ParamFetcherInterface;
 use FOS\RestBundle\View\View as FOSRestView;
-use FOS\UserBundle\Model\GroupInterface;
+use Sonata\UserBundle\Model\GroupInterface;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 use Sonata\DatagridBundle\Pager\PagerInterface;
 use Sonata\UserBundle\Model\GroupManagerInterface;
@@ -102,7 +102,7 @@ class GroupController
      *  requirements={
      *      {"name"="id", "dataType"="integer", "requirement"="\d+", "description"="group id"}
      *  },
-     *  output={"class"="FOS\UserBundle\Model\GroupInterface", "groups"={"sonata_api_read"}},
+     *  output={"class"="Sonata\UserBundle\Model\GroupInterface", "groups"={"sonata_api_read"}},
      *  statusCodes={
      *      200="Returned when successful",
      *      404="Returned when group is not found"

--- a/src/Controller/Api/UserController.php
+++ b/src/Controller/Api/UserController.php
@@ -18,7 +18,7 @@ use FOS\RestBundle\Controller\Annotations\QueryParam;
 use FOS\RestBundle\Controller\Annotations\View;
 use FOS\RestBundle\Request\ParamFetcherInterface;
 use FOS\RestBundle\View\View as FOSRestView;
-use FOS\UserBundle\Model\GroupInterface;
+use Sonata\UserBundle\Model\GroupInterface;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 use Sonata\DatagridBundle\Pager\PagerInterface;
 use Sonata\UserBundle\Model\GroupManagerInterface;

--- a/src/Controller/ChangePasswordController.php
+++ b/src/Controller/ChangePasswordController.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Controller;
+
+use Sonata\UserBundle\Event\FilterUserResponseEvent;
+use Sonata\UserBundle\Event\FormEvent;
+use Sonata\UserBundle\Event\GetResponseUserEvent;
+use Sonata\UserBundle\Form\Factory\FactoryInterface;
+use Sonata\UserBundle\FOSUserEvents;
+use Sonata\UserBundle\Model\FOSUserInterface;
+use Sonata\UserBundle\Model\FOSUserManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+/**
+ * Controller managing the password change.
+ *
+ * @author Thibault Duplessis <thibault.duplessis@gmail.com>
+ * @author Christophe Coevoet <stof@notk.org>
+ */
+class ChangePasswordController extends Controller
+{
+    private $eventDispatcher;
+    private $formFactory;
+    private $userManager;
+
+    public function __construct(EventDispatcherInterface $eventDispatcher, FactoryInterface $formFactory, FOSUserManagerInterface $userManager)
+    {
+        $this->eventDispatcher = $eventDispatcher;
+        $this->formFactory = $formFactory;
+        $this->userManager = $userManager;
+    }
+
+    /**
+     * Change user password.
+     *
+     * @param Request $request
+     *
+     * @return Response
+     */
+    public function changePasswordAction(Request $request)
+    {
+        $user = $this->getUser();
+        if (!is_object($user) || !$user instanceof FOSUserInterface) {
+            throw new AccessDeniedException('This user does not have access to this section.');
+        }
+
+        $event = new GetResponseUserEvent($user, $request);
+        $this->eventDispatcher->dispatch(FOSUserEvents::CHANGE_PASSWORD_INITIALIZE, $event);
+
+        if (null !== $event->getResponse()) {
+            return $event->getResponse();
+        }
+
+        $form = $this->formFactory->createForm();
+        $form->setData($user);
+
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $event = new FormEvent($form, $request);
+            $this->eventDispatcher->dispatch(FOSUserEvents::CHANGE_PASSWORD_SUCCESS, $event);
+
+            $this->userManager->updateUser($user);
+
+            if (null === $response = $event->getResponse()) {
+                $url = $this->generateUrl('fos_user_profile_show');
+                $response = new RedirectResponse($url);
+            }
+
+            $this->eventDispatcher->dispatch(FOSUserEvents::CHANGE_PASSWORD_COMPLETED, new FilterUserResponseEvent($user, $request, $response));
+
+            return $response;
+        }
+
+        return $this->render('@FOSUser/ChangePassword/change_password.html.twig', array(
+            'form' => $form->createView(),
+        ));
+    }
+}

--- a/src/Controller/GroupController.php
+++ b/src/Controller/GroupController.php
@@ -1,0 +1,199 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Controller;
+
+use Sonata\UserBundle\Event\FilterGroupResponseEvent;
+use Sonata\UserBundle\Event\FormEvent;
+use Sonata\UserBundle\Event\GetResponseGroupEvent;
+use Sonata\UserBundle\Event\GroupEvent;
+use Sonata\UserBundle\Form\Factory\FactoryInterface;
+use Sonata\UserBundle\FOSUserEvents;
+use Sonata\UserBundle\Model\GroupInterface;
+use Sonata\UserBundle\Model\FOSGroupManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * RESTful controller managing group CRUD.
+ *
+ * @author Thibault Duplessis <thibault.duplessis@gmail.com>
+ * @author Christophe Coevoet <stof@notk.org>
+ */
+class GroupController extends Controller
+{
+    private $eventDispatcher;
+    private $formFactory;
+    private $groupManager;
+
+    public function __construct(EventDispatcherInterface $eventDispatcher, FactoryInterface $formFactory, FOSGroupManagerInterface $groupManager)
+    {
+        $this->eventDispatcher = $eventDispatcher;
+        $this->formFactory = $formFactory;
+        $this->groupManager = $groupManager;
+    }
+
+    /**
+     * Show all groups.
+     */
+    public function listAction()
+    {
+        return $this->render('@FOSUser/Group/list.html.twig', array(
+            'groups' => $this->groupManager->findGroups(),
+        ));
+    }
+
+    /**
+     * Show one group.
+     *
+     * @param string $groupName
+     *
+     * @return Response
+     */
+    public function showAction($groupName)
+    {
+        return $this->render('@FOSUser/Group/show.html.twig', array(
+            'group' => $this->findGroupBy('name', $groupName),
+        ));
+    }
+
+    /**
+     * Edit one group, show the edit form.
+     *
+     * @param Request $request
+     * @param string  $groupName
+     *
+     * @return Response
+     */
+    public function editAction(Request $request, $groupName)
+    {
+        $group = $this->findGroupBy('name', $groupName);
+
+        $event = new GetResponseGroupEvent($group, $request);
+        $this->eventDispatcher->dispatch(FOSUserEvents::GROUP_EDIT_INITIALIZE, $event);
+
+        if (null !== $event->getResponse()) {
+            return $event->getResponse();
+        }
+
+        $form = $this->formFactory->createForm();
+        $form->setData($group);
+
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $event = new FormEvent($form, $request);
+            $this->eventDispatcher->dispatch(FOSUserEvents::GROUP_EDIT_SUCCESS, $event);
+
+            $this->groupManager->updateGroup($group);
+
+            if (null === $response = $event->getResponse()) {
+                $url = $this->generateUrl('fos_user_group_show', array('groupName' => $group->getName()));
+                $response = new RedirectResponse($url);
+            }
+
+            $this->eventDispatcher->dispatch(FOSUserEvents::GROUP_EDIT_COMPLETED, new FilterGroupResponseEvent($group, $request, $response));
+
+            return $response;
+        }
+
+        return $this->render('@FOSUser/Group/edit.html.twig', array(
+            'form' => $form->createView(),
+            'group_name' => $group->getName(),
+        ));
+    }
+
+    /**
+     * Show the new form.
+     *
+     * @param Request $request
+     *
+     * @return Response
+     */
+    public function newAction(Request $request)
+    {
+        $group = $this->groupManager->createGroup('');
+
+        $this->eventDispatcher->dispatch(FOSUserEvents::GROUP_CREATE_INITIALIZE, new GroupEvent($group, $request));
+
+        $form = $this->formFactory->createForm();
+        $form->setData($group);
+
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $event = new FormEvent($form, $request);
+            $this->eventDispatcher->dispatch(FOSUserEvents::GROUP_CREATE_SUCCESS, $event);
+
+            $this->groupManager->updateGroup($group);
+
+            if (null === $response = $event->getResponse()) {
+                $url = $this->generateUrl('fos_user_group_show', array('groupName' => $group->getName()));
+                $response = new RedirectResponse($url);
+            }
+
+            $this->eventDispatcher->dispatch(FOSUserEvents::GROUP_CREATE_COMPLETED, new FilterGroupResponseEvent($group, $request, $response));
+
+            return $response;
+        }
+
+        return $this->render('@FOSUser/Group/new.html.twig', array(
+            'form' => $form->createView(),
+        ));
+    }
+
+    /**
+     * Delete one group.
+     *
+     * @param Request $request
+     * @param string  $groupName
+     *
+     * @return RedirectResponse
+     */
+    public function deleteAction(Request $request, $groupName)
+    {
+        $group = $this->findGroupBy('name', $groupName);
+        $this->groupManager->deleteGroup($group);
+
+        $response = new RedirectResponse($this->generateUrl('fos_user_group_list'));
+
+        $this->eventDispatcher->dispatch(FOSUserEvents::GROUP_DELETE_COMPLETED, new FilterGroupResponseEvent($group, $request, $response));
+
+        return $response;
+    }
+
+    /**
+     * Find a group by a specific property.
+     *
+     * @param string $key   property name
+     * @param mixed  $value property value
+     *
+     * @throws NotFoundHttpException if user does not exist
+     *
+     * @return GroupInterface
+     */
+    protected function findGroupBy($key, $value)
+    {
+        if (!empty($value)) {
+            $group = $this->groupManager->{'findGroupBy'.ucfirst($key)}($value);
+        }
+
+        if (empty($group)) {
+            throw new NotFoundHttpException(sprintf('The group with "%s" does not exist for value "%s"', $key, $value));
+        }
+
+        return $group;
+    }
+}

--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Controller;
+
+use Sonata\UserBundle\Event\FilterUserResponseEvent;
+use Sonata\UserBundle\Event\FormEvent;
+use Sonata\UserBundle\Event\GetResponseUserEvent;
+use Sonata\UserBundle\Form\Factory\FactoryInterface;
+use Sonata\UserBundle\FOSUserEvents;
+use Sonata\UserBundle\Model\FOSUserInterface;
+use Sonata\UserBundle\Model\FOSUserManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+/**
+ * Controller managing the user profile.
+ *
+ * @author Christophe Coevoet <stof@notk.org>
+ */
+class ProfileController extends Controller
+{
+    private $eventDispatcher;
+    private $formFactory;
+    private $userManager;
+
+    public function __construct(EventDispatcherInterface $eventDispatcher, FactoryInterface $formFactory, FOSUserManagerInterface $userManager)
+    {
+        $this->eventDispatcher = $eventDispatcher;
+        $this->formFactory = $formFactory;
+        $this->userManager = $userManager;
+    }
+
+    /**
+     * Show the user.
+     */
+    public function showAction()
+    {
+        $user = $this->getUser();
+        if (!is_object($user) || !$user instanceof FOSUserInterface) {
+            throw new AccessDeniedException('This user does not have access to this section.');
+        }
+
+        return $this->render('@FOSUser/Profile/show.html.twig', array(
+            'user' => $user,
+        ));
+    }
+
+    /**
+     * Edit the user.
+     *
+     * @param Request $request
+     *
+     * @return Response
+     */
+    public function editAction(Request $request)
+    {
+        $user = $this->getUser();
+        if (!is_object($user) || !$user instanceof FOSUserInterface) {
+            throw new AccessDeniedException('This user does not have access to this section.');
+        }
+
+        $event = new GetResponseUserEvent($user, $request);
+        $this->eventDispatcher->dispatch(FOSUserEvents::PROFILE_EDIT_INITIALIZE, $event);
+
+        if (null !== $event->getResponse()) {
+            return $event->getResponse();
+        }
+
+        $form = $this->formFactory->createForm();
+        $form->setData($user);
+
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $event = new FormEvent($form, $request);
+            $this->eventDispatcher->dispatch(FOSUserEvents::PROFILE_EDIT_SUCCESS, $event);
+
+            $this->userManager->updateUser($user);
+
+            if (null === $response = $event->getResponse()) {
+                $url = $this->generateUrl('fos_user_profile_show');
+                $response = new RedirectResponse($url);
+            }
+
+            $this->eventDispatcher->dispatch(FOSUserEvents::PROFILE_EDIT_COMPLETED, new FilterUserResponseEvent($user, $request, $response));
+
+            return $response;
+        }
+
+        return $this->render('@FOSUser/Profile/edit.html.twig', array(
+            'form' => $form->createView(),
+        ));
+    }
+}

--- a/src/Controller/RegistrationController.php
+++ b/src/Controller/RegistrationController.php
@@ -1,0 +1,192 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Controller;
+
+use Sonata\UserBundle\Event\FilterUserResponseEvent;
+use Sonata\UserBundle\Event\FormEvent;
+use Sonata\UserBundle\Event\GetResponseUserEvent;
+use Sonata\UserBundle\Form\Factory\FactoryInterface;
+use Sonata\UserBundle\FOSUserEvents;
+use Sonata\UserBundle\Model\FOSUserInterface;
+use Sonata\UserBundle\Model\FOSUserManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+/**
+ * Controller managing the registration.
+ *
+ * @author Thibault Duplessis <thibault.duplessis@gmail.com>
+ * @author Christophe Coevoet <stof@notk.org>
+ */
+class RegistrationController extends Controller
+{
+    private $eventDispatcher;
+    private $formFactory;
+    private $userManager;
+    private $tokenStorage;
+
+    public function __construct(EventDispatcherInterface $eventDispatcher, FactoryInterface $formFactory, FOSUserManagerInterface $userManager, TokenStorageInterface $tokenStorage)
+    {
+        $this->eventDispatcher = $eventDispatcher;
+        $this->formFactory = $formFactory;
+        $this->userManager = $userManager;
+        $this->tokenStorage = $tokenStorage;
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @return Response
+     */
+    public function registerAction(Request $request)
+    {
+        $user = $this->userManager->createUser();
+        $user->setEnabled(true);
+
+        $event = new GetResponseUserEvent($user, $request);
+        $this->eventDispatcher->dispatch(FOSUserEvents::REGISTRATION_INITIALIZE, $event);
+
+        if (null !== $event->getResponse()) {
+            return $event->getResponse();
+        }
+
+        $form = $this->formFactory->createForm();
+        $form->setData($user);
+
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted()) {
+            if ($form->isValid()) {
+                $event = new FormEvent($form, $request);
+                $this->eventDispatcher->dispatch(FOSUserEvents::REGISTRATION_SUCCESS, $event);
+
+                $this->userManager->updateUser($user);
+
+                if (null === $response = $event->getResponse()) {
+                    $url = $this->generateUrl('fos_user_registration_confirmed');
+                    $response = new RedirectResponse($url);
+                }
+
+                $this->eventDispatcher->dispatch(FOSUserEvents::REGISTRATION_COMPLETED, new FilterUserResponseEvent($user, $request, $response));
+
+                return $response;
+            }
+
+            $event = new FormEvent($form, $request);
+            $this->eventDispatcher->dispatch(FOSUserEvents::REGISTRATION_FAILURE, $event);
+
+            if (null !== $response = $event->getResponse()) {
+                return $response;
+            }
+        }
+
+        return $this->render('@FOSUser/Registration/register.html.twig', array(
+            'form' => $form->createView(),
+        ));
+    }
+
+    /**
+     * Tell the user to check their email provider.
+     */
+    public function checkEmailAction(Request $request)
+    {
+        $email = $request->getSession()->get('fos_user_send_confirmation_email/email');
+
+        if (empty($email)) {
+            return new RedirectResponse($this->generateUrl('fos_user_registration_register'));
+        }
+
+        $request->getSession()->remove('fos_user_send_confirmation_email/email');
+        $user = $this->userManager->findUserByEmail($email);
+
+        if (null === $user) {
+            return new RedirectResponse($this->container->get('router')->generate('fos_user_security_login'));
+        }
+
+        return $this->render('@FOSUser/Registration/check_email.html.twig', array(
+            'user' => $user,
+        ));
+    }
+
+    /**
+     * Receive the confirmation token from user email provider, login the user.
+     *
+     * @param Request $request
+     * @param string  $token
+     *
+     * @return Response
+     */
+    public function confirmAction(Request $request, $token)
+    {
+        $userManager = $this->userManager;
+
+        $user = $userManager->findUserByConfirmationToken($token);
+
+        if (null === $user) {
+            throw new NotFoundHttpException(sprintf('The user with confirmation token "%s" does not exist', $token));
+        }
+
+        $user->setConfirmationToken(null);
+        $user->setEnabled(true);
+
+        $event = new GetResponseUserEvent($user, $request);
+        $this->eventDispatcher->dispatch(FOSUserEvents::REGISTRATION_CONFIRM, $event);
+
+        $userManager->updateUser($user);
+
+        if (null === $response = $event->getResponse()) {
+            $url = $this->generateUrl('fos_user_registration_confirmed');
+            $response = new RedirectResponse($url);
+        }
+
+        $this->eventDispatcher->dispatch(FOSUserEvents::REGISTRATION_CONFIRMED, new FilterUserResponseEvent($user, $request, $response));
+
+        return $response;
+    }
+
+    /**
+     * Tell the user his account is now confirmed.
+     */
+    public function confirmedAction(Request $request)
+    {
+        $user = $this->getUser();
+        if (!is_object($user) || !$user instanceof FOSUserInterface) {
+            throw new AccessDeniedException('This user does not have access to this section.');
+        }
+
+        return $this->render('@FOSUser/Registration/confirmed.html.twig', array(
+            'user' => $user,
+            'targetUrl' => $this->getTargetUrlFromSession($request->getSession()),
+        ));
+    }
+
+    /**
+     * @return string|null
+     */
+    private function getTargetUrlFromSession(SessionInterface $session)
+    {
+        $key = sprintf('_security.%s.target_path', $this->tokenStorage->getToken()->getProviderKey());
+
+        if ($session->has($key)) {
+            return $session->get($key);
+        }
+
+        return null;
+    }
+}

--- a/src/Controller/ResettingController.php
+++ b/src/Controller/ResettingController.php
@@ -1,0 +1,201 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Controller;
+
+use Sonata\UserBundle\Event\FilterUserResponseEvent;
+use Sonata\UserBundle\Event\FormEvent;
+use Sonata\UserBundle\Event\GetResponseNullableUserEvent;
+use Sonata\UserBundle\Event\GetResponseUserEvent;
+use Sonata\UserBundle\Form\Factory\FactoryInterface;
+use Sonata\UserBundle\FOSUserEvents;
+use Sonata\UserBundle\Mailer\MailerInterface;
+use Sonata\UserBundle\Model\FOSUserManagerInterface;
+use Sonata\UserBundle\Util\TokenGeneratorInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Controller managing the resetting of the password.
+ *
+ * @author Thibault Duplessis <thibault.duplessis@gmail.com>
+ * @author Christophe Coevoet <stof@notk.org>
+ */
+class ResettingController extends Controller
+{
+    private $eventDispatcher;
+    private $formFactory;
+    private $userManager;
+    private $tokenGenerator;
+    private $mailer;
+
+    /**
+     * @var int
+     */
+    private $retryTtl;
+
+    /**
+     * @param EventDispatcherInterface $eventDispatcher
+     * @param FactoryInterface         $formFactory
+     * @param FOSUserManagerInterface     $userManager
+     * @param TokenGeneratorInterface  $tokenGenerator
+     * @param MailerInterface          $mailer
+     * @param int                      $retryTtl
+     */
+    public function __construct(EventDispatcherInterface $eventDispatcher, FactoryInterface $formFactory, FOSUserManagerInterface $userManager, TokenGeneratorInterface $tokenGenerator, MailerInterface $mailer, $retryTtl)
+    {
+        $this->eventDispatcher = $eventDispatcher;
+        $this->formFactory = $formFactory;
+        $this->userManager = $userManager;
+        $this->tokenGenerator = $tokenGenerator;
+        $this->mailer = $mailer;
+        $this->retryTtl = $retryTtl;
+    }
+
+    /**
+     * Request reset user password: show form.
+     */
+    public function requestAction()
+    {
+        return $this->render('@FOSUser/Resetting/request.html.twig');
+    }
+
+    /**
+     * Request reset user password: submit form and send email.
+     *
+     * @param Request $request
+     *
+     * @return Response
+     */
+    public function sendEmailAction(Request $request)
+    {
+        $username = $request->request->get('username');
+
+        $user = $this->userManager->findUserByUsernameOrEmail($username);
+
+        $event = new GetResponseNullableUserEvent($user, $request);
+        $this->eventDispatcher->dispatch(FOSUserEvents::RESETTING_SEND_EMAIL_INITIALIZE, $event);
+
+        if (null !== $event->getResponse()) {
+            return $event->getResponse();
+        }
+
+        if (null !== $user && !$user->isPasswordRequestNonExpired($this->retryTtl)) {
+            $event = new GetResponseUserEvent($user, $request);
+            $this->eventDispatcher->dispatch(FOSUserEvents::RESETTING_RESET_REQUEST, $event);
+
+            if (null !== $event->getResponse()) {
+                return $event->getResponse();
+            }
+
+            if (null === $user->getConfirmationToken()) {
+                $user->setConfirmationToken($this->tokenGenerator->generateToken());
+            }
+
+            $event = new GetResponseUserEvent($user, $request);
+            $this->eventDispatcher->dispatch(FOSUserEvents::RESETTING_SEND_EMAIL_CONFIRM, $event);
+
+            if (null !== $event->getResponse()) {
+                return $event->getResponse();
+            }
+
+            $this->mailer->sendResettingEmailMessage($user);
+            $user->setPasswordRequestedAt(new \DateTime());
+            $this->userManager->updateUser($user);
+
+            $event = new GetResponseUserEvent($user, $request);
+            $this->eventDispatcher->dispatch(FOSUserEvents::RESETTING_SEND_EMAIL_COMPLETED, $event);
+
+            if (null !== $event->getResponse()) {
+                return $event->getResponse();
+            }
+        }
+
+        return new RedirectResponse($this->generateUrl('fos_user_resetting_check_email', array('username' => $username)));
+    }
+
+    /**
+     * Tell the user to check his email provider.
+     *
+     * @param Request $request
+     *
+     * @return Response
+     */
+    public function checkEmailAction(Request $request)
+    {
+        $username = $request->query->get('username');
+
+        if (empty($username)) {
+            // the user does not come from the sendEmail action
+            return new RedirectResponse($this->generateUrl('fos_user_resetting_request'));
+        }
+
+        return $this->render('@FOSUser/Resetting/check_email.html.twig', array(
+            'tokenLifetime' => ceil($this->retryTtl / 3600),
+        ));
+    }
+
+    /**
+     * Reset user password.
+     *
+     * @param Request $request
+     * @param string  $token
+     *
+     * @return Response
+     */
+    public function resetAction(Request $request, $token)
+    {
+        $user = $this->userManager->findUserByConfirmationToken($token);
+
+        if (null === $user) {
+            return new RedirectResponse($this->container->get('router')->generate('fos_user_security_login'));
+        }
+
+        $event = new GetResponseUserEvent($user, $request);
+        $this->eventDispatcher->dispatch(FOSUserEvents::RESETTING_RESET_INITIALIZE, $event);
+
+        if (null !== $event->getResponse()) {
+            return $event->getResponse();
+        }
+
+        $form = $this->formFactory->createForm();
+        $form->setData($user);
+
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $event = new FormEvent($form, $request);
+            $this->eventDispatcher->dispatch(FOSUserEvents::RESETTING_RESET_SUCCESS, $event);
+
+            $this->userManager->updateUser($user);
+
+            if (null === $response = $event->getResponse()) {
+                $url = $this->generateUrl('fos_user_profile_show');
+                $response = new RedirectResponse($url);
+            }
+
+            $this->eventDispatcher->dispatch(
+                FOSUserEvents::RESETTING_RESET_COMPLETED,
+                new FilterUserResponseEvent($user, $request, $response)
+            );
+
+            return $response;
+        }
+
+        return $this->render('@FOSUser/Resetting/reset.html.twig', array(
+            'token' => $token,
+            'form' => $form->createView(),
+        ));
+    }
+}

--- a/src/Controller/SecurityController.php
+++ b/src/Controller/SecurityController.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
+
+/**
+ * Controller managing security.
+ *
+ * @author Thibault Duplessis <thibault.duplessis@gmail.com>
+ * @author Christophe Coevoet <stof@notk.org>
+ */
+class SecurityController extends Controller
+{
+    private $tokenManager;
+
+    public function __construct(CsrfTokenManagerInterface $tokenManager = null)
+    {
+        $this->tokenManager = $tokenManager;
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @return Response
+     */
+    public function loginAction(Request $request)
+    {
+        /** @var $session Session */
+        $session = $request->getSession();
+
+        $authErrorKey = Security::AUTHENTICATION_ERROR;
+        $lastUsernameKey = Security::LAST_USERNAME;
+
+        // get the error if any (works with forward and redirect -- see below)
+        if ($request->attributes->has($authErrorKey)) {
+            $error = $request->attributes->get($authErrorKey);
+        } elseif (null !== $session && $session->has($authErrorKey)) {
+            $error = $session->get($authErrorKey);
+            $session->remove($authErrorKey);
+        } else {
+            $error = null;
+        }
+
+        if (!$error instanceof AuthenticationException) {
+            $error = null; // The value does not come from the security component.
+        }
+
+        // last username entered by the user
+        $lastUsername = (null === $session) ? '' : $session->get($lastUsernameKey);
+
+        $csrfToken = $this->tokenManager
+            ? $this->tokenManager->getToken('authenticate')->getValue()
+            : null;
+
+        return $this->renderLogin(array(
+            'last_username' => $lastUsername,
+            'error' => $error,
+            'csrf_token' => $csrfToken,
+        ));
+    }
+
+    public function checkAction()
+    {
+        throw new \RuntimeException('You must configure the check path to be handled by the firewall using form_login in your security firewall configuration.');
+    }
+
+    public function logoutAction()
+    {
+        throw new \RuntimeException('You must activate the logout in your security firewall configuration.');
+    }
+
+    /**
+     * Renders the login template with the given parameters. Overwrite this function in
+     * an extended controller to provide additional data for the login template.
+     *
+     * @param array $data
+     *
+     * @return Response
+     */
+    protected function renderLogin(array $data)
+    {
+        return $this->render('@FOSUser/Security/login.html.twig', $data);
+    }
+}

--- a/src/DependencyInjection/Compiler/CheckForMailerPass.php
+++ b/src/DependencyInjection/Compiler/CheckForMailerPass.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Flex\Recipe;
+
+/**
+ * Checks to see if the mailer service exists.
+ *
+ * @author Ryan Weaver <ryan@knpuniversity.com>
+ */
+class CheckForMailerPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        // if the mailer isn't needed, then no error needed
+        if (!$container->has('fos_user.mailer')) {
+            return;
+        }
+
+        // the mailer exists, so all is good
+        if ($container->has('mailer')) {
+            return;
+        }
+
+        if ($container->findDefinition('fos_user.mailer')->hasTag('fos_user.requires_swift')) {
+            $message = 'A feature you activated in FOSUserBundle requires the "mailer" service to be available.';
+
+            if (class_exists(Recipe::class)) {
+                $message .= ' Run "composer require swiftmailer-bundle" to install SwiftMailer or configure a different mailer in "config/packages/fos_user.yaml".';
+            }
+
+            throw new \LogicException($message);
+        }
+    }
+}

--- a/src/DependencyInjection/Compiler/CheckForSessionPass.php
+++ b/src/DependencyInjection/Compiler/CheckForSessionPass.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Flex\Recipe;
+
+/**
+ * Checks to see if the session service exists.
+ *
+ * @author Ryan Weaver <ryan@knpuniversity.com>
+ */
+class CheckForSessionPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if ($container->has('fos_user.session') && !$container->has('session')) {
+            $message = 'FOSUserBundle requires the "session" service to be available.';
+
+            if (class_exists(Recipe::class)) {
+                $message .= ' Uncomment the "session" section in "config/packages/framework.yaml" to activate it.';
+            }
+
+            throw new \LogicException($message);
+        }
+    }
+}

--- a/src/DependencyInjection/Compiler/InjectRememberMeServicesPass.php
+++ b/src/DependencyInjection/Compiler/InjectRememberMeServicesPass.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Inject RememberMeServices into LoginManager.
+ *
+ * @author Vasily Khayrulin <sirianru@gmail.com>
+ */
+class InjectRememberMeServicesPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $firewallName = $container->getParameter('fos_user.firewall_name');
+        $loginManager = $container->getDefinition('fos_user.security.login_manager');
+
+        if ($container->hasDefinition('security.authentication.rememberme.services.persistent.'.$firewallName)) {
+            $loginManager->replaceArgument(4, new Reference('security.authentication.rememberme.services.persistent.'.$firewallName));
+        } elseif ($container->hasDefinition('security.authentication.rememberme.services.simplehash.'.$firewallName)) {
+            $loginManager->replaceArgument(4, new Reference('security.authentication.rememberme.services.simplehash.'.$firewallName));
+        }
+    }
+}

--- a/src/DependencyInjection/Compiler/InjectUserCheckerPass.php
+++ b/src/DependencyInjection/Compiler/InjectUserCheckerPass.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Injects firewall's UserChecker into LoginManager.
+ *
+ * @author Gocha Ossinkine <ossinkine@ya.ru>
+ */
+class InjectUserCheckerPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $firewallName = $container->getParameter('fos_user.firewall_name');
+        $loginManager = $container->findDefinition('fos_user.security.login_manager');
+
+        if ($container->has('security.user_checker.'.$firewallName)) {
+            $loginManager->replaceArgument(1, new Reference('security.user_checker.'.$firewallName));
+        }
+    }
+}

--- a/src/DependencyInjection/Compiler/ValidationPass.php
+++ b/src/DependencyInjection/Compiler/ValidationPass.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Registers the additional validators according to the storage.
+ *
+ * @author Christophe Coevoet <stof@notk.org>
+ */
+class ValidationPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasParameter('fos_user.storage')) {
+            return;
+        }
+
+        $storage = $container->getParameter('fos_user.storage');
+
+        if ('custom' === $storage) {
+            return;
+        }
+
+        $validationFile = __DIR__.'/../../Resources/config/storage-validation/'.$storage.'.xml';
+
+        $container->getDefinition('validator.builder')
+            ->addMethodCall('addXmlMapping', array($validationFile));
+    }
+}

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -19,6 +19,7 @@ use Sonata\UserBundle\Admin\Entity\UserAdmin;
 use Sonata\UserBundle\Entity\BaseGroup;
 use Sonata\UserBundle\Entity\BaseUser;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
@@ -125,7 +126,248 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('mailer')->defaultValue('sonata.user.mailer.default')->info('Custom mailer used to send reset password emails')->end()
             ->end()
         ;
-
+        // $this->addFOSSection($rootNode);
         return $treeBuilder;
+    }
+
+    private function addFOSSection(ArrayNodeDefinition $node)
+    {
+        $supportedDrivers = array('orm', 'mongodb', 'couchdb', 'custom');
+
+        $node
+            ->children()
+                ->scalarNode('db_driver')
+                    ->validate()
+                        ->ifNotInArray($supportedDrivers)
+                        ->thenInvalid('The driver %s is not supported. Please choose one of '.json_encode($supportedDrivers))
+                    ->end()
+                    ->cannotBeOverwritten()
+                    ->isRequired()
+                    ->cannotBeEmpty()
+                ->end()
+                ->scalarNode('user_class')->isRequired()->cannotBeEmpty()->end()
+                ->scalarNode('firewall_name')->isRequired()->cannotBeEmpty()->end()
+                ->scalarNode('model_manager_name')->defaultNull()->end()
+                ->booleanNode('use_authentication_listener')->defaultTrue()->end()
+                ->booleanNode('use_listener')->defaultTrue()->end()
+                ->booleanNode('use_flash_notifications')->defaultTrue()->end()
+                ->booleanNode('use_username_form_type')->defaultTrue()->end()
+                ->arrayNode('from_email')
+                    ->isRequired()
+                    ->children()
+                        ->scalarNode('address')->isRequired()->cannotBeEmpty()->end()
+                        ->scalarNode('sender_name')->isRequired()->cannotBeEmpty()->end()
+                    ->end()
+                ->end()
+            ->end()
+            // Using the custom driver requires changing the manager services
+            ->validate()
+                ->ifTrue(function ($v) {
+                    return 'custom' === $v['db_driver'] && 'fos_user.user_manager.default' === $v['service']['user_manager'];
+                })
+                ->thenInvalid('You need to specify your own user manager service when using the "custom" driver.')
+            ->end()
+            ->validate()
+                ->ifTrue(function ($v) {
+                    return 'custom' === $v['db_driver'] && !empty($v['group']) && 'fos_user.group_manager.default' === $v['group']['group_manager'];
+                })
+                ->thenInvalid('You need to specify your own group manager service when using the "custom" driver.')
+            ->end();
+
+        $this->addProfileSection($node);
+        $this->addChangePasswordSection($node);
+        $this->addRegistrationSection($node);
+        $this->addResettingSection($node);
+        $this->addServiceSection($node);
+        $this->addGroupSection($node);
+    }
+
+    /**
+     * @param ArrayNodeDefinition $node
+     */
+    private function addProfileSection(ArrayNodeDefinition $node)
+    {
+        $node
+            ->children()
+                ->arrayNode('profile')
+                    ->addDefaultsIfNotSet()
+                    ->canBeUnset()
+                    ->children()
+                        ->arrayNode('form')
+                            ->addDefaultsIfNotSet()
+                            ->fixXmlConfig('validation_group')
+                            ->children()
+                                ->scalarNode('type')->defaultValue(Type\ProfileFormType::class)->end()
+                                ->scalarNode('name')->defaultValue('fos_user_profile_form')->end()
+                                ->arrayNode('validation_groups')
+                                    ->prototype('scalar')->end()
+                                    ->defaultValue(array('Profile', 'Default'))
+                                ->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end();
+    }
+
+    /**
+     * @param ArrayNodeDefinition $node
+     */
+    private function addRegistrationSection(ArrayNodeDefinition $node)
+    {
+        $node
+            ->children()
+                ->arrayNode('registration')
+                    ->addDefaultsIfNotSet()
+                    ->canBeUnset()
+                    ->children()
+                        ->arrayNode('confirmation')
+                            ->addDefaultsIfNotSet()
+                            ->children()
+                                ->booleanNode('enabled')->defaultFalse()->end()
+                                ->scalarNode('template')->defaultValue('@FOSUser/Registration/email.txt.twig')->end()
+                                ->arrayNode('from_email')
+                                    ->canBeUnset()
+                                    ->children()
+                                        ->scalarNode('address')->isRequired()->cannotBeEmpty()->end()
+                                        ->scalarNode('sender_name')->isRequired()->cannotBeEmpty()->end()
+                                    ->end()
+                                ->end()
+                            ->end()
+                        ->end()
+                        ->arrayNode('form')
+                            ->addDefaultsIfNotSet()
+                            ->children()
+                                ->scalarNode('type')->defaultValue(Type\RegistrationFormType::class)->end()
+                                ->scalarNode('name')->defaultValue('fos_user_registration_form')->end()
+                                ->arrayNode('validation_groups')
+                                    ->prototype('scalar')->end()
+                                    ->defaultValue(array('Registration', 'Default'))
+                                ->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end();
+    }
+
+    /**
+     * @param ArrayNodeDefinition $node
+     */
+    private function addResettingSection(ArrayNodeDefinition $node)
+    {
+        $node
+            ->children()
+                ->arrayNode('resetting')
+                    ->addDefaultsIfNotSet()
+                    ->canBeUnset()
+                    ->children()
+                        ->scalarNode('retry_ttl')->defaultValue(7200)->end()
+                        ->scalarNode('token_ttl')->defaultValue(86400)->end()
+                        ->arrayNode('email')
+                            ->addDefaultsIfNotSet()
+                            ->children()
+                                ->scalarNode('template')->defaultValue('@FOSUser/Resetting/email.txt.twig')->end()
+                                ->arrayNode('from_email')
+                                    ->canBeUnset()
+                                    ->children()
+                                        ->scalarNode('address')->isRequired()->cannotBeEmpty()->end()
+                                        ->scalarNode('sender_name')->isRequired()->cannotBeEmpty()->end()
+                                    ->end()
+                                ->end()
+                            ->end()
+                        ->end()
+                        ->arrayNode('form')
+                            ->addDefaultsIfNotSet()
+                            ->children()
+                                ->scalarNode('type')->defaultValue(Type\ResettingFormType::class)->end()
+                                ->scalarNode('name')->defaultValue('fos_user_resetting_form')->end()
+                                ->arrayNode('validation_groups')
+                                    ->prototype('scalar')->end()
+                                    ->defaultValue(array('ResetPassword', 'Default'))
+                                ->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end();
+    }
+
+    /**
+     * @param ArrayNodeDefinition $node
+     */
+    private function addChangePasswordSection(ArrayNodeDefinition $node)
+    {
+        $node
+            ->children()
+                ->arrayNode('change_password')
+                    ->addDefaultsIfNotSet()
+                    ->canBeUnset()
+                    ->children()
+                        ->arrayNode('form')
+                            ->addDefaultsIfNotSet()
+                            ->children()
+                                ->scalarNode('type')->defaultValue(Type\ChangePasswordFormType::class)->end()
+                                ->scalarNode('name')->defaultValue('fos_user_change_password_form')->end()
+                                ->arrayNode('validation_groups')
+                                    ->prototype('scalar')->end()
+                                    ->defaultValue(array('ChangePassword', 'Default'))
+                                ->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end();
+    }
+
+    /**
+     * @param ArrayNodeDefinition $node
+     */
+    private function addServiceSection(ArrayNodeDefinition $node)
+    {
+        $node
+            ->addDefaultsIfNotSet()
+            ->children()
+                ->arrayNode('service')
+                    ->addDefaultsIfNotSet()
+                        ->children()
+                            ->scalarNode('mailer')->defaultValue('fos_user.mailer.default')->end()
+                            ->scalarNode('email_canonicalizer')->defaultValue('fos_user.util.canonicalizer.default')->end()
+                            ->scalarNode('token_generator')->defaultValue('fos_user.util.token_generator.default')->end()
+                            ->scalarNode('username_canonicalizer')->defaultValue('fos_user.util.canonicalizer.default')->end()
+                            ->scalarNode('user_manager')->defaultValue('fos_user.user_manager.default')->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end();
+    }
+
+    /**
+     * @param ArrayNodeDefinition $node
+     */
+    private function addGroupSection(ArrayNodeDefinition $node)
+    {
+        $node
+            ->children()
+                ->arrayNode('group')
+                    ->canBeUnset()
+                    ->children()
+                        ->scalarNode('group_class')->isRequired()->cannotBeEmpty()->end()
+                        ->scalarNode('group_manager')->defaultValue('fos_user.group_manager.default')->end()
+                        ->arrayNode('form')
+                            ->addDefaultsIfNotSet()
+                            ->fixXmlConfig('validation_group')
+                            ->children()
+                                ->scalarNode('type')->defaultValue(Type\GroupFormType::class)->end()
+                                ->scalarNode('name')->defaultValue('fos_user_group_form')->end()
+                                ->arrayNode('validation_groups')
+                                    ->prototype('scalar')->end()
+                                    ->defaultValue(array('Registration', 'Default'))
+                                ->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end();
     }
 }

--- a/src/DependencyInjection/SonataUserExtension.php
+++ b/src/DependencyInjection/SonataUserExtension.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Sonata\UserBundle\DependencyInjection;
 
 use Sonata\EasyExtendsBundle\Mapper\DoctrineCollector;
-use Sonata\GoogleAuthenticator\GoogleAuthenticator;
 use Sonata\UserBundle\Document\BaseGroup as DocumentGroup;
 use Sonata\UserBundle\Document\BaseUser as DocumentUser;
 use Sonata\UserBundle\Entity\BaseGroup as EntityGroup;
@@ -67,7 +66,15 @@ class SonataUserExtension extends Extension implements PrependExtensionInterface
 
         $loader->load('form.xml');
 
-        if (class_exists(GoogleAuthenticator::class)) {
+        if (class_exists('Google\Authenticator\GoogleAuthenticator')) {
+            @trigger_error(
+                'The \'Google\Authenticator\' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.',
+                E_USER_DEPRECATED
+            );
+        }
+
+        if (class_exists('Google\Authenticator\GoogleAuthenticator') ||
+            class_exists('Sonata\GoogleAuthenticator\GoogleAuthenticator')) {
             $loader->load('google_authenticator.xml');
         }
 
@@ -157,7 +164,8 @@ class SonataUserExtension extends Extension implements PrependExtensionInterface
             return;
         }
 
-        if (!class_exists(GoogleAuthenticator::class)) {
+        if (!class_exists('Google\Authenticator\GoogleAuthenticator')
+            && !class_exists('Sonata\GoogleAuthenticator\GoogleAuthenticator')) {
             throw new \RuntimeException('Please add ``sonata-project/google-authenticator`` package');
         }
 
@@ -302,5 +310,278 @@ class SonataUserExtension extends Extension implements PrependExtensionInterface
     private function configureMailer(array $config, ContainerBuilder $container): void
     {
         $container->setAlias('sonata.user.mailer', $config['mailer']);
+    }
+
+    /* Migrated from FOSUserBundle */
+    /**
+     * @var array
+     */
+    private static $doctrineDrivers = array(
+        'orm' => array(
+            'registry' => 'doctrine',
+            'tag' => 'doctrine.event_subscriber',
+        ),
+        'mongodb' => array(
+            'registry' => 'doctrine_mongodb',
+            'tag' => 'doctrine_mongodb.odm.event_subscriber',
+        ),
+        'couchdb' => array(
+            'registry' => 'doctrine_couchdb',
+            'tag' => 'doctrine_couchdb.event_subscriber',
+            'listener_class' => 'FOS\UserBundle\Doctrine\CouchDB\UserListener',
+        ),
+    );
+
+    private $mailerNeeded = false;
+    private $sessionNeeded = false;
+
+    /**
+     * {@inheritdoc}
+     */
+    /*
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $processor = new Processor();
+        $configuration = new Configuration();
+
+        $config = $processor->processConfiguration($configuration, $configs);
+
+        $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+
+        if ('custom' !== $config['db_driver']) {
+            if (isset(self::$doctrineDrivers[$config['db_driver']])) {
+                $loader->load('doctrine.xml');
+                $container->setAlias('fos_user.doctrine_registry', new Alias(self::$doctrineDrivers[$config['db_driver']]['registry'], false));
+            } else {
+                $loader->load(sprintf('%s.xml', $config['db_driver']));
+            }
+            $container->setParameter($this->getAlias().'.backend_type_'.$config['db_driver'], true);
+        }
+
+        if (isset(self::$doctrineDrivers[$config['db_driver']])) {
+            $definition = $container->getDefinition('fos_user.object_manager');
+            $definition->setFactory(array(new Reference('fos_user.doctrine_registry'), 'getManager'));
+        }
+
+        foreach (array('validator', 'security', 'util', 'mailer', 'listeners', 'commands') as $basename) {
+            $loader->load(sprintf('%s.xml', $basename));
+        }
+
+        if (!$config['use_authentication_listener']) {
+            $container->removeDefinition('fos_user.listener.authentication');
+        }
+
+        if ($config['use_flash_notifications']) {
+            $this->sessionNeeded = true;
+            $loader->load('flash_notifications.xml');
+        }
+
+        $container->setAlias('fos_user.util.email_canonicalizer', $config['service']['email_canonicalizer']);
+        $container->setAlias('fos_user.util.username_canonicalizer', $config['service']['username_canonicalizer']);
+        $container->setAlias('fos_user.util.token_generator', $config['service']['token_generator']);
+        $container->setAlias('fos_user.user_manager', new Alias($config['service']['user_manager'], true));
+
+        if ($config['use_listener'] && isset(self::$doctrineDrivers[$config['db_driver']])) {
+            $listenerDefinition = $container->getDefinition('fos_user.user_listener');
+            $listenerDefinition->addTag(self::$doctrineDrivers[$config['db_driver']]['tag']);
+            if (isset(self::$doctrineDrivers[$config['db_driver']]['listener_class'])) {
+                $listenerDefinition->setClass(self::$doctrineDrivers[$config['db_driver']]['listener_class']);
+            }
+        }
+
+        if ($config['use_username_form_type']) {
+            $loader->load('username_form_type.xml');
+        }
+
+        $this->remapParametersNamespaces($config, $container, array(
+            '' => array(
+                'db_driver' => 'fos_user.storage',
+                'firewall_name' => 'fos_user.firewall_name',
+                'model_manager_name' => 'fos_user.model_manager_name',
+                'user_class' => 'fos_user.model.user.class',
+            ),
+        ));
+
+        if (!empty($config['profile'])) {
+            $this->loadProfile($config['profile'], $container, $loader);
+        }
+
+        if (!empty($config['registration'])) {
+            $this->loadRegistration($config['registration'], $container, $loader, $config['from_email']);
+        }
+
+        if (!empty($config['change_password'])) {
+            $this->loadChangePassword($config['change_password'], $container, $loader);
+        }
+
+        if (!empty($config['resetting'])) {
+            $this->loadResetting($config['resetting'], $container, $loader, $config['from_email']);
+        }
+
+        if (!empty($config['group'])) {
+            $this->loadGroups($config['group'], $container, $loader, $config['db_driver']);
+        }
+
+        if ($this->mailerNeeded) {
+            $container->setAlias('fos_user.mailer', $config['service']['mailer']);
+        }
+
+        if ($this->sessionNeeded) {
+            // Use a private alias rather than a parameter, to avoid leaking it at runtime (the private alias will be removed)
+            $container->setAlias('fos_user.session', new Alias('session', false));
+        }
+    }*/
+
+    /**
+     * @param array            $config
+     * @param ContainerBuilder $container
+     * @param array            $map
+     */
+    protected function remapParameters(array $config, ContainerBuilder $container, array $map)
+    {
+        foreach ($map as $name => $paramName) {
+            if (array_key_exists($name, $config)) {
+                $container->setParameter($paramName, $config[$name]);
+            }
+        }
+    }
+
+    /**
+     * @param array            $config
+     * @param ContainerBuilder $container
+     * @param array            $namespaces
+     */
+    protected function remapParametersNamespaces(array $config, ContainerBuilder $container, array $namespaces)
+    {
+        foreach ($namespaces as $ns => $map) {
+            if ($ns) {
+                if (!array_key_exists($ns, $config)) {
+                    continue;
+                }
+                $namespaceConfig = $config[$ns];
+            } else {
+                $namespaceConfig = $config;
+            }
+            if (is_array($map)) {
+                $this->remapParameters($namespaceConfig, $container, $map);
+            } else {
+                foreach ($namespaceConfig as $name => $value) {
+                    $container->setParameter(sprintf($map, $name), $value);
+                }
+            }
+        }
+    }
+
+    /**
+     * @param array            $config
+     * @param ContainerBuilder $container
+     * @param XmlFileLoader    $loader
+     */
+    private function loadProfile(array $config, ContainerBuilder $container, XmlFileLoader $loader)
+    {
+        $loader->load('profile.xml');
+
+        $this->remapParametersNamespaces($config, $container, array(
+            'form' => 'fos_user.profile.form.%s',
+        ));
+    }
+
+    /**
+     * @param array            $config
+     * @param ContainerBuilder $container
+     * @param XmlFileLoader    $loader
+     * @param array            $fromEmail
+     */
+    private function loadRegistration(array $config, ContainerBuilder $container, XmlFileLoader $loader, array $fromEmail)
+    {
+        $loader->load('registration.xml');
+        $this->sessionNeeded = true;
+
+        if ($config['confirmation']['enabled']) {
+            $this->mailerNeeded = true;
+            $loader->load('email_confirmation.xml');
+        }
+
+        if (isset($config['confirmation']['from_email'])) {
+            // overwrite the global one
+            $fromEmail = $config['confirmation']['from_email'];
+            unset($config['confirmation']['from_email']);
+        }
+        $container->setParameter('fos_user.registration.confirmation.from_email', array($fromEmail['address'] => $fromEmail['sender_name']));
+
+        $this->remapParametersNamespaces($config, $container, array(
+            'confirmation' => 'fos_user.registration.confirmation.%s',
+            'form' => 'fos_user.registration.form.%s',
+        ));
+    }
+
+    /**
+     * @param array            $config
+     * @param ContainerBuilder $container
+     * @param XmlFileLoader    $loader
+     */
+    private function loadChangePassword(array $config, ContainerBuilder $container, XmlFileLoader $loader)
+    {
+        $loader->load('change_password.xml');
+
+        $this->remapParametersNamespaces($config, $container, array(
+            'form' => 'fos_user.change_password.form.%s',
+        ));
+    }
+
+    /**
+     * @param array            $config
+     * @param ContainerBuilder $container
+     * @param XmlFileLoader    $loader
+     * @param array            $fromEmail
+     */
+    private function loadResetting(array $config, ContainerBuilder $container, XmlFileLoader $loader, array $fromEmail)
+    {
+        $this->mailerNeeded = true;
+        $loader->load('resetting.xml');
+
+        if (isset($config['email']['from_email'])) {
+            // overwrite the global one
+            $fromEmail = $config['email']['from_email'];
+            unset($config['email']['from_email']);
+        }
+        $container->setParameter('fos_user.resetting.email.from_email', array($fromEmail['address'] => $fromEmail['sender_name']));
+
+        $this->remapParametersNamespaces($config, $container, array(
+            '' => array(
+                'retry_ttl' => 'fos_user.resetting.retry_ttl',
+                'token_ttl' => 'fos_user.resetting.token_ttl',
+            ),
+            'email' => 'fos_user.resetting.email.%s',
+            'form' => 'fos_user.resetting.form.%s',
+        ));
+    }
+
+    /**
+     * @param array            $config
+     * @param ContainerBuilder $container
+     * @param XmlFileLoader    $loader
+     * @param string           $dbDriver
+     */
+    private function loadGroups(array $config, ContainerBuilder $container, XmlFileLoader $loader, $dbDriver)
+    {
+        $loader->load('group.xml');
+        if ('custom' !== $dbDriver) {
+            if (isset(self::$doctrineDrivers[$dbDriver])) {
+                $loader->load('doctrine_group.xml');
+            } else {
+                $loader->load(sprintf('%s_group.xml', $dbDriver));
+            }
+        }
+
+        $container->setAlias('fos_user.group_manager', new Alias($config['group_manager'], true));
+        $container->setAlias('FOS\UserBundle\Model\GroupManagerInterface', new Alias('fos_user.group_manager', false));
+
+        $this->remapParametersNamespaces($config, $container, array(
+            '' => array(
+                'group_class' => 'fos_user.model.group.class',
+            ),
+            'form' => 'fos_user.group.form.%s',
+        ));
     }
 }

--- a/src/Doctrine/CouchDB/UserListener.php
+++ b/src/Doctrine/CouchDB/UserListener.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Doctrine\CouchDB;
+
+use Doctrine\Common\EventSubscriber;
+use Doctrine\ODM\CouchDB\Event;
+use Doctrine\ODM\CouchDB\Event\LifecycleEventArgs;
+use Sonata\UserBundle\Model\FOSUserInterface;
+use Sonata\UserBundle\Util\CanonicalFieldsUpdater;
+use Sonata\UserBundle\Util\PasswordUpdaterInterface;
+
+class UserListener implements EventSubscriber
+{
+    private $passwordUpdater;
+    private $canonicalFieldsUpdater;
+
+    public function __construct(PasswordUpdaterInterface $passwordUpdater, CanonicalFieldsUpdater $canonicalFieldsUpdater)
+    {
+        $this->passwordUpdater = $passwordUpdater;
+        $this->canonicalFieldsUpdater = $canonicalFieldsUpdater;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSubscribedEvents()
+    {
+        return array(
+            Event::prePersist,
+            Event::preUpdate,
+        );
+    }
+
+    /**
+     * @param LifecycleEventArgs $args
+     */
+    public function prePersist(LifecycleEventArgs $args)
+    {
+        $object = $args->getDocument();
+        if ($object instanceof FOSUserInterface) {
+            $this->updateUserFields($object);
+        }
+    }
+
+    /**
+     * @param LifecycleEventArgs $args
+     */
+    public function preUpdate(LifecycleEventArgs $args)
+    {
+        $object = $args->getDocument();
+        if ($object instanceof FOSUserInterface) {
+            $this->updateUserFields($object);
+        }
+    }
+
+    /**
+     * Updates the user properties.
+     *
+     * @param FOSUserInterface $user
+     */
+    private function updateUserFields(FOSUserInterface $user)
+    {
+        $this->canonicalFieldsUpdater->updateCanonicalFields($user);
+        $this->passwordUpdater->hashPassword($user);
+    }
+}

--- a/src/Doctrine/GroupManager.php
+++ b/src/Doctrine/GroupManager.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Doctrine;
+
+use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Common\Persistence\ObjectRepository;
+use Sonata\UserBundle\Model\GroupInterface;
+use Sonata\UserBundle\Model\GroupManager as BaseGroupManager;
+
+class GroupManager extends BaseGroupManager
+{
+    /**
+     * @var ObjectManager
+     */
+    protected $objectManager;
+
+    /**
+     * @var string
+     */
+    protected $class;
+
+    /**
+     * @var ObjectRepository
+     */
+    protected $repository;
+
+    /**
+     * GroupManager constructor.
+     *
+     * @param ObjectManager $om
+     * @param string        $class
+     */
+    public function __construct(ObjectManager $om, $class)
+    {
+        $this->objectManager = $om;
+        $this->repository = $om->getRepository($class);
+
+        $metadata = $om->getClassMetadata($class);
+        $this->class = $metadata->getName();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deleteGroup(GroupInterface $group)
+    {
+        $this->objectManager->remove($group);
+        $this->objectManager->flush();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getClass()
+    {
+        return $this->class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function findGroupBy(array $criteria)
+    {
+        return $this->repository->findOneBy($criteria);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function findGroups()
+    {
+        return $this->repository->findAll();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function updateGroup(GroupInterface $group, $andFlush = true)
+    {
+        $this->objectManager->persist($group);
+        if ($andFlush) {
+            $this->objectManager->flush();
+        }
+    }
+}

--- a/src/Doctrine/UserListener.php
+++ b/src/Doctrine/UserListener.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Doctrine;
+
+use Doctrine\Common\EventSubscriber;
+use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
+use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\ORM\EntityManager;
+use Sonata\UserBundle\Model\FOSUserInterface;
+use Sonata\UserBundle\Util\CanonicalFieldsUpdater;
+use Sonata\UserBundle\Util\PasswordUpdaterInterface;
+
+/**
+ * Doctrine listener updating the canonical username and password fields.
+ *
+ * @author Christophe Coevoet <stof@notk.org>
+ * @author David Buchmann <mail@davidbu.ch>
+ */
+class UserListener implements EventSubscriber
+{
+    private $passwordUpdater;
+    private $canonicalFieldsUpdater;
+
+    public function __construct(PasswordUpdaterInterface $passwordUpdater, CanonicalFieldsUpdater $canonicalFieldsUpdater)
+    {
+        $this->passwordUpdater = $passwordUpdater;
+        $this->canonicalFieldsUpdater = $canonicalFieldsUpdater;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSubscribedEvents()
+    {
+        return array(
+            'prePersist',
+            'preUpdate',
+        );
+    }
+
+    /**
+     * Pre persist listener based on doctrine common.
+     *
+     * @param LifecycleEventArgs $args
+     */
+    public function prePersist(LifecycleEventArgs $args)
+    {
+        $object = $args->getObject();
+        if ($object instanceof FOSUserInterface) {
+            $this->updateUserFields($object);
+        }
+    }
+
+    /**
+     * Pre update listener based on doctrine common.
+     *
+     * @param LifecycleEventArgs $args
+     */
+    public function preUpdate(LifecycleEventArgs $args)
+    {
+        $object = $args->getObject();
+        if ($object instanceof FOSUserInterface) {
+            $this->updateUserFields($object);
+            $this->recomputeChangeSet($args->getObjectManager(), $object);
+        }
+    }
+
+    /**
+     * Updates the user properties.
+     *
+     * @param FOSUserInterface $user
+     */
+    private function updateUserFields(FOSUserInterface $user)
+    {
+        $this->canonicalFieldsUpdater->updateCanonicalFields($user);
+        $this->passwordUpdater->hashPassword($user);
+    }
+
+    /**
+     * Recomputes change set for Doctrine implementations not doing it automatically after the event.
+     *
+     * @param ObjectManager $om
+     * @param FOSUserInterface $user
+     */
+    private function recomputeChangeSet(ObjectManager $om, FOSUserInterface $user)
+    {
+        $meta = $om->getClassMetadata(get_class($user));
+
+        if ($om instanceof EntityManager) {
+            $om->getUnitOfWork()->recomputeSingleEntityChangeSet($meta, $user);
+
+            return;
+        }
+
+        if ($om instanceof DocumentManager) {
+            $om->getUnitOfWork()->recomputeSingleDocumentChangeSet($meta, $user);
+        }
+    }
+}

--- a/src/Doctrine/UserManager.php
+++ b/src/Doctrine/UserManager.php
@@ -1,0 +1,116 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Doctrine;
+
+use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Common\Persistence\ObjectRepository;
+use Sonata\UserBundle\Model\FOSUserInterface;
+use Sonata\UserBundle\Model\UserManager as BaseUserManager;
+use Sonata\UserBundle\Util\CanonicalFieldsUpdater;
+use Sonata\UserBundle\Util\PasswordUpdaterInterface;
+
+class UserManager extends BaseUserManager
+{
+    /**
+     * @var ObjectManager
+     */
+    protected $objectManager;
+
+    /**
+     * @var string
+     */
+    private $class;
+
+    /**
+     * Constructor.
+     *
+     * @param PasswordUpdaterInterface $passwordUpdater
+     * @param CanonicalFieldsUpdater   $canonicalFieldsUpdater
+     * @param ObjectManager            $om
+     * @param string                   $class
+     */
+    public function __construct(PasswordUpdaterInterface $passwordUpdater, CanonicalFieldsUpdater $canonicalFieldsUpdater, ObjectManager $om, $class)
+    {
+        parent::__construct($passwordUpdater, $canonicalFieldsUpdater);
+
+        $this->objectManager = $om;
+        $this->class = $class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deleteUser(FOSUserInterface $user)
+    {
+        $this->objectManager->remove($user);
+        $this->objectManager->flush();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getClass()
+    {
+        if (false !== strpos($this->class, ':')) {
+            $metadata = $this->objectManager->getClassMetadata($this->class);
+            $this->class = $metadata->getName();
+        }
+
+        return $this->class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function findUserBy(array $criteria)
+    {
+        return $this->getRepository()->findOneBy($criteria);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function findUsers()
+    {
+        return $this->getRepository()->findAll();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reloadUser(FOSUserInterface $user)
+    {
+        $this->objectManager->refresh($user);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function updateUser(FOSUserInterface $user, $andFlush = true)
+    {
+        $this->updateCanonicalFields($user);
+        $this->updatePassword($user);
+
+        $this->objectManager->persist($user);
+        if ($andFlush) {
+            $this->objectManager->flush();
+        }
+    }
+
+    /**
+     * @return ObjectRepository
+     */
+    protected function getRepository()
+    {
+        return $this->objectManager->getRepository($this->getClass());
+    }
+}

--- a/src/Document/BaseGroup.php
+++ b/src/Document/BaseGroup.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\UserBundle\Document;
 
-use FOS\UserBundle\Model\Group as AbstractedGroup;
+use Sonata\UserBundle\Model\Group as AbstractedGroup;
 
 /**
  * Represents a Base Group Document.

--- a/src/Document/GroupManager.php
+++ b/src/Document/GroupManager.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\UserBundle\Document;
 
-use FOS\UserBundle\Doctrine\GroupManager as BaseGroupManager;
+use Sonata\UserBundle\Doctrine\GroupManager as BaseGroupManager;
 use Sonata\UserBundle\Model\GroupManagerInterface;
 
 /**

--- a/src/Document/UserManager.php
+++ b/src/Document/UserManager.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\UserBundle\Document;
 
-use FOS\UserBundle\Doctrine\UserManager as BaseUserManager;
+use Sonata\UserBundle\Doctrine\UserManager as BaseUserManager;
 use Sonata\UserBundle\Model\UserManagerInterface;
 
 /**

--- a/src/Entity/BaseGroup.php
+++ b/src/Entity/BaseGroup.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\UserBundle\Entity;
 
-use FOS\UserBundle\Model\Group as AbstractedGroup;
+use Sonata\UserBundle\Model\Group as AbstractedGroup;
 
 /**
  * Represents a Base Group Entity.

--- a/src/Entity/GroupManager.php
+++ b/src/Entity/GroupManager.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\UserBundle\Entity;
 
-use FOS\UserBundle\Doctrine\GroupManager as BaseGroupManager;
+use Sonata\UserBundle\Doctrine\GroupManager as BaseGroupManager;
 use Sonata\DatagridBundle\Pager\Doctrine\Pager;
 use Sonata\DatagridBundle\ProxyQuery\Doctrine\ProxyQuery;
 use Sonata\UserBundle\Model\GroupManagerInterface;

--- a/src/Entity/UserManager.php
+++ b/src/Entity/UserManager.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\UserBundle\Entity;
 
-use FOS\UserBundle\Doctrine\UserManager as BaseUserManager;
+use Sonata\UserBundle\Doctrine\UserManager as BaseUserManager;
 use Sonata\CoreBundle\Model\ManagerInterface;
 use Sonata\DatagridBundle\Pager\Doctrine\Pager;
 use Sonata\DatagridBundle\ProxyQuery\Doctrine\ProxyQuery;

--- a/src/Event/FilterGroupResponseEvent.php
+++ b/src/Event/FilterGroupResponseEvent.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Event;
+
+use Sonata\UserBundle\Model\GroupInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class FilterGroupResponseEvent extends GroupEvent
+{
+    /**
+     * @var Response
+     */
+    private $response;
+
+    /**
+     * FilterGroupResponseEvent constructor.
+     *
+     * @param GroupInterface $group
+     * @param Request        $request
+     * @param Response       $response
+     */
+    public function __construct(GroupInterface $group, Request $request, Response $response)
+    {
+        parent::__construct($group, $request);
+
+        $this->response = $response;
+    }
+
+    /**
+     * @param Response $response
+     */
+    public function setResponse(Response $response)
+    {
+        $this->response = $response;
+    }
+
+    /**
+     * @return Response|null
+     */
+    public function getResponse()
+    {
+        return $this->response;
+    }
+}

--- a/src/Event/FilterUserResponseEvent.php
+++ b/src/Event/FilterUserResponseEvent.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Event;
+
+use Sonata\UserBundle\Model\FOSUserInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class FilterUserResponseEvent extends UserEvent
+{
+    private $response;
+
+    /**
+     * FilterUserResponseEvent constructor.
+     *
+     * @param FOSUserInterface $user
+     * @param Request       $request
+     * @param Response      $response
+     */
+    public function __construct(FOSUserInterface $user, Request $request, Response $response)
+    {
+        parent::__construct($user, $request);
+        $this->response = $response;
+    }
+
+    /**
+     * @return Response
+     */
+    public function getResponse()
+    {
+        return $this->response;
+    }
+
+    /**
+     * Sets a new response object.
+     *
+     * @param Response $response
+     */
+    public function setResponse(Response $response)
+    {
+        $this->response = $response;
+    }
+}

--- a/src/Event/FormEvent.php
+++ b/src/Event/FormEvent.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class FormEvent extends Event
+{
+    /**
+     * @var FormInterface
+     */
+    private $form;
+
+    /**
+     * @var Request
+     */
+    private $request;
+
+    /**
+     * @var Response
+     */
+    private $response;
+
+    /**
+     * FormEvent constructor.
+     *
+     * @param FormInterface $form
+     * @param Request       $request
+     */
+    public function __construct(FormInterface $form, Request $request)
+    {
+        $this->form = $form;
+        $this->request = $request;
+    }
+
+    /**
+     * @return FormInterface
+     */
+    public function getForm()
+    {
+        return $this->form;
+    }
+
+    /**
+     * @return Request
+     */
+    public function getRequest()
+    {
+        return $this->request;
+    }
+
+    /**
+     * @param Response $response
+     */
+    public function setResponse(Response $response)
+    {
+        $this->response = $response;
+    }
+
+    /**
+     * @return Response|null
+     */
+    public function getResponse()
+    {
+        return $this->response;
+    }
+}

--- a/src/Event/GetResponseGroupEvent.php
+++ b/src/Event/GetResponseGroupEvent.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Event;
+
+use Symfony\Component\HttpFoundation\Response;
+
+class GetResponseGroupEvent extends GroupEvent
+{
+    /**
+     * @var Response
+     */
+    private $response;
+
+    /**
+     * @param Response $response
+     */
+    public function setResponse(Response $response)
+    {
+        $this->response = $response;
+    }
+
+    /**
+     * @return Response|null
+     */
+    public function getResponse()
+    {
+        return $this->response;
+    }
+}

--- a/src/Event/GetResponseNullableUserEvent.php
+++ b/src/Event/GetResponseNullableUserEvent.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Event;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * Response user event that allows null user.
+ *
+ * @author Konstantinos Christofilos <kostas.christofilos@gmail.com>
+ */
+class GetResponseNullableUserEvent extends GetResponseUserEvent
+{
+    /**
+     * GetResponseNullableUserEvent constructor.
+     *
+     * @param UserInterface|null $user
+     * @param Request            $request
+     */
+    public function __construct(UserInterface $user = null, Request $request)
+    {
+        $this->user = $user;
+        $this->request = $request;
+    }
+}

--- a/src/Event/GetResponseUserEvent.php
+++ b/src/Event/GetResponseUserEvent.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Event;
+
+use Symfony\Component\HttpFoundation\Response;
+
+class GetResponseUserEvent extends UserEvent
+{
+    /**
+     * @var Response
+     */
+    private $response;
+
+    /**
+     * @param Response $response
+     */
+    public function setResponse(Response $response)
+    {
+        $this->response = $response;
+    }
+
+    /**
+     * @return Response|null
+     */
+    public function getResponse()
+    {
+        return $this->response;
+    }
+}

--- a/src/Event/GroupEvent.php
+++ b/src/Event/GroupEvent.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Event;
+
+use Sonata\UserBundle\Model\GroupInterface;
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\HttpFoundation\Request;
+
+class GroupEvent extends Event
+{
+    /**
+     * @var GroupInterface
+     */
+    private $group;
+
+    /**
+     * @var Request
+     */
+    private $request;
+
+    /**
+     * GroupEvent constructor.
+     *
+     * @param GroupInterface $group
+     * @param Request        $request
+     */
+    public function __construct(GroupInterface $group, Request $request)
+    {
+        $this->group = $group;
+        $this->request = $request;
+    }
+
+    /**
+     * @return GroupInterface
+     */
+    public function getGroup()
+    {
+        return $this->group;
+    }
+
+    /**
+     * @return Request
+     */
+    public function getRequest()
+    {
+        return $this->request;
+    }
+}

--- a/src/Event/UserEvent.php
+++ b/src/Event/UserEvent.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Event;
+
+use Sonata\UserBundle\Model\FOSUserInterface;
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\HttpFoundation\Request;
+
+class UserEvent extends Event
+{
+    /**
+     * @var null|Request
+     */
+    protected $request;
+
+    /**
+     * @var FOSUserInterface
+     */
+    protected $user;
+
+    /**
+     * UserEvent constructor.
+     *
+     * @param FOSUserInterface $user
+     * @param Request|null  $request
+     */
+    public function __construct(FOSUserInterface $user, Request $request = null)
+    {
+        $this->user = $user;
+        $this->request = $request;
+    }
+
+    /**
+     * @return FOSUserInterface
+     */
+    public function getUser()
+    {
+        return $this->user;
+    }
+
+    /**
+     * @return Request
+     */
+    public function getRequest()
+    {
+        return $this->request;
+    }
+}

--- a/src/EventListener/AuthenticationListener.php
+++ b/src/EventListener/AuthenticationListener.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\EventListener;
+
+use Sonata\UserBundle\Event\FilterUserResponseEvent;
+use Sonata\UserBundle\Event\UserEvent;
+use Sonata\UserBundle\FOSUserEvents;
+use Sonata\UserBundle\Security\LoginManagerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Security\Core\Exception\AccountStatusException;
+
+class AuthenticationListener implements EventSubscriberInterface
+{
+    /**
+     * @var LoginManagerInterface
+     */
+    private $loginManager;
+
+    /**
+     * @var string
+     */
+    private $firewallName;
+
+    /**
+     * AuthenticationListener constructor.
+     *
+     * @param LoginManagerInterface $loginManager
+     * @param string                $firewallName
+     */
+    public function __construct(LoginManagerInterface $loginManager, $firewallName)
+    {
+        $this->loginManager = $loginManager;
+        $this->firewallName = $firewallName;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(
+            FOSUserEvents::REGISTRATION_COMPLETED => 'authenticate',
+            FOSUserEvents::REGISTRATION_CONFIRMED => 'authenticate',
+            FOSUserEvents::RESETTING_RESET_COMPLETED => 'authenticate',
+        );
+    }
+
+    /**
+     * @param FilterUserResponseEvent  $event
+     * @param string                   $eventName
+     * @param EventDispatcherInterface $eventDispatcher
+     */
+    public function authenticate(FilterUserResponseEvent $event, $eventName, EventDispatcherInterface $eventDispatcher)
+    {
+        try {
+            $this->loginManager->logInUser($this->firewallName, $event->getUser(), $event->getResponse());
+
+            $eventDispatcher->dispatch(FOSUserEvents::SECURITY_IMPLICIT_LOGIN, new UserEvent($event->getUser(), $event->getRequest()));
+        } catch (AccountStatusException $ex) {
+            // We simply do not authenticate users which do not pass the user
+            // checker (not enabled, expired, etc.).
+        }
+    }
+}

--- a/src/EventListener/EmailConfirmationListener.php
+++ b/src/EventListener/EmailConfirmationListener.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\EventListener;
+
+use Sonata\UserBundle\Event\FormEvent;
+use Sonata\UserBundle\FOSUserEvents;
+use Sonata\UserBundle\Mailer\MailerInterface;
+use Sonata\UserBundle\Util\TokenGeneratorInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+class EmailConfirmationListener implements EventSubscriberInterface
+{
+    private $mailer;
+    private $tokenGenerator;
+    private $router;
+    private $session;
+
+    /**
+     * EmailConfirmationListener constructor.
+     *
+     * @param MailerInterface         $mailer
+     * @param TokenGeneratorInterface $tokenGenerator
+     * @param UrlGeneratorInterface   $router
+     * @param SessionInterface        $session
+     */
+    public function __construct(MailerInterface $mailer, TokenGeneratorInterface $tokenGenerator, UrlGeneratorInterface $router, SessionInterface $session)
+    {
+        $this->mailer = $mailer;
+        $this->tokenGenerator = $tokenGenerator;
+        $this->router = $router;
+        $this->session = $session;
+    }
+
+    /**
+     * @return array
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(
+            FOSUserEvents::REGISTRATION_SUCCESS => 'onRegistrationSuccess',
+        );
+    }
+
+    /**
+     * @param FormEvent $event
+     */
+    public function onRegistrationSuccess(FormEvent $event)
+    {
+        /** @var $user \Sonata\UserBundle\Model\FOSUserInterface */
+        $user = $event->getForm()->getData();
+
+        $user->setEnabled(false);
+        if (null === $user->getConfirmationToken()) {
+            $user->setConfirmationToken($this->tokenGenerator->generateToken());
+        }
+
+        $this->mailer->sendConfirmationEmailMessage($user);
+
+        $this->session->set('fos_user_send_confirmation_email/email', $user->getEmail());
+
+        $url = $this->router->generate('fos_user_registration_check_email');
+        $event->setResponse(new RedirectResponse($url));
+    }
+}

--- a/src/EventListener/FlashListener.php
+++ b/src/EventListener/FlashListener.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\EventListener;
+
+use Sonata\UserBundle\FOSUserEvents;
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class FlashListener implements EventSubscriberInterface
+{
+    /**
+     * @var string[]
+     */
+    private static $successMessages = array(
+        FOSUserEvents::CHANGE_PASSWORD_COMPLETED => 'change_password.flash.success',
+        FOSUserEvents::GROUP_CREATE_COMPLETED => 'group.flash.created',
+        FOSUserEvents::GROUP_DELETE_COMPLETED => 'group.flash.deleted',
+        FOSUserEvents::GROUP_EDIT_COMPLETED => 'group.flash.updated',
+        FOSUserEvents::PROFILE_EDIT_COMPLETED => 'profile.flash.updated',
+        FOSUserEvents::REGISTRATION_COMPLETED => 'registration.flash.user_created',
+        FOSUserEvents::RESETTING_RESET_COMPLETED => 'resetting.flash.success',
+    );
+
+    /**
+     * @var Session
+     */
+    private $session;
+
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    /**
+     * FlashListener constructor.
+     *
+     * @param Session             $session
+     * @param TranslatorInterface $translator
+     */
+    public function __construct(Session $session, TranslatorInterface $translator)
+    {
+        $this->session = $session;
+        $this->translator = $translator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(
+            FOSUserEvents::CHANGE_PASSWORD_COMPLETED => 'addSuccessFlash',
+            FOSUserEvents::GROUP_CREATE_COMPLETED => 'addSuccessFlash',
+            FOSUserEvents::GROUP_DELETE_COMPLETED => 'addSuccessFlash',
+            FOSUserEvents::GROUP_EDIT_COMPLETED => 'addSuccessFlash',
+            FOSUserEvents::PROFILE_EDIT_COMPLETED => 'addSuccessFlash',
+            FOSUserEvents::REGISTRATION_COMPLETED => 'addSuccessFlash',
+            FOSUserEvents::RESETTING_RESET_COMPLETED => 'addSuccessFlash',
+        );
+    }
+
+    /**
+     * @param Event  $event
+     * @param string $eventName
+     */
+    public function addSuccessFlash(Event $event, $eventName)
+    {
+        if (!isset(self::$successMessages[$eventName])) {
+            throw new \InvalidArgumentException('This event does not correspond to a known flash message');
+        }
+
+        $this->session->getFlashBag()->add('success', $this->trans(self::$successMessages[$eventName]));
+    }
+
+    /**
+     * @param string$message
+     * @param array $params
+     *
+     * @return string
+     */
+    private function trans($message, array $params = array())
+    {
+        return $this->translator->trans($message, $params, 'FOSUserBundle');
+    }
+}

--- a/src/EventListener/LastLoginListener.php
+++ b/src/EventListener/LastLoginListener.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\EventListener;
+
+use Sonata\UserBundle\Event\UserEvent;
+use Sonata\UserBundle\FOSUserEvents;
+use Sonata\UserBundle\Model\FOSUserInterface;
+use Sonata\UserBundle\Model\FOSUserManagerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
+use Symfony\Component\Security\Http\SecurityEvents;
+
+class LastLoginListener implements EventSubscriberInterface
+{
+    protected $userManager;
+
+    /**
+     * LastLoginListener constructor.
+     *
+     * @param FOSUserManagerInterface $userManager
+     */
+    public function __construct(FOSUserManagerInterface $userManager)
+    {
+        $this->userManager = $userManager;
+    }
+
+    /**
+     * @return array
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(
+            FOSUserEvents::SECURITY_IMPLICIT_LOGIN => 'onImplicitLogin',
+            SecurityEvents::INTERACTIVE_LOGIN => 'onSecurityInteractiveLogin',
+        );
+    }
+
+    /**
+     * @param UserEvent $event
+     */
+    public function onImplicitLogin(UserEvent $event)
+    {
+        $user = $event->getUser();
+
+        $user->setLastLogin(new \DateTime());
+        $this->userManager->updateUser($user);
+    }
+
+    /**
+     * @param InteractiveLoginEvent $event
+     */
+    public function onSecurityInteractiveLogin(InteractiveLoginEvent $event)
+    {
+        $user = $event->getAuthenticationToken()->getUser();
+
+        if ($user instanceof FOSUserInterface) {
+            $user->setLastLogin(new \DateTime());
+            $this->userManager->updateUser($user);
+        }
+    }
+}

--- a/src/EventListener/ResettingListener.php
+++ b/src/EventListener/ResettingListener.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\EventListener;
+
+use Sonata\UserBundle\Event\FormEvent;
+use Sonata\UserBundle\Event\GetResponseUserEvent;
+use Sonata\UserBundle\FOSUserEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+class ResettingListener implements EventSubscriberInterface
+{
+    /**
+     * @var UrlGeneratorInterface
+     */
+    private $router;
+
+    /**
+     * @var int
+     */
+    private $tokenTtl;
+
+    /**
+     * ResettingListener constructor.
+     *
+     * @param UrlGeneratorInterface $router
+     * @param int                   $tokenTtl
+     */
+    public function __construct(UrlGeneratorInterface $router, $tokenTtl)
+    {
+        $this->router = $router;
+        $this->tokenTtl = $tokenTtl;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(
+            FOSUserEvents::RESETTING_RESET_INITIALIZE => 'onResettingResetInitialize',
+            FOSUserEvents::RESETTING_RESET_SUCCESS => 'onResettingResetSuccess',
+            FOSUserEvents::RESETTING_RESET_REQUEST => 'onResettingResetRequest',
+        );
+    }
+
+    /**
+     * @param GetResponseUserEvent $event
+     */
+    public function onResettingResetInitialize(GetResponseUserEvent $event)
+    {
+        if (!$event->getUser()->isPasswordRequestNonExpired($this->tokenTtl)) {
+            $event->setResponse(new RedirectResponse($this->router->generate('fos_user_resetting_request')));
+        }
+    }
+
+    /**
+     * @param FormEvent $event
+     */
+    public function onResettingResetSuccess(FormEvent $event)
+    {
+        /** @var $user \Sonata\UserBundle\Model\FOSUserInterface */
+        $user = $event->getForm()->getData();
+
+        $user->setConfirmationToken(null);
+        $user->setPasswordRequestedAt(null);
+        $user->setEnabled(true);
+    }
+
+    /**
+     * @param GetResponseUserEvent $event
+     */
+    public function onResettingResetRequest(GetResponseUserEvent $event)
+    {
+        if (!$event->getUser()->isAccountNonLocked()) {
+            $event->setResponse(new RedirectResponse($this->router->generate('fos_user_resetting_request')));
+        }
+    }
+}

--- a/src/EventListener/TwoFactorLoginSuccessHandler.php
+++ b/src/EventListener/TwoFactorLoginSuccessHandler.php
@@ -13,8 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\UserBundle\EventListener;
 
-use FOS\UserBundle\Model\UserManagerInterface;
-use Sonata\GoogleAuthenticator\GoogleQrUrl;
+use Sonata\UserBundle\Model\FOSUserManagerInterface;
 use Sonata\UserBundle\GoogleAuthenticator\Helper;
 use Sonata\UserBundle\Model\User;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -43,7 +42,7 @@ final class TwoFactorLoginSuccessHandler implements AuthenticationSuccessHandler
     private $googleAuthenticator;
 
     /**
-     * @var UserManagerInterface
+     * @var FOSUserManagerInterface
      */
     private $userManager;
 
@@ -55,7 +54,7 @@ final class TwoFactorLoginSuccessHandler implements AuthenticationSuccessHandler
     public function __construct(
         Environment $engine,
         Helper $helper,
-        UserManagerInterface $userManager,
+        FOSUserManagerInterface $userManager,
         UrlGeneratorInterface $urlGenerator = null // NEXT_MAJOR: make it mandatory.
     ) {
         $this->engine = $engine;
@@ -77,7 +76,7 @@ final class TwoFactorLoginSuccessHandler implements AuthenticationSuccessHandler
             $secret = $this->googleAuthenticator->generateSecret();
             $user->setTwoStepVerificationCode($secret);
 
-            $qrCodeUrl = GoogleQrUrl::generate($user->getUsername(), $secret);
+            $qrCodeUrl = $this->googleAuthenticator->getUrl($user);
             $this->userManager->updateUser($user);
 
             return new Response($this->engine->render(

--- a/src/FOSUserEvents.php
+++ b/src/FOSUserEvents.php
@@ -1,0 +1,321 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle;
+
+/**
+ * Contains all events thrown in the FOSUserBundle.
+ */
+final class FOSUserEvents
+{
+    /**
+     * The CHANGE_PASSWORD_INITIALIZE event occurs when the change password process is initialized.
+     *
+     * This event allows you to modify the default values of the user before binding the form.
+     *
+     * @Event("Sonata\UserBundle\Event\GetResponseUserEvent")
+     */
+    const CHANGE_PASSWORD_INITIALIZE = 'fos_user.change_password.edit.initialize';
+
+    /**
+     * The CHANGE_PASSWORD_SUCCESS event occurs when the change password form is submitted successfully.
+     *
+     * This event allows you to set the response instead of using the default one.
+     *
+     * @Event("Sonata\UserBundle\Event\FormEvent")
+     */
+    const CHANGE_PASSWORD_SUCCESS = 'fos_user.change_password.edit.success';
+
+    /**
+     * The CHANGE_PASSWORD_COMPLETED event occurs after saving the user in the change password process.
+     *
+     * This event allows you to access the response which will be sent.
+     *
+     * @Event("Sonata\UserBundle\Event\FilterUserResponseEvent")
+     */
+    const CHANGE_PASSWORD_COMPLETED = 'fos_user.change_password.edit.completed';
+
+    /**
+     * The GROUP_CREATE_INITIALIZE event occurs when the group creation process is initialized.
+     *
+     * This event allows you to modify the default values of the user before binding the form.
+     *
+     * @Event("Sonata\UserBundle\Event\GroupEvent")
+     */
+    const GROUP_CREATE_INITIALIZE = 'fos_user.group.create.initialize';
+
+    /**
+     * The GROUP_CREATE_SUCCESS event occurs when the group creation form is submitted successfully.
+     *
+     * This event allows you to set the response instead of using the default one.
+     *
+     * @Event("Sonata\UserBundle\Event\FormEvent")
+     */
+    const GROUP_CREATE_SUCCESS = 'fos_user.group.create.success';
+
+    /**
+     * The GROUP_CREATE_COMPLETED event occurs after saving the group in the group creation process.
+     *
+     * This event allows you to access the response which will be sent.
+     *
+     * @Event("Sonata\UserBundle\Event\FilterGroupResponseEvent")
+     */
+    const GROUP_CREATE_COMPLETED = 'fos_user.group.create.completed';
+
+    /**
+     * The GROUP_DELETE_COMPLETED event occurs after deleting the group.
+     *
+     * This event allows you to access the response which will be sent.
+     *
+     * @Event("Sonata\UserBundle\Event\FilterGroupResponseEvent")
+     */
+    const GROUP_DELETE_COMPLETED = 'fos_user.group.delete.completed';
+
+    /**
+     * The GROUP_EDIT_INITIALIZE event occurs when the group editing process is initialized.
+     *
+     * This event allows you to modify the default values of the user before binding the form.
+     *
+     * @Event("Sonata\UserBundle\Event\GetResponseGroupEvent")
+     */
+    const GROUP_EDIT_INITIALIZE = 'fos_user.group.edit.initialize';
+
+    /**
+     * The GROUP_EDIT_SUCCESS event occurs when the group edit form is submitted successfully.
+     *
+     * This event allows you to set the response instead of using the default one.
+     *
+     * @Event("Sonata\UserBundle\Event\FormEvent")
+     */
+    const GROUP_EDIT_SUCCESS = 'fos_user.group.edit.success';
+
+    /**
+     * The GROUP_EDIT_COMPLETED event occurs after saving the group in the group edit process.
+     *
+     * This event allows you to access the response which will be sent.
+     *
+     * @Event("Sonata\UserBundle\Event\FilterGroupResponseEvent")
+     */
+    const GROUP_EDIT_COMPLETED = 'fos_user.group.edit.completed';
+
+    /**
+     * The PROFILE_EDIT_INITIALIZE event occurs when the profile editing process is initialized.
+     *
+     * This event allows you to modify the default values of the user before binding the form.
+     *
+     * @Event("Sonata\UserBundle\Event\GetResponseUserEvent")
+     */
+    const PROFILE_EDIT_INITIALIZE = 'fos_user.profile.edit.initialize';
+
+    /**
+     * The PROFILE_EDIT_SUCCESS event occurs when the profile edit form is submitted successfully.
+     *
+     * This event allows you to set the response instead of using the default one.
+     *
+     * @Event("Sonata\UserBundle\Event\FormEvent")
+     */
+    const PROFILE_EDIT_SUCCESS = 'fos_user.profile.edit.success';
+
+    /**
+     * The PROFILE_EDIT_COMPLETED event occurs after saving the user in the profile edit process.
+     *
+     * This event allows you to access the response which will be sent.
+     *
+     * @Event("Sonata\UserBundle\Event\FilterUserResponseEvent")
+     */
+    const PROFILE_EDIT_COMPLETED = 'fos_user.profile.edit.completed';
+
+    /**
+     * The REGISTRATION_INITIALIZE event occurs when the registration process is initialized.
+     *
+     * This event allows you to modify the default values of the user before binding the form.
+     *
+     * @Event("Sonata\UserBundle\Event\UserEvent")
+     */
+    const REGISTRATION_INITIALIZE = 'fos_user.registration.initialize';
+
+    /**
+     * The REGISTRATION_SUCCESS event occurs when the registration form is submitted successfully.
+     *
+     * This event allows you to set the response instead of using the default one.
+     *
+     * @Event("Sonata\UserBundle\Event\FormEvent")
+     */
+    const REGISTRATION_SUCCESS = 'fos_user.registration.success';
+
+    /**
+     * The REGISTRATION_FAILURE event occurs when the registration form is not valid.
+     *
+     * This event allows you to set the response instead of using the default one.
+     * The event listener method receives a Sonata\UserBundle\Event\FormEvent instance.
+     *
+     * @Event("Sonata\UserBundle\Event\FormEvent")
+     */
+    const REGISTRATION_FAILURE = 'fos_user.registration.failure';
+
+    /**
+     * The REGISTRATION_COMPLETED event occurs after saving the user in the registration process.
+     *
+     * This event allows you to access the response which will be sent.
+     *
+     * @Event("Sonata\UserBundle\Event\FilterUserResponseEvent")
+     */
+    const REGISTRATION_COMPLETED = 'fos_user.registration.completed';
+
+    /**
+     * The REGISTRATION_CONFIRM event occurs just before confirming the account.
+     *
+     * This event allows you to access the user which will be confirmed.
+     *
+     * @Event("Sonata\UserBundle\Event\GetResponseUserEvent")
+     */
+    const REGISTRATION_CONFIRM = 'fos_user.registration.confirm';
+
+    /**
+     * The REGISTRATION_CONFIRMED event occurs after confirming the account.
+     *
+     * This event allows you to access the response which will be sent.
+     *
+     * @Event("Sonata\UserBundle\Event\FilterUserResponseEvent")
+     */
+    const REGISTRATION_CONFIRMED = 'fos_user.registration.confirmed';
+
+    /**
+     * The RESETTING_RESET_REQUEST event occurs when a user requests a password reset of the account.
+     *
+     * This event allows you to check if a user is locked out before requesting a password.
+     * The event listener method receives a Sonata\UserBundle\Event\GetResponseUserEvent instance.
+     *
+     * @Event("Sonata\UserBundle\Event\GetResponseUserEvent")
+     */
+    const RESETTING_RESET_REQUEST = 'fos_user.resetting.reset.request';
+
+    /**
+     * The RESETTING_RESET_INITIALIZE event occurs when the resetting process is initialized.
+     *
+     * This event allows you to set the response to bypass the processing.
+     *
+     * @Event("Sonata\UserBundle\Event\GetResponseUserEvent")
+     */
+    const RESETTING_RESET_INITIALIZE = 'fos_user.resetting.reset.initialize';
+
+    /**
+     * The RESETTING_RESET_SUCCESS event occurs when the resetting form is submitted successfully.
+     *
+     * This event allows you to set the response instead of using the default one.
+     *
+     * @Event("Sonata\UserBundle\Event\FormEvent ")
+     */
+    const RESETTING_RESET_SUCCESS = 'fos_user.resetting.reset.success';
+
+    /**
+     * The RESETTING_RESET_COMPLETED event occurs after saving the user in the resetting process.
+     *
+     * This event allows you to access the response which will be sent.
+     *
+     * @Event("Sonata\UserBundle\Event\FilterUserResponseEvent")
+     */
+    const RESETTING_RESET_COMPLETED = 'fos_user.resetting.reset.completed';
+
+    /**
+     * The SECURITY_IMPLICIT_LOGIN event occurs when the user is logged in programmatically.
+     *
+     * This event allows you to access the response which will be sent.
+     *
+     * @Event("Sonata\UserBundle\Event\UserEvent")
+     */
+    const SECURITY_IMPLICIT_LOGIN = 'fos_user.security.implicit_login';
+
+    /**
+     * The RESETTING_SEND_EMAIL_INITIALIZE event occurs when the send email process is initialized.
+     *
+     * This event allows you to set the response to bypass the email confirmation processing.
+     * The event listener method receives a Sonata\UserBundle\Event\GetResponseNullableUserEvent instance.
+     *
+     * @Event("Sonata\UserBundle\Event\GetResponseNullableUserEvent")
+     */
+    const RESETTING_SEND_EMAIL_INITIALIZE = 'fos_user.resetting.send_email.initialize';
+
+    /**
+     * The RESETTING_SEND_EMAIL_CONFIRM event occurs when all prerequisites to send email are
+     * confirmed and before the mail is sent.
+     *
+     * This event allows you to set the response to bypass the email sending.
+     * The event listener method receives a Sonata\UserBundle\Event\GetResponseUserEvent instance.
+     *
+     * @Event("Sonata\UserBundle\Event\GetResponseUserEvent")
+     */
+    const RESETTING_SEND_EMAIL_CONFIRM = 'fos_user.resetting.send_email.confirm';
+
+    /**
+     * The RESETTING_SEND_EMAIL_COMPLETED event occurs after the email is sent.
+     *
+     * This event allows you to set the response to bypass the the redirection after the email is sent.
+     * The event listener method receives a Sonata\UserBundle\Event\GetResponseUserEvent instance.
+     *
+     * @Event("Sonata\UserBundle\Event\GetResponseUserEvent")
+     */
+    const RESETTING_SEND_EMAIL_COMPLETED = 'fos_user.resetting.send_email.completed';
+
+    /**
+     * The USER_CREATED event occurs when the user is created with UserManipulator.
+     *
+     * This event allows you to access the created user and to add some behaviour after the creation.
+     *
+     * @Event("Sonata\UserBundle\Event\UserEvent")
+     */
+    const USER_CREATED = 'fos_user.user.created';
+
+    /**
+     * The USER_PASSWORD_CHANGED event occurs when the user is created with UserManipulator.
+     *
+     * This event allows you to access the created user and to add some behaviour after the password change.
+     *
+     * @Event("Sonata\UserBundle\Event\UserEvent")
+     */
+    const USER_PASSWORD_CHANGED = 'fos_user.user.password_changed';
+
+    /**
+     * The USER_ACTIVATED event occurs when the user is created with UserManipulator.
+     *
+     * This event allows you to access the activated user and to add some behaviour after the activation.
+     *
+     * @Event("Sonata\UserBundle\Event\UserEvent")
+     */
+    const USER_ACTIVATED = 'fos_user.user.activated';
+
+    /**
+     * The USER_DEACTIVATED event occurs when the user is created with UserManipulator.
+     *
+     * This event allows you to access the deactivated user and to add some behaviour after the deactivation.
+     *
+     * @Event("Sonata\UserBundle\Event\UserEvent")
+     */
+    const USER_DEACTIVATED = 'fos_user.user.deactivated';
+
+    /**
+     * The USER_PROMOTED event occurs when the user is created with UserManipulator.
+     *
+     * This event allows you to access the promoted user and to add some behaviour after the promotion.
+     *
+     * @Event("Sonata\UserBundle\Event\UserEvent")
+     */
+    const USER_PROMOTED = 'fos_user.user.promoted';
+
+    /**
+     * The USER_DEMOTED event occurs when the user is created with UserManipulator.
+     *
+     * This event allows you to access the demoted user and to add some behaviour after the demotion.
+     *
+     * @Event("Sonata\UserBundle\Event\UserEvent")
+     */
+    const USER_DEMOTED = 'fos_user.user.demoted';
+}

--- a/src/Form/DataTransformer/UserToUsernameTransformer.php
+++ b/src/Form/DataTransformer/UserToUsernameTransformer.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Form\DataTransformer;
+
+use Sonata\UserBundle\Model\FOSUserInterface;
+use Sonata\UserBundle\Model\FOSUserManagerInterface;
+use Symfony\Component\Form\DataTransformerInterface;
+use Symfony\Component\Form\Exception\UnexpectedTypeException;
+
+/**
+ * Transforms between a FOSUserInterface instance and a username string.
+ *
+ * @author Thibault Duplessis <thibault.duplessis@gmail.com>
+ */
+class UserToUsernameTransformer implements DataTransformerInterface
+{
+    /**
+     * @var FOSUserManagerInterface
+     */
+    protected $userManager;
+
+    /**
+     * UserToUsernameTransformer constructor.
+     *
+     * @param FOSUserManagerInterface $userManager
+     */
+    public function __construct(FOSUserManagerInterface $userManager)
+    {
+        $this->userManager = $userManager;
+    }
+
+    /**
+     * Transforms a FOSUserInterface instance into a username string.
+     *
+     * @param FOSUserInterface|null $value FOSUserInterface instance
+     *
+     * @return string|null Username
+     *
+     * @throws UnexpectedTypeException if the given value is not a FOSUserInterface instance
+     */
+    public function transform($value)
+    {
+        if (null === $value) {
+            return;
+        }
+
+        if (!$value instanceof FOSUserInterface) {
+            throw new UnexpectedTypeException($value, 'Sonata\UserBundle\Model\FOSUserInterface');
+        }
+
+        return $value->getUsername();
+    }
+
+    /**
+     * Transforms a username string into a FOSUserInterface instance.
+     *
+     * @param string $value Username
+     *
+     * @return FOSUserInterface the corresponding FOSUserInterface instance
+     *
+     * @throws UnexpectedTypeException if the given value is not a string
+     */
+    public function reverseTransform($value)
+    {
+        if (null === $value || '' === $value) {
+            return;
+        }
+
+        if (!is_string($value)) {
+            throw new UnexpectedTypeException($value, 'string');
+        }
+
+        return $this->userManager->findUserByUsername($value);
+    }
+}

--- a/src/Form/Factory/FactoryInterface.php
+++ b/src/Form/Factory/FactoryInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Form\Factory;
+
+use Symfony\Component\Form\FormInterface;
+
+interface FactoryInterface
+{
+    /**
+     * @return FormInterface
+     */
+    public function createForm();
+}

--- a/src/Form/Factory/FormFactory.php
+++ b/src/Form/Factory/FormFactory.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Form\Factory;
+
+use Symfony\Component\Form\FormFactoryInterface;
+
+class FormFactory implements FactoryInterface
+{
+    /**
+     * @var FormFactoryInterface
+     */
+    private $formFactory;
+
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var string
+     */
+    private $type;
+
+    /**
+     * @var array
+     */
+    private $validationGroups;
+
+    /**
+     * FormFactory constructor.
+     *
+     * @param FormFactoryInterface $formFactory
+     * @param string               $name
+     * @param string               $type
+     * @param array                $validationGroups
+     */
+    public function __construct(FormFactoryInterface $formFactory, $name, $type, array $validationGroups = null)
+    {
+        $this->formFactory = $formFactory;
+        $this->name = $name;
+        $this->type = $type;
+        $this->validationGroups = $validationGroups;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createForm(array $options = array())
+    {
+        $options = array_merge(array('validation_groups' => $this->validationGroups), $options);
+
+        return $this->formFactory->createNamed($this->name, $this->type, null, $options);
+    }
+}

--- a/src/Form/Type/ChangePasswordFormType.php
+++ b/src/Form/Type/ChangePasswordFormType.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Security\Core\Validator\Constraints\UserPassword;
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+class ChangePasswordFormType extends AbstractType
+{
+    /**
+     * @var string
+     */
+    private $class;
+
+    /**
+     * @param string $class The User class name
+     */
+    public function __construct($class)
+    {
+        $this->class = $class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $constraintsOptions = array(
+            'message' => 'fos_user.current_password.invalid',
+        );
+
+        if (!empty($options['validation_groups'])) {
+            $constraintsOptions['groups'] = array(reset($options['validation_groups']));
+        }
+
+        $builder->add('current_password', PasswordType::class, array(
+            'label' => 'form.current_password',
+            'translation_domain' => 'FOSUserBundle',
+            'mapped' => false,
+            'constraints' => array(
+                new NotBlank(),
+                new UserPassword($constraintsOptions),
+            ),
+            'attr' => array(
+                'autocomplete' => 'current-password',
+            ),
+        ));
+
+        $builder->add('plainPassword', RepeatedType::class, array(
+            'type' => PasswordType::class,
+            'options' => array(
+                'translation_domain' => 'FOSUserBundle',
+                'attr' => array(
+                    'autocomplete' => 'new-password',
+                ),
+            ),
+            'first_options' => array('label' => 'form.new_password'),
+            'second_options' => array('label' => 'form.new_password_confirmation'),
+            'invalid_message' => 'fos_user.password.mismatch',
+        ));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'data_class' => $this->class,
+            'csrf_token_id' => 'change_password',
+        ));
+    }
+
+    // BC for SF < 3.0
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'fos_user_change_password';
+    }
+}

--- a/src/Form/Type/GroupFormType.php
+++ b/src/Form/Type/GroupFormType.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class GroupFormType extends AbstractType
+{
+    /**
+     * @var string
+     */
+    private $class;
+
+    /**
+     * @param string $class The Group class name
+     */
+    public function __construct($class)
+    {
+        $this->class = $class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->add('name', null, array('label' => 'form.group_name', 'translation_domain' => 'FOSUserBundle'));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'data_class' => $this->class,
+            'csrf_token_id' => 'group',
+        ));
+    }
+
+    // BC for SF < 3.0
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'fos_user_group';
+    }
+}

--- a/src/Form/Type/ProfileFormType.php
+++ b/src/Form/Type/ProfileFormType.php
@@ -1,0 +1,108 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Security\Core\Validator\Constraints\UserPassword;
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+class ProfileFormType extends AbstractType
+{
+    /**
+     * @var string
+     */
+    private $class;
+
+    /**
+     * @param string $class The User class name
+     */
+    public function __construct($class)
+    {
+        $this->class = $class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $this->buildUserForm($builder, $options);
+
+        $constraintsOptions = array(
+            'message' => 'fos_user.current_password.invalid',
+        );
+
+        if (!empty($options['validation_groups'])) {
+            $constraintsOptions['groups'] = array(reset($options['validation_groups']));
+        }
+
+        $builder->add('current_password', PasswordType::class, array(
+            'label' => 'form.current_password',
+            'translation_domain' => 'FOSUserBundle',
+            'mapped' => false,
+            'constraints' => array(
+                new NotBlank(),
+                new UserPassword($constraintsOptions),
+            ),
+            'attr' => array(
+                'autocomplete' => 'current-password',
+            ),
+        ));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'data_class' => $this->class,
+            'csrf_token_id' => 'profile',
+        ));
+    }
+
+    // BC for SF < 3.0
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'fos_user_profile';
+    }
+
+    /**
+     * Builds the embedded form representing the user.
+     *
+     * @param FormBuilderInterface $builder
+     * @param array                $options
+     */
+    protected function buildUserForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('username', null, array('label' => 'form.username', 'translation_domain' => 'FOSUserBundle'))
+            ->add('email', EmailType::class, array('label' => 'form.email', 'translation_domain' => 'FOSUserBundle'))
+        ;
+    }
+}

--- a/src/Form/Type/RegistrationFormType.php
+++ b/src/Form/Type/RegistrationFormType.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class RegistrationFormType extends AbstractType
+{
+    /**
+     * @var string
+     */
+    private $class;
+
+    /**
+     * @param string $class The User class name
+     */
+    public function __construct($class)
+    {
+        $this->class = $class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('email', EmailType::class, array('label' => 'form.email', 'translation_domain' => 'FOSUserBundle'))
+            ->add('username', null, array('label' => 'form.username', 'translation_domain' => 'FOSUserBundle'))
+            ->add('plainPassword', RepeatedType::class, array(
+                'type' => PasswordType::class,
+                'options' => array(
+                    'translation_domain' => 'FOSUserBundle',
+                    'attr' => array(
+                        'autocomplete' => 'new-password',
+                    ),
+                ),
+                'first_options' => array('label' => 'form.password'),
+                'second_options' => array('label' => 'form.password_confirmation'),
+                'invalid_message' => 'fos_user.password.mismatch',
+            ))
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'data_class' => $this->class,
+            'csrf_token_id' => 'registration',
+        ));
+    }
+
+    // BC for SF < 3.0
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'fos_user_registration';
+    }
+}

--- a/src/Form/Type/ResettingFormType.php
+++ b/src/Form/Type/ResettingFormType.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class ResettingFormType extends AbstractType
+{
+    /**
+     * @var string
+     */
+    private $class;
+
+    /**
+     * @param string $class The User class name
+     */
+    public function __construct($class)
+    {
+        $this->class = $class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->add('plainPassword', RepeatedType::class, array(
+            'type' => PasswordType::class,
+            'options' => array(
+                'translation_domain' => 'FOSUserBundle',
+                'attr' => array(
+                    'autocomplete' => 'new-password',
+                ),
+            ),
+            'first_options' => array('label' => 'form.new_password'),
+            'second_options' => array('label' => 'form.new_password_confirmation'),
+            'invalid_message' => 'fos_user.password.mismatch',
+        ));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'data_class' => $this->class,
+            'csrf_token_id' => 'resetting',
+        ));
+    }
+
+    // BC for SF < 3.0
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'fos_user_resetting';
+    }
+}

--- a/src/Form/Type/UsernameFormType.php
+++ b/src/Form/Type/UsernameFormType.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Form\Type;
+
+use Sonata\UserBundle\Form\DataTransformer\UserToUsernameTransformer;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+/**
+ * Form type for representing a UserInterface instance by its username string.
+ *
+ * @author Thibault Duplessis <thibault.duplessis@gmail.com>
+ */
+class UsernameFormType extends AbstractType
+{
+    /**
+     * @var UserToUsernameTransformer
+     */
+    protected $usernameTransformer;
+
+    /**
+     * Constructor.
+     *
+     * @param UserToUsernameTransformer $usernameTransformer
+     */
+    public function __construct(UserToUsernameTransformer $usernameTransformer)
+    {
+        $this->usernameTransformer = $usernameTransformer;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->addModelTransformer($this->usernameTransformer);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getParent()
+    {
+        return TextType::class;
+    }
+
+    // BC for SF < 3.0
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'fos_user_username';
+    }
+}

--- a/src/GoogleAuthenticator/Helper.php
+++ b/src/GoogleAuthenticator/Helper.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\UserBundle\GoogleAuthenticator;
 
-use Sonata\GoogleAuthenticator\GoogleAuthenticator as BaseGoogleAuthenticator;
+use Google\Authenticator\GoogleAuthenticator as BaseGoogleAuthenticator;
 use Sonata\UserBundle\Model\UserInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;

--- a/src/Mailer/FOSMailer.php
+++ b/src/Mailer/FOSMailer.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Mailer;
+
+use Sonata\UserBundle\Model\FOSUserInterface;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+/**
+ * @author Thibault Duplessis <thibault.duplessis@gmail.com>
+ */
+class Mailer implements MailerInterface
+{
+    /**
+     * @var \Swift_Mailer
+     */
+    protected $mailer;
+
+    /**
+     * @var UrlGeneratorInterface
+     */
+    protected $router;
+
+    /**
+     * @var EngineInterface
+     */
+    protected $templating;
+
+    /**
+     * @var array
+     */
+    protected $parameters;
+
+    /**
+     * Mailer constructor.
+     *
+     * @param \Swift_Mailer         $mailer
+     * @param UrlGeneratorInterface $router
+     * @param EngineInterface       $templating
+     * @param array                 $parameters
+     */
+    public function __construct($mailer, UrlGeneratorInterface  $router, EngineInterface $templating, array $parameters)
+    {
+        $this->mailer = $mailer;
+        $this->router = $router;
+        $this->templating = $templating;
+        $this->parameters = $parameters;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function sendConfirmationEmailMessage(FOSUserInterface $user)
+    {
+        $template = $this->parameters['confirmation.template'];
+        $url = $this->router->generate('fos_user_registration_confirm', array('token' => $user->getConfirmationToken()), UrlGeneratorInterface::ABSOLUTE_URL);
+        $rendered = $this->templating->render($template, array(
+            'user' => $user,
+            'confirmationUrl' => $url,
+        ));
+        $this->sendEmailMessage($rendered, $this->parameters['from_email']['confirmation'], (string) $user->getEmail());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function sendResettingEmailMessage(FOSUserInterface $user)
+    {
+        $template = $this->parameters['resetting.template'];
+        $url = $this->router->generate('fos_user_resetting_reset', array('token' => $user->getConfirmationToken()), UrlGeneratorInterface::ABSOLUTE_URL);
+        $rendered = $this->templating->render($template, array(
+            'user' => $user,
+            'confirmationUrl' => $url,
+        ));
+        $this->sendEmailMessage($rendered, $this->parameters['from_email']['resetting'], (string) $user->getEmail());
+    }
+
+    /**
+     * @param string       $renderedTemplate
+     * @param array|string $fromEmail
+     * @param array|string $toEmail
+     */
+    protected function sendEmailMessage($renderedTemplate, $fromEmail, $toEmail)
+    {
+        // Render the email, use the first line as the subject, and the rest as the body
+        $renderedLines = explode("\n", trim($renderedTemplate));
+        $subject = array_shift($renderedLines);
+        $body = implode("\n", $renderedLines);
+
+        $message = (new \Swift_Message())
+            ->setSubject($subject)
+            ->setFrom($fromEmail)
+            ->setTo($toEmail)
+            ->setBody($body);
+
+        $this->mailer->send($message);
+    }
+}

--- a/src/Mailer/Mailer.php
+++ b/src/Mailer/Mailer.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Sonata\UserBundle\Mailer;
 
-use FOS\UserBundle\Mailer\MailerInterface;
-use FOS\UserBundle\Model\UserInterface;
+use Sonata\UserBundle\Mailer\MailerInterface;
+use Sonata\UserBundle\Model\FOSUserInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Twig\Environment;
 
@@ -54,7 +54,7 @@ final class Mailer implements MailerInterface
         $this->emailTemplate = $emailTemplate;
     }
 
-    public function sendResettingEmailMessage(UserInterface $user): void
+    public function sendResettingEmailMessage(FOSUserInterface $user): void
     {
         $url = $this->urlGenerator->generate('sonata_user_admin_resetting_reset', [
             'token' => $user->getConfirmationToken(),
@@ -78,7 +78,7 @@ final class Mailer implements MailerInterface
         $this->mailer->send($message);
     }
 
-    public function sendConfirmationEmailMessage(UserInterface $user): void
+    public function sendConfirmationEmailMessage(FOSUserInterface $user): void
     {
         throw new \LogicException('This method is not implemented.');
     }

--- a/src/Mailer/MailerInterface.php
+++ b/src/Mailer/MailerInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Mailer;
+
+use Sonata\UserBundle\Model\FOSUserInterface;
+
+/**
+ * @author Thibault Duplessis <thibault.duplessis@gmail.com>
+ */
+interface MailerInterface
+{
+    /**
+     * Send an email to a user to confirm the account creation.
+     *
+     * @param FOSUserInterface $user
+     */
+    public function sendConfirmationEmailMessage(FOSUserInterface $user);
+
+    /**
+     * Send an email to a user to confirm the password reset.
+     *
+     * @param FOSUserInterface $user
+     */
+    public function sendResettingEmailMessage(FOSUserInterface $user);
+}

--- a/src/Mailer/NoopMailer.php
+++ b/src/Mailer/NoopMailer.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Mailer;
+
+use Sonata\UserBundle\Model\FOSUserInterface;
+
+/**
+ * This mailer does nothing.
+ * It is used when the 'email' configuration is not set,
+ * and allows to use this bundle without swiftmailer.
+ *
+ * @author Thibault Duplessis <thibault.duplessis@gmail.com>
+ */
+class NoopMailer implements MailerInterface
+{
+    /**
+     * @param FOSUserInterface $user
+     */
+    public function sendConfirmationEmailMessage(FOSUserInterface $user)
+    {
+        // nothing happens.
+    }
+
+    /**
+     * @param FOSUserInterface $user
+     */
+    public function sendResettingEmailMessage(FOSUserInterface $user)
+    {
+        // nothing happens.
+    }
+}

--- a/src/Mailer/TwigSwiftMailer.php
+++ b/src/Mailer/TwigSwiftMailer.php
@@ -1,0 +1,122 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Mailer;
+
+use Sonata\UserBundle\Model\FOSUserInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+/**
+ * @author Christophe Coevoet <stof@notk.org>
+ */
+class TwigSwiftMailer implements MailerInterface
+{
+    /**
+     * @var \Swift_Mailer
+     */
+    protected $mailer;
+
+    /**
+     * @var UrlGeneratorInterface
+     */
+    protected $router;
+
+    /**
+     * @var \Twig_Environment
+     */
+    protected $twig;
+
+    /**
+     * @var array
+     */
+    protected $parameters;
+
+    /**
+     * TwigSwiftMailer constructor.
+     *
+     * @param \Swift_Mailer         $mailer
+     * @param UrlGeneratorInterface $router
+     * @param \Twig_Environment     $twig
+     * @param array                 $parameters
+     */
+    public function __construct(\Swift_Mailer $mailer, UrlGeneratorInterface $router, \Twig_Environment $twig, array $parameters)
+    {
+        $this->mailer = $mailer;
+        $this->router = $router;
+        $this->twig = $twig;
+        $this->parameters = $parameters;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function sendConfirmationEmailMessage(FOSUserInterface $user)
+    {
+        $template = $this->parameters['template']['confirmation'];
+        $url = $this->router->generate('fos_user_registration_confirm', array('token' => $user->getConfirmationToken()), UrlGeneratorInterface::ABSOLUTE_URL);
+
+        $context = array(
+            'user' => $user,
+            'confirmationUrl' => $url,
+        );
+
+        $this->sendMessage($template, $context, $this->parameters['from_email']['confirmation'], (string) $user->getEmail());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function sendResettingEmailMessage(FOSUserInterface $user)
+    {
+        $template = $this->parameters['template']['resetting'];
+        $url = $this->router->generate('fos_user_resetting_reset', array('token' => $user->getConfirmationToken()), UrlGeneratorInterface::ABSOLUTE_URL);
+
+        $context = array(
+            'user' => $user,
+            'confirmationUrl' => $url,
+        );
+
+        $this->sendMessage($template, $context, $this->parameters['from_email']['resetting'], (string) $user->getEmail());
+    }
+
+    /**
+     * @param string $templateName
+     * @param array  $context
+     * @param array  $fromEmail
+     * @param string $toEmail
+     */
+    protected function sendMessage($templateName, $context, $fromEmail, $toEmail)
+    {
+        $template = $this->twig->load($templateName);
+        $subject = $template->renderBlock('subject', $context);
+        $textBody = $template->renderBlock('body_text', $context);
+
+        $htmlBody = '';
+
+        if ($template->hasBlock('body_html', $context)) {
+            $htmlBody = $template->renderBlock('body_html', $context);
+        }
+
+        $message = (new \Swift_Message())
+            ->setSubject($subject)
+            ->setFrom($fromEmail)
+            ->setTo($toEmail);
+
+        if (!empty($htmlBody)) {
+            $message->setBody($htmlBody, 'text/html')
+                ->addPart($textBody, 'text/plain');
+        } else {
+            $message->setBody($textBody);
+        }
+
+        $this->mailer->send($message);
+    }
+}

--- a/src/Model/FOSGroupManagerInterface.php
+++ b/src/Model/FOSGroupManagerInterface.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Model;
+
+/**
+ * Interface to be implemented by group managers. This adds an additional level
+ * of abstraction between your application, and the actual repository.
+ *
+ * All changes to groups should happen through this interface.
+ *
+ * @author Christophe Coevoet <stof@notk.org>
+ */
+interface FOSGroupManagerInterface
+{
+    /**
+     * Returns an empty group instance.
+     *
+     * @param string $name
+     *
+     * @return GroupInterface
+     */
+    public function createGroup($name);
+
+    /**
+     * Deletes a group.
+     *
+     * @param GroupInterface $group
+     */
+    public function deleteGroup(GroupInterface $group);
+
+    /**
+     * Finds one group by the given criteria.
+     *
+     * @param array $criteria
+     *
+     * @return GroupInterface
+     */
+    public function findGroupBy(array $criteria);
+
+    /**
+     * Finds a group by name.
+     *
+     * @param string $name
+     *
+     * @return GroupInterface
+     */
+    public function findGroupByName($name);
+
+    /**
+     * Returns a collection with all group instances.
+     *
+     * @return \Traversable
+     */
+    public function findGroups();
+
+    /**
+     * Returns the group's fully qualified class name.
+     *
+     * @return string
+     */
+    public function getClass();
+
+    /**
+     * Updates a group.
+     *
+     * @param GroupInterface $group
+     */
+    public function updateGroup(GroupInterface $group);
+}

--- a/src/Model/FOSUser.php
+++ b/src/Model/FOSUser.php
@@ -1,0 +1,557 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Model;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+
+/**
+ * Storage agnostic user object.
+ *
+ * @author Thibault Duplessis <thibault.duplessis@gmail.com>
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ */
+abstract class FOSUser implements FOSUserInterface, GroupableInterface
+{
+    /**
+     * @var mixed
+     */
+    protected $id;
+
+    /**
+     * @var string
+     */
+    protected $username;
+
+    /**
+     * @var string
+     */
+    protected $usernameCanonical;
+
+    /**
+     * @var string
+     */
+    protected $email;
+
+    /**
+     * @var string
+     */
+    protected $emailCanonical;
+
+    /**
+     * @var bool
+     */
+    protected $enabled;
+
+    /**
+     * The salt to use for hashing.
+     *
+     * @var string
+     */
+    protected $salt;
+
+    /**
+     * Encrypted password. Must be persisted.
+     *
+     * @var string
+     */
+    protected $password;
+
+    /**
+     * Plain password. Used for model validation. Must not be persisted.
+     *
+     * @var string
+     */
+    protected $plainPassword;
+
+    /**
+     * @var \DateTime|null
+     */
+    protected $lastLogin;
+
+    /**
+     * Random string sent to the user email address in order to verify it.
+     *
+     * @var string|null
+     */
+    protected $confirmationToken;
+
+    /**
+     * @var \DateTime|null
+     */
+    protected $passwordRequestedAt;
+
+    /**
+     * @var GroupInterface[]|Collection
+     */
+    protected $groups;
+
+    /**
+     * @var array
+     */
+    protected $roles;
+
+    /**
+     * User constructor.
+     */
+    public function __construct()
+    {
+        $this->enabled = false;
+        $this->roles = array();
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        return (string) $this->getUsername();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addRole($role)
+    {
+        $role = strtoupper($role);
+        if ($role === static::ROLE_DEFAULT) {
+            return $this;
+        }
+
+        if (!in_array($role, $this->roles, true)) {
+            $this->roles[] = $role;
+        }
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function serialize()
+    {
+        return serialize(array(
+            $this->password,
+            $this->salt,
+            $this->usernameCanonical,
+            $this->username,
+            $this->enabled,
+            $this->id,
+            $this->email,
+            $this->emailCanonical,
+        ));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function unserialize($serialized)
+    {
+        $data = unserialize($serialized);
+
+        if (13 === count($data)) {
+            // Unserializing a User object from 1.3.x
+            unset($data[4], $data[5], $data[6], $data[9], $data[10]);
+            $data = array_values($data);
+        } elseif (11 === count($data)) {
+            // Unserializing a User from a dev version somewhere between 2.0-alpha3 and 2.0-beta1
+            unset($data[4], $data[7], $data[8]);
+            $data = array_values($data);
+        }
+
+        list(
+            $this->password,
+            $this->salt,
+            $this->usernameCanonical,
+            $this->username,
+            $this->enabled,
+            $this->id,
+            $this->email,
+            $this->emailCanonical
+        ) = $data;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function eraseCredentials()
+    {
+        $this->plainPassword = null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getUsername()
+    {
+        return $this->username;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getUsernameCanonical()
+    {
+        return $this->usernameCanonical;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSalt()
+    {
+        return $this->salt;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getEmail()
+    {
+        return $this->email;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getEmailCanonical()
+    {
+        return $this->emailCanonical;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPassword()
+    {
+        return $this->password;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPlainPassword()
+    {
+        return $this->plainPassword;
+    }
+
+    /**
+     * Gets the last login time.
+     *
+     * @return \DateTime|null
+     */
+    public function getLastLogin()
+    {
+        return $this->lastLogin;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfirmationToken()
+    {
+        return $this->confirmationToken;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRoles()
+    {
+        $roles = $this->roles;
+
+        foreach ($this->getGroups() as $group) {
+            $roles = array_merge($roles, $group->getRoles());
+        }
+
+        // we need to make sure to have at least one role
+        $roles[] = static::ROLE_DEFAULT;
+
+        return array_unique($roles);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasRole($role)
+    {
+        return in_array(strtoupper($role), $this->getRoles(), true);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isAccountNonExpired()
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isAccountNonLocked()
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isCredentialsNonExpired()
+    {
+        return true;
+    }
+
+    public function isEnabled()
+    {
+        return $this->enabled;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isSuperAdmin()
+    {
+        return $this->hasRole(static::ROLE_SUPER_ADMIN);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function removeRole($role)
+    {
+        if (false !== $key = array_search(strtoupper($role), $this->roles, true)) {
+            unset($this->roles[$key]);
+            $this->roles = array_values($this->roles);
+        }
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUsername($username)
+    {
+        $this->username = $username;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUsernameCanonical($usernameCanonical)
+    {
+        $this->usernameCanonical = $usernameCanonical;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setSalt($salt)
+    {
+        $this->salt = $salt;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setEmail($email)
+    {
+        $this->email = $email;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setEmailCanonical($emailCanonical)
+    {
+        $this->emailCanonical = $emailCanonical;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setEnabled($boolean)
+    {
+        $this->enabled = (bool) $boolean;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setPassword($password)
+    {
+        $this->password = $password;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setSuperAdmin($boolean)
+    {
+        if (true === $boolean) {
+            $this->addRole(static::ROLE_SUPER_ADMIN);
+        } else {
+            $this->removeRole(static::ROLE_SUPER_ADMIN);
+        }
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setPlainPassword($password)
+    {
+        $this->plainPassword = $password;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setLastLogin(\DateTime $time = null)
+    {
+        $this->lastLogin = $time;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setConfirmationToken($confirmationToken)
+    {
+        $this->confirmationToken = $confirmationToken;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setPasswordRequestedAt(\DateTime $date = null)
+    {
+        $this->passwordRequestedAt = $date;
+
+        return $this;
+    }
+
+    /**
+     * Gets the timestamp that the user requested a password reset.
+     *
+     * @return null|\DateTime
+     */
+    public function getPasswordRequestedAt()
+    {
+        return $this->passwordRequestedAt;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isPasswordRequestNonExpired($ttl)
+    {
+        return $this->getPasswordRequestedAt() instanceof \DateTime &&
+               $this->getPasswordRequestedAt()->getTimestamp() + $ttl > time();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setRoles(array $roles)
+    {
+        $this->roles = array();
+
+        foreach ($roles as $role) {
+            $this->addRole($role);
+        }
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getGroups()
+    {
+        return $this->groups ?: $this->groups = new ArrayCollection();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getGroupNames()
+    {
+        $names = array();
+        foreach ($this->getGroups() as $group) {
+            $names[] = $group->getName();
+        }
+
+        return $names;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasGroup($name)
+    {
+        return in_array($name, $this->getGroupNames());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addGroup(GroupInterface $group)
+    {
+        if (!$this->getGroups()->contains($group)) {
+            $this->getGroups()->add($group);
+        }
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function removeGroup(GroupInterface $group)
+    {
+        if ($this->getGroups()->contains($group)) {
+            $this->getGroups()->removeElement($group);
+        }
+
+        return $this;
+    }
+}

--- a/src/Model/FOSUserInterface.php
+++ b/src/Model/FOSUserInterface.php
@@ -1,0 +1,230 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Model;
+
+use Symfony\Component\Security\Core\User\AdvancedUserInterface;
+
+/**
+ * @author Thibault Duplessis <thibault.duplessis@gmail.com>
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ */
+interface FOSUserInterface extends AdvancedUserInterface, \Serializable
+{
+    const ROLE_DEFAULT = 'ROLE_USER';
+
+    const ROLE_SUPER_ADMIN = 'ROLE_SUPER_ADMIN';
+
+    /**
+     * Returns the user unique id.
+     *
+     * @return mixed
+     */
+    public function getId();
+
+    /**
+     * Sets the username.
+     *
+     * @param string $username
+     *
+     * @return static
+     */
+    public function setUsername($username);
+
+    /**
+     * Gets the canonical username in search and sort queries.
+     *
+     * @return string
+     */
+    public function getUsernameCanonical();
+
+    /**
+     * Sets the canonical username.
+     *
+     * @param string $usernameCanonical
+     *
+     * @return static
+     */
+    public function setUsernameCanonical($usernameCanonical);
+
+    /**
+     * @param string|null $salt
+     *
+     * @return static
+     */
+    public function setSalt($salt);
+
+    /**
+     * Gets email.
+     *
+     * @return string
+     */
+    public function getEmail();
+
+    /**
+     * Sets the email.
+     *
+     * @param string $email
+     *
+     * @return static
+     */
+    public function setEmail($email);
+
+    /**
+     * Gets the canonical email in search and sort queries.
+     *
+     * @return string
+     */
+    public function getEmailCanonical();
+
+    /**
+     * Sets the canonical email.
+     *
+     * @param string $emailCanonical
+     *
+     * @return static
+     */
+    public function setEmailCanonical($emailCanonical);
+
+    /**
+     * Gets the plain password.
+     *
+     * @return string
+     */
+    public function getPlainPassword();
+
+    /**
+     * Sets the plain password.
+     *
+     * @param string $password
+     *
+     * @return static
+     */
+    public function setPlainPassword($password);
+
+    /**
+     * Sets the hashed password.
+     *
+     * @param string $password
+     *
+     * @return static
+     */
+    public function setPassword($password);
+
+    /**
+     * Tells if the the given user has the super admin role.
+     *
+     * @return bool
+     */
+    public function isSuperAdmin();
+
+    /**
+     * @param bool $boolean
+     *
+     * @return static
+     */
+    public function setEnabled($boolean);
+
+    /**
+     * Sets the super admin status.
+     *
+     * @param bool $boolean
+     *
+     * @return static
+     */
+    public function setSuperAdmin($boolean);
+
+    /**
+     * Gets the confirmation token.
+     *
+     * @return string|null
+     */
+    public function getConfirmationToken();
+
+    /**
+     * Sets the confirmation token.
+     *
+     * @param string|null $confirmationToken
+     *
+     * @return static
+     */
+    public function setConfirmationToken($confirmationToken);
+
+    /**
+     * Sets the timestamp that the user requested a password reset.
+     *
+     * @param null|\DateTime $date
+     *
+     * @return static
+     */
+    public function setPasswordRequestedAt(\DateTime $date = null);
+
+    /**
+     * Checks whether the password reset request has expired.
+     *
+     * @param int $ttl Requests older than this many seconds will be considered expired
+     *
+     * @return bool
+     */
+    public function isPasswordRequestNonExpired($ttl);
+
+    /**
+     * Sets the last login time.
+     *
+     * @param \DateTime|null $time
+     *
+     * @return static
+     */
+    public function setLastLogin(\DateTime $time = null);
+
+    /**
+     * Never use this to check if this user has access to anything!
+     *
+     * Use the AuthorizationChecker, or an implementation of AccessDecisionManager
+     * instead, e.g.
+     *
+     *         $authorizationChecker->isGranted('ROLE_USER');
+     *
+     * @param string $role
+     *
+     * @return bool
+     */
+    public function hasRole($role);
+
+    /**
+     * Sets the roles of the user.
+     *
+     * This overwrites any previous roles.
+     *
+     * @param array $roles
+     *
+     * @return static
+     */
+    public function setRoles(array $roles);
+
+    /**
+     * Adds a role to the user.
+     *
+     * @param string $role
+     *
+     * @return static
+     */
+    public function addRole($role);
+
+    /**
+     * Removes a role to the user.
+     *
+     * @param string $role
+     *
+     * @return static
+     */
+    public function removeRole($role);
+}

--- a/src/Model/FOSUserManagerInterface.php
+++ b/src/Model/FOSUserManagerInterface.php
@@ -1,0 +1,129 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Model;
+
+/**
+ * Interface to be implemented by user managers. This adds an additional level
+ * of abstraction between your application, and the actual repository.
+ *
+ * All changes to users should happen through this interface.
+ *
+ * The class also contains ACL annotations which will only work if you have the
+ * SecurityExtraBundle installed, otherwise they will simply be ignored.
+ *
+ * @author Gordon Franke <info@nevalon.de>
+ * @author Thibault Duplessis <thibault.duplessis@gmail.com>
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ */
+interface FOSUserManagerInterface
+{
+    /**
+     * Creates an empty user instance.
+     *
+     * @return UserInterface
+     */
+    public function createUser();
+
+    /**
+     * Deletes a user.
+     *
+     * @param FOSUserInterface $user
+     */
+    public function deleteUser(FOSUserInterface $user);
+
+    /**
+     * Finds one user by the given criteria.
+     *
+     * @param array $criteria
+     *
+     * @return UserInterface|null
+     */
+    public function findUserBy(array $criteria);
+
+    /**
+     * Find a user by its username.
+     *
+     * @param string $username
+     *
+     * @return UserInterface|null
+     */
+    public function findUserByUsername($username);
+
+    /**
+     * Finds a user by its email.
+     *
+     * @param string $email
+     *
+     * @return UserInterface|null
+     */
+    public function findUserByEmail($email);
+
+    /**
+     * Finds a user by its username or email.
+     *
+     * @param string $usernameOrEmail
+     *
+     * @return UserInterface|null
+     */
+    public function findUserByUsernameOrEmail($usernameOrEmail);
+
+    /**
+     * Finds a user by its confirmationToken.
+     *
+     * @param string $token
+     *
+     * @return UserInterface|null
+     */
+    public function findUserByConfirmationToken($token);
+
+    /**
+     * Returns a collection with all user instances.
+     *
+     * @return \Traversable
+     */
+    public function findUsers();
+
+    /**
+     * Returns the user's fully qualified class name.
+     *
+     * @return string
+     */
+    public function getClass();
+
+    /**
+     * Reloads a user.
+     *
+     * @param FOSUserInterface $user
+     */
+    public function reloadUser(FOSUserInterface $user);
+
+    /**
+     * Updates a user.
+     *
+     * @param FOSUserInterface $user
+     */
+    public function updateUser(FOSUserInterface $user);
+
+    /**
+     * Updates the canonical username and email fields for a user.
+     *
+     * @param FOSUserInterface $user
+     */
+    public function updateCanonicalFields(FOSUserInterface $user);
+
+    /**
+     * Updates a user password if a plain password is set.
+     *
+     * @param FOSUserInterface $user
+     */
+    public function updatePassword(FOSUserInterface $user);
+}

--- a/src/Model/Group.php
+++ b/src/Model/Group.php
@@ -1,0 +1,122 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Model;
+
+/**
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ */
+abstract class Group implements GroupInterface
+{
+    /**
+     * @var mixed
+     */
+    protected $id;
+
+    /**
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @var array
+     */
+    protected $roles;
+
+    /**
+     * Group constructor.
+     *
+     * @param string $name
+     * @param array  $roles
+     */
+    public function __construct($name, $roles = array())
+    {
+        $this->name = $name;
+        $this->roles = $roles;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addRole($role)
+    {
+        if (!$this->hasRole($role)) {
+            $this->roles[] = strtoupper($role);
+        }
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasRole($role)
+    {
+        return in_array(strtoupper($role), $this->roles, true);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRoles()
+    {
+        return $this->roles;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function removeRole($role)
+    {
+        if (false !== $key = array_search(strtoupper($role), $this->roles, true)) {
+            unset($this->roles[$key]);
+            $this->roles = array_values($this->roles);
+        }
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setRoles(array $roles)
+    {
+        $this->roles = $roles;
+
+        return $this;
+    }
+}

--- a/src/Model/GroupInterface.php
+++ b/src/Model/GroupInterface.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Model;
+
+/**
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ * @author Christophe Coevoet <stof@notk.org>
+ */
+interface GroupInterface
+{
+    /**
+     * @param string $role
+     *
+     * @return static
+     */
+    public function addRole($role);
+
+    /**
+     * @return int
+     */
+    public function getId();
+
+    /**
+     * @return string
+     */
+    public function getName();
+
+    /**
+     * @param string $role
+     *
+     * @return bool
+     */
+    public function hasRole($role);
+
+    /**
+     * @return array
+     */
+    public function getRoles();
+
+    /**
+     * @param string $role
+     *
+     * @return static
+     */
+    public function removeRole($role);
+
+    /**
+     * @param string $name
+     *
+     * @return static
+     */
+    public function setName($name);
+
+    /**
+     * @param array $roles
+     *
+     * @return static
+     */
+    public function setRoles(array $roles);
+}

--- a/src/Model/GroupManager.php
+++ b/src/Model/GroupManager.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Model;
+
+/**
+ * Abstract Group Manager implementation which can be used as base class for your
+ * concrete manager.
+ *
+ * @author Christophe Coevoet <stof@notk.org>
+ */
+abstract class GroupManager implements FOSGroupManagerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function createGroup($name)
+    {
+        $class = $this->getClass();
+
+        return new $class($name);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function findGroupByName($name)
+    {
+        return $this->findGroupBy(array('name' => $name));
+    }
+}

--- a/src/Model/GroupManagerInterface.php
+++ b/src/Model/GroupManagerInterface.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Sonata\UserBundle\Model;
 
-use FOS\UserBundle\Model\GroupInterface;
-use FOS\UserBundle\Model\GroupManagerInterface as BaseInterface;
+use Sonata\UserBundle\Model\GroupInterface;
+use Sonata\UserBundle\Model\FOSGroupManagerInterface as BaseInterface;
 use Sonata\CoreBundle\Model\PageableManagerInterface;
 
 /**

--- a/src/Model/GroupableInterface.php
+++ b/src/Model/GroupableInterface.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Model;
+
+/**
+ * @author Thibault Duplessis <thibault.duplessis@gmail.com>
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ * @author Christophe Coevoet <stof@notk.org>
+ */
+interface GroupableInterface
+{
+    /**
+     * Gets the groups granted to the user.
+     *
+     * @return \Traversable
+     */
+    public function getGroups();
+
+    /**
+     * Gets the name of the groups which includes the user.
+     *
+     * @return array
+     */
+    public function getGroupNames();
+
+    /**
+     * Indicates whether the user belongs to the specified group or not.
+     *
+     * @param string $name Name of the group
+     *
+     * @return bool
+     */
+    public function hasGroup($name);
+
+    /**
+     * Add a group to the user groups.
+     *
+     * @param GroupInterface $group
+     *
+     * @return static
+     */
+    public function addGroup(GroupInterface $group);
+
+    /**
+     * Remove a group from the user groups.
+     *
+     * @param GroupInterface $group
+     *
+     * @return static
+     */
+    public function removeGroup(GroupInterface $group);
+}

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\UserBundle\Model;
 
-use FOS\UserBundle\Model\User as AbstractedUser;
+use Sonata\UserBundle\Model\FOSUser as AbstractedUser;
 
 /**
  * Represents a User model.

--- a/src/Model/UserInterface.php
+++ b/src/Model/UserInterface.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\UserBundle\Model;
 
-interface UserInterface extends \FOS\UserBundle\Model\UserInterface
+interface UserInterface extends \Sonata\UserBundle\Model\FOSUserInterface
 {
     public const GENDER_FEMALE = 'f';
     public const GENDER_MALE = 'm';

--- a/src/Model/UserManager.php
+++ b/src/Model/UserManager.php
@@ -1,0 +1,115 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Model;
+
+use Sonata\UserBundle\Util\CanonicalFieldsUpdater;
+use Sonata\UserBundle\Util\PasswordUpdaterInterface;
+
+/**
+ * Abstract User Manager implementation which can be used as base class for your
+ * concrete manager.
+ *
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ */
+abstract class UserManager implements FOSUserManagerInterface
+{
+    private $passwordUpdater;
+    private $canonicalFieldsUpdater;
+
+    public function __construct(PasswordUpdaterInterface $passwordUpdater, CanonicalFieldsUpdater $canonicalFieldsUpdater)
+    {
+        $this->passwordUpdater = $passwordUpdater;
+        $this->canonicalFieldsUpdater = $canonicalFieldsUpdater;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createUser()
+    {
+        $class = $this->getClass();
+        $user = new $class();
+
+        return $user;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function findUserByEmail($email)
+    {
+        return $this->findUserBy(array('emailCanonical' => $this->canonicalFieldsUpdater->canonicalizeEmail($email)));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function findUserByUsername($username)
+    {
+        return $this->findUserBy(array('usernameCanonical' => $this->canonicalFieldsUpdater->canonicalizeUsername($username)));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function findUserByUsernameOrEmail($usernameOrEmail)
+    {
+        if (preg_match('/^.+\@\S+\.\S+$/', $usernameOrEmail)) {
+            $user = $this->findUserByEmail($usernameOrEmail);
+            if (null !== $user) {
+                return $user;
+            }
+        }
+
+        return $this->findUserByUsername($usernameOrEmail);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function findUserByConfirmationToken($token)
+    {
+        return $this->findUserBy(array('confirmationToken' => $token));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function updateCanonicalFields(FOSUserInterface $user)
+    {
+        $this->canonicalFieldsUpdater->updateCanonicalFields($user);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function updatePassword(FOSUserInterface $user)
+    {
+        $this->passwordUpdater->hashPassword($user);
+    }
+
+    /**
+     * @return PasswordUpdaterInterface
+     */
+    protected function getPasswordUpdater()
+    {
+        return $this->passwordUpdater;
+    }
+
+    /**
+     * @return CanonicalFieldsUpdater
+     */
+    protected function getCanonicalFieldsUpdater()
+    {
+        return $this->canonicalFieldsUpdater;
+    }
+}

--- a/src/Model/UserManagerInterface.php
+++ b/src/Model/UserManagerInterface.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\UserBundle\Model;
 
-use FOS\UserBundle\Model\UserManagerInterface as BaseInterface;
+use Sonata\UserBundle\Model\FOSUserManagerInterface as BaseInterface;
 use Sonata\CoreBundle\Model\PageableManagerInterface;
 
 /**

--- a/src/Resources/config/change_password.xml
+++ b/src/Resources/config/change_password.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="fos_user.change_password.form.factory" class="Sonata\UserBundle\Form\Factory\FormFactory">
+            <argument type="service" id="form.factory" />
+            <argument>%fos_user.change_password.form.name%</argument>
+            <argument>%fos_user.change_password.form.type%</argument>
+            <argument>%fos_user.change_password.form.validation_groups%</argument>
+        </service>
+
+        <service id="fos_user.change_password.form.type" class="Sonata\UserBundle\Form\Type\ChangePasswordFormType">
+            <tag name="form.type" alias="fos_user_change_password" />
+            <argument>%fos_user.model.user.class%</argument>
+        </service>
+
+        <service id="fos_user.change_password.controller" class="Sonata\UserBundle\Controller\ChangePasswordController" public="true">
+            <argument type="service" id="event_dispatcher" />
+            <argument type="service" id="fos_user.change_password.form.factory" />
+            <argument type="service" id="fos_user.user_manager" />
+            <call method="setContainer">
+                <argument type="service" id="service_container" />
+            </call>
+        </service>
+    </services>
+
+</container>

--- a/src/Resources/config/commands.xml
+++ b/src/Resources/config/commands.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="fos_user.command.activate_user" class="Sonata\UserBundle\Command\ActivateUserCommand">
+            <argument type="service" id="fos_user.util.user_manipulator" />
+            <tag name="console.command" command="fos:user:activate" />
+        </service>
+        <service id="fos_user.command.change_password" class="Sonata\UserBundle\Command\ChangePasswordCommand">
+            <argument type="service" id="fos_user.util.user_manipulator" />
+            <tag name="console.command" command="fos:user:change-password" />
+        </service>
+        <service id="fos_user.command.create_user" class="Sonata\UserBundle\Command\CreateUserCommand">
+            <argument type="service" id="fos_user.util.user_manipulator" />
+            <tag name="console.command" command="fos:user:create" />
+        </service>
+        <service id="fos_user.command.deactivate_user" class="Sonata\UserBundle\Command\DeactivateUserCommand">
+            <argument type="service" id="fos_user.util.user_manipulator" />
+            <tag name="console.command" command="fos:user:deactivate" />
+        </service>
+        <service id="fos_user.command.demote_user" class="Sonata\UserBundle\Command\DemoteUserCommand">
+            <argument type="service" id="fos_user.util.user_manipulator" />
+            <tag name="console.command" command="fos:user:demote" />
+        </service>
+        <service id="fos_user.command.promote_user" class="Sonata\UserBundle\Command\PromoteUserCommand">
+            <argument type="service" id="fos_user.util.user_manipulator" />
+            <tag name="console.command" command="fos:user:promote" />
+        </service>
+    </services>
+
+</container>

--- a/src/Resources/config/doctrine.xml
+++ b/src/Resources/config/doctrine.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="fos_user.user_manager.default" class="Sonata\UserBundle\Doctrine\UserManager" public="false">
+            <argument type="service" id="fos_user.util.password_updater" />
+            <argument type="service" id="fos_user.util.canonical_fields_updater" />
+            <argument type="service" id="fos_user.object_manager" />
+            <argument>%fos_user.model.user.class%</argument>
+        </service>
+
+        <!-- The factory is configured in the DI extension class to support more Symfony versions -->
+        <service id="fos_user.object_manager" class="Doctrine\Common\Persistence\ObjectManager" public="false">
+            <argument>%fos_user.model_manager_name%</argument>
+        </service>
+
+        <service id="fos_user.user_listener" class="Sonata\UserBundle\Doctrine\UserListener" public="false">
+            <argument type="service" id="fos_user.util.password_updater" />
+            <argument type="service" id="fos_user.util.canonical_fields_updater" />
+        </service>
+    </services>
+
+</container>

--- a/src/Resources/config/doctrine/BaseUser.orm.xml
+++ b/src/Resources/config/doctrine/BaseUser.orm.xml
@@ -10,7 +10,7 @@
         <field name="website" type="string" column="website" length="64" nullable="true"/>
         <field name="biography" type="string" column="biography" length="1000" nullable="true"/>
         <field name="gender" type="string" column="gender" length="1" nullable="true"/>
-        <field name="locale" type="string" column="locale" length="15" nullable="true"/>
+        <field name="locale" type="string" column="locale" length="8" nullable="true"/>
         <field name="timezone" type="string" column="timezone" length="64" nullable="true"/>
         <field name="phone" type="string" column="phone" length="64" nullable="true"/>
         <!-- social fields -->

--- a/src/Resources/config/doctrine/Group.couchdb.xml
+++ b/src/Resources/config/doctrine/Group.couchdb.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping>
+    <mapped-superclass name="Sonata\UserBundle\Model\Group" indexed="true">
+
+        <field name="name" fieldName="name" type="string" index="true" />
+        <field name="roles" fieldName="roles" type="mixed" />
+
+    </mapped-superclass>
+
+</doctrine-mapping>

--- a/src/Resources/config/doctrine/Group.mongodb.xml
+++ b/src/Resources/config/doctrine/Group.mongodb.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
+                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
+                        http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
+
+    <mapped-superclass name="Sonata\UserBundle\Model\Group" collection="fos_user_group">
+
+        <field name="name" fieldName="name" type="string" />
+
+        <field name="roles" fieldName="roles" type="collection" />
+
+        <indexes>
+            <index>
+                <key name="name" order="asc" />
+                <option name="safe" value="true" />
+                <option name="unique" value="true" />
+            </index>
+        </indexes>
+
+    </mapped-superclass>
+
+</doctrine-mongo-mapping>

--- a/src/Resources/config/doctrine/Group.orm.xml
+++ b/src/Resources/config/doctrine/Group.orm.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                  http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <mapped-superclass name="Sonata\UserBundle\Model\Group">
+
+        <field name="name" column="name" type="string" length="180" unique="true" />
+
+        <field name="roles" column="roles" type="array" />
+
+    </mapped-superclass>
+
+</doctrine-mapping>

--- a/src/Resources/config/doctrine/User.couchdb.xml
+++ b/src/Resources/config/doctrine/User.couchdb.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping>
+
+    <mapped-superclass name="Sonata\UserBundle\Model\FOSUser" indexed="true">
+
+        <field name="username" fieldName="username" type="string" index="true" />
+        <field name="usernameCanonical" fieldName="usernameCanonical" type="string" index="true" />
+        <field name="email" fieldName="email" type="string" index="true" />
+        <field name="emailCanonical" fieldName="emailCanonical" type="string" index="true" />
+        <field name="enabled" fieldName="enabled" type="mixed" />
+        <field name="salt" fieldName="salt" type="string" />
+        <field name="password" fieldName="password" type="string" />
+        <field name="lastLogin" fieldName="lastLogin" type="datetime" />
+        <field name="confirmationToken" fieldName="confirmationToken" type="string" index="true" />
+        <field name="passwordRequestedAt" fieldName="passwordRequestedAt" type="datetime" />
+        <field name="roles" fieldName="roles" type="mixed" />
+
+    </mapped-superclass>
+
+</doctrine-mapping>

--- a/src/Resources/config/doctrine/User.mongodb.xml
+++ b/src/Resources/config/doctrine/User.mongodb.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping"
+                        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                        xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping
+                        http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
+
+    <mapped-superclass name="Sonata\UserBundle\Model\FOSUser" collection="fos_user_user">
+
+        <field name="username" fieldName="username" type="string" />
+
+        <field name="usernameCanonical" fieldName="usernameCanonical" type="string" />
+
+        <field name="email" fieldName="email" type="string" />
+
+        <field name="emailCanonical" fieldName="emailCanonical" type="string" />
+
+        <field name="enabled" fieldName="enabled" type="boolean" />
+
+        <field name="salt" fieldName="salt" type="string" />
+
+        <field name="password" fieldName="password" type="string" />
+
+        <field name="lastLogin" fieldName="lastLogin" type="date" />
+
+        <field name="confirmationToken" fieldName="confirmationToken" type="string" />
+
+        <field name="passwordRequestedAt" fieldName="passwordRequestedAt" type="date" />
+
+        <field name="roles" fieldName="roles" type="collection" />
+
+        <indexes>
+            <index>
+                <key name="usernameCanonical" order="asc" />
+                <option name="safe" value="true" />
+                <option name="unique" value="true" />
+            </index>
+            <index>
+                <key name="emailCanonical" order="asc" />
+                <option name="safe" value="true" />
+                <option name="unique" value="true" />
+            </index>
+            <index>
+                <key name="confirmationToken" order="asc" />
+                <option name="safe" value="true" />
+                <option name="sparse" value="true" />
+                <option name="unique" value="true" />
+            </index>
+        </indexes>
+
+    </mapped-superclass>
+
+</doctrine-mongo-mapping>

--- a/src/Resources/config/doctrine/User.orm.xml
+++ b/src/Resources/config/doctrine/User.orm.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping
+                  http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+
+    <mapped-superclass name="Sonata\UserBundle\Model\FOSUser">
+
+        <field name="username" column="username" type="string" length="180" />
+
+        <field name="usernameCanonical" column="username_canonical" type="string" length="180" unique="true" />
+
+        <field name="email" column="email" type="string" length="180" />
+
+        <field name="emailCanonical" column="email_canonical" type="string" length="180" unique="true" />
+
+        <field name="enabled" column="enabled" type="boolean" />
+
+        <field name="salt" column="salt" type="string" nullable="true" />
+
+        <field name="password" column="password" type="string" />
+
+        <field name="lastLogin" column="last_login" type="datetime" nullable="true" />
+
+        <field name="confirmationToken" column="confirmation_token" type="string" length="180" unique="true" nullable="true" />
+
+        <field name="passwordRequestedAt" column="password_requested_at" type="datetime" nullable="true" />
+
+        <field name="roles" column="roles" type="array" />
+
+    </mapped-superclass>
+
+</doctrine-mapping>

--- a/src/Resources/config/doctrine_group.xml
+++ b/src/Resources/config/doctrine_group.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="fos_user.group_manager.class">Sonata\UserBundle\Doctrine\GroupManager</parameter>
+    </parameters>
+
+    <services>
+        <service id="fos_user.group_manager.default" class="%fos_user.group_manager.class%" public="false">
+            <argument type="service" id="fos_user.object_manager" />
+            <argument>%fos_user.model.group.class%</argument>
+        </service>
+    </services>
+
+</container>

--- a/src/Resources/config/email_confirmation.xml
+++ b/src/Resources/config/email_confirmation.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="fos_user.listener.email_confirmation" class="Sonata\UserBundle\EventListener\EmailConfirmationListener">
+            <tag name="kernel.event_subscriber" />
+            <argument type="service" id="fos_user.mailer" />
+            <argument type="service" id="fos_user.util.token_generator" />
+            <argument type="service" id="router" />
+            <argument type="service" id="session" />
+        </service>
+    </services>
+
+</container>

--- a/src/Resources/config/flash_notifications.xml
+++ b/src/Resources/config/flash_notifications.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="fos_user.listener.flash" class="Sonata\UserBundle\EventListener\FlashListener">
+            <tag name="kernel.event_subscriber" />
+            <argument type="service" id="session" />
+            <argument type="service" id="translator" />
+        </service>
+    </services>
+
+</container>

--- a/src/Resources/config/fos-mailer.xml
+++ b/src/Resources/config/fos-mailer.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="fos_user.resetting.email.template">@FOSUser/Resetting/email.txt.twig</parameter>
+        <parameter key="fos_user.registration.confirmation.template">@FOSUser/Registration/email.txt.twig</parameter>
+    </parameters>
+
+    <services>
+        <service id="fos_user.mailer.default" class="FOS\UserBundle\Mailer\Mailer" public="false">
+            <argument type="service" id="mailer" />
+            <argument type="service" id="router" />
+            <argument type="service" id="templating" />
+            <argument type="collection">
+                <argument key="confirmation.template">%fos_user.registration.confirmation.template%</argument>
+                <argument key="resetting.template">%fos_user.resetting.email.template%</argument>
+                <argument key="from_email" type="collection">
+                    <argument key="confirmation">%fos_user.registration.confirmation.from_email%</argument>
+                    <argument key="resetting">%fos_user.resetting.email.from_email%</argument>
+                </argument>
+            </argument>
+            <tag name="fos_user.requires_swift" />
+        </service>
+
+        <service id="fos_user.mailer.twig_swift" class="FOS\UserBundle\Mailer\TwigSwiftMailer" public="false">
+            <argument type="service" id="mailer" />
+            <argument type="service" id="router" />
+            <argument type="service" id="twig" />
+            <argument type="collection">
+                <argument key="template" type="collection">
+                    <argument key="confirmation">%fos_user.registration.confirmation.template%</argument>
+                    <argument key="resetting">%fos_user.resetting.email.template%</argument>
+                </argument>
+                <argument key="from_email" type="collection">
+                    <argument key="confirmation">%fos_user.registration.confirmation.from_email%</argument>
+                    <argument key="resetting">%fos_user.resetting.email.from_email%</argument>
+                </argument>
+            </argument>
+            <tag name="fos_user.requires_swift" />
+        </service>
+
+        <service id="fos_user.mailer.noop" class="FOS\UserBundle\Mailer\NoopMailer" public="false" />
+    </services>
+
+</container>

--- a/src/Resources/config/google_authenticator.xml
+++ b/src/Resources/config/google_authenticator.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="sonata.user.google.authenticator" class="Sonata\GoogleAuthenticator\GoogleAuthenticator">
+        <service id="sonata.user.google.authenticator" class="Google\Authenticator\GoogleAuthenticator">
 
         </service>
         <service id="sonata.user.google.authenticator.provider" class="Sonata\UserBundle\GoogleAuthenticator\Helper">

--- a/src/Resources/config/group.xml
+++ b/src/Resources/config/group.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="fos_user.group.form.factory" class="Sonata\UserBundle\Form\Factory\FormFactory">
+            <argument type="service" id="form.factory" />
+            <argument>%fos_user.group.form.name%</argument>
+            <argument>%fos_user.group.form.type%</argument>
+            <argument>%fos_user.group.form.validation_groups%</argument>
+        </service>
+
+        <service id="fos_user.group.form.type" class="Sonata\UserBundle\Form\Type\GroupFormType">
+            <tag name="form.type" alias="fos_user_group" />
+            <argument>%fos_user.model.group.class%</argument>
+        </service>
+
+        <service id="fos_user.group.controller" class="Sonata\UserBundle\Controller\GroupController" public="true">
+            <argument type="service" id="event_dispatcher" />
+            <argument type="service" id="fos_user.group.form.factory" />
+            <argument type="service" id="fos_user.group_manager" />
+            <call method="setContainer">
+                <argument type="service" id="service_container" />
+            </call>
+        </service>
+    </services>
+
+</container>

--- a/src/Resources/config/listeners.xml
+++ b/src/Resources/config/listeners.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="fos_user.listener.authentication" class="Sonata\UserBundle\EventListener\AuthenticationListener">
+            <tag name="kernel.event_subscriber" />
+            <argument type="service" id="fos_user.security.login_manager" />
+            <argument>%fos_user.firewall_name%</argument>
+        </service>
+    </services>
+
+</container>

--- a/src/Resources/config/profile.xml
+++ b/src/Resources/config/profile.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+
+        <service id="fos_user.profile.form.factory" class="Sonata\UserBundle\Form\Factory\FormFactory">
+            <argument type="service" id="form.factory" />
+            <argument>%fos_user.profile.form.name%</argument>
+            <argument>%fos_user.profile.form.type%</argument>
+            <argument>%fos_user.profile.form.validation_groups%</argument>
+        </service>
+
+        <service id="fos_user.profile.form.type" class="Sonata\UserBundle\Form\Type\ProfileFormType">
+            <argument>%fos_user.model.user.class%</argument>
+            <tag name="form.type" alias="fos_user_profile" />
+        </service>
+
+        <service id="fos_user.profile.controller" class="Sonata\UserBundle\Controller\ProfileController" public="true">
+            <argument type="service" id="event_dispatcher" />
+            <argument type="service" id="fos_user.profile.form.factory" />
+            <argument type="service" id="fos_user.user_manager" />
+            <call method="setContainer">
+                <argument type="service" id="service_container" />
+            </call>
+        </service>
+    </services>
+
+</container>

--- a/src/Resources/config/registration.xml
+++ b/src/Resources/config/registration.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+
+        <service id="fos_user.registration.form.factory" class="Sonata\UserBundle\Form\Factory\FormFactory">
+            <argument type="service" id="form.factory" />
+            <argument>%fos_user.registration.form.name%</argument>
+            <argument>%fos_user.registration.form.type%</argument>
+            <argument>%fos_user.registration.form.validation_groups%</argument>
+        </service>
+
+        <service id="fos_user.registration.form.type" class="Sonata\UserBundle\Form\Type\RegistrationFormType">
+            <tag name="form.type" alias="fos_user_registration" />
+            <argument>%fos_user.model.user.class%</argument>
+        </service>
+
+        <service id="fos_user.registration.controller" class="Sonata\UserBundle\Controller\RegistrationController" public="true">
+            <argument type="service" id="event_dispatcher" />
+            <argument type="service" id="fos_user.registration.form.factory" />
+            <argument type="service" id="fos_user.user_manager" />
+            <argument type="service" id="security.token_storage" />
+            <call method="setContainer">
+                <argument type="service" id="service_container" />
+            </call>
+        </service>
+    </services>
+
+</container>

--- a/src/Resources/config/resetting.xml
+++ b/src/Resources/config/resetting.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+
+        <service id="fos_user.resetting.form.factory" class="Sonata\UserBundle\Form\Factory\FormFactory">
+            <argument type="service" id="form.factory" />
+            <argument>%fos_user.resetting.form.name%</argument>
+            <argument>%fos_user.resetting.form.type%</argument>
+            <argument>%fos_user.resetting.form.validation_groups%</argument>
+        </service>
+
+        <service id="fos_user.resetting.form.type" class="Sonata\UserBundle\Form\Type\ResettingFormType">
+            <tag name="form.type" alias="fos_user_resetting" />
+            <argument>%fos_user.model.user.class%</argument>
+        </service>
+
+        <service id="fos_user.listener.resetting" class="Sonata\UserBundle\EventListener\ResettingListener">
+            <tag name="kernel.event_subscriber" />
+            <argument type="service" id="router" />
+            <argument>%fos_user.resetting.token_ttl%</argument>
+        </service>
+
+        <service id="fos_user.resetting.controller" class="Sonata\UserBundle\Controller\ResettingController" public="true">
+            <argument type="service" id="event_dispatcher" />
+            <argument type="service" id="fos_user.resetting.form.factory" />
+            <argument type="service" id="fos_user.user_manager" />
+            <argument type="service" id="fos_user.util.token_generator" />
+            <argument type="service" id="fos_user.mailer" />
+            <argument>%fos_user.resetting.retry_ttl%</argument>
+            <call method="setContainer">
+                <argument type="service" id="service_container" />
+            </call>
+        </service>
+    </services>
+
+</container>

--- a/src/Resources/config/routing/all.xml
+++ b/src/Resources/config/routing/all.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<routes xmlns="http://symfony.com/schema/routing"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
+
+    <import
+        resource="@FOSUserBundle/Resources/config/routing/security.xml" />
+    <import
+        resource="@FOSUserBundle/Resources/config/routing/profile.xml"
+        prefix="/profile" />
+    <import
+        resource="@FOSUserBundle/Resources/config/routing/registration.xml"
+        prefix="/register" />
+    <import
+        resource="@FOSUserBundle/Resources/config/routing/resetting.xml"
+        prefix="/resetting" />
+    <import
+        resource="@FOSUserBundle/Resources/config/routing/change_password.xml"
+        prefix="/profile" />
+</routes>

--- a/src/Resources/config/routing/change_password.xml
+++ b/src/Resources/config/routing/change_password.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<routes xmlns="http://symfony.com/schema/routing"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
+
+    <route id="fos_user_change_password" path="/change-password" methods="GET POST">
+        <default key="_controller">fos_user.change_password.controller:changePasswordAction</default>
+    </route>
+
+</routes>

--- a/src/Resources/config/routing/group.xml
+++ b/src/Resources/config/routing/group.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<routes xmlns="http://symfony.com/schema/routing"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
+
+    <route id="fos_user_group_list" path="/list" methods="GET">
+        <default key="_controller">fos_user.group.controller:listAction</default>
+    </route>
+
+    <route id="fos_user_group_new" path="/new" methods="GET POST">
+        <default key="_controller">fos_user.group.controller:newAction</default>
+    </route>
+
+    <route id="fos_user_group_show" path="/{groupName}" methods="GET">
+        <default key="_controller">fos_user.group.controller:showAction</default>
+    </route>
+
+    <route id="fos_user_group_edit" path="/{groupName}/edit" methods="GET POST">
+        <default key="_controller">fos_user.group.controller:editAction</default>
+    </route>
+
+    <route id="fos_user_group_delete" path="/{groupName}/delete" methods="GET">
+        <default key="_controller">fos_user.group.controller:deleteAction</default>
+    </route>
+
+</routes>

--- a/src/Resources/config/routing/profile.xml
+++ b/src/Resources/config/routing/profile.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<routes xmlns="http://symfony.com/schema/routing"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
+
+    <route id="fos_user_profile_show" path="/" methods="GET">
+        <default key="_controller">fos_user.profile.controller:showAction</default>
+    </route>
+
+    <route id="fos_user_profile_edit" path="/edit" methods="GET POST">
+        <default key="_controller">fos_user.profile.controller:editAction</default>
+    </route>
+
+</routes>

--- a/src/Resources/config/routing/registration.xml
+++ b/src/Resources/config/routing/registration.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<routes xmlns="http://symfony.com/schema/routing"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
+
+    <route id="fos_user_registration_register" path="/" methods="GET POST">
+        <default key="_controller">fos_user.registration.controller:registerAction</default>
+    </route>
+
+    <route id="fos_user_registration_check_email" path="/check-email" methods="GET">
+        <default key="_controller">fos_user.registration.controller:checkEmailAction</default>
+    </route>
+
+    <route id="fos_user_registration_confirm" path="/confirm/{token}" methods="GET">
+        <default key="_controller">fos_user.registration.controller:confirmAction</default>
+    </route>
+
+    <route id="fos_user_registration_confirmed" path="/confirmed" methods="GET">
+        <default key="_controller">fos_user.registration.controller:confirmedAction</default>
+    </route>
+
+</routes>

--- a/src/Resources/config/routing/resetting.xml
+++ b/src/Resources/config/routing/resetting.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<routes xmlns="http://symfony.com/schema/routing"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
+
+    <route id="fos_user_resetting_request" path="/request" methods="GET">
+        <default key="_controller">fos_user.resetting.controller:requestAction</default>
+    </route>
+
+    <route id="fos_user_resetting_send_email" path="/send-email" methods="POST">
+        <default key="_controller">fos_user.resetting.controller:sendEmailAction</default>
+    </route>
+
+    <route id="fos_user_resetting_check_email" path="/check-email" methods="GET">
+        <default key="_controller">fos_user.resetting.controller:checkEmailAction</default>
+    </route>
+
+    <route id="fos_user_resetting_reset" path="/reset/{token}" methods="GET POST">
+        <default key="_controller">fos_user.resetting.controller:resetAction</default>
+    </route>
+
+</routes>

--- a/src/Resources/config/routing/security.xml
+++ b/src/Resources/config/routing/security.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<routes xmlns="http://symfony.com/schema/routing"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
+
+    <route id="fos_user_security_login" path="/login" methods="GET POST">
+        <default key="_controller">fos_user.security.controller:loginAction</default>
+    </route>
+
+    <route id="fos_user_security_check" path="/login_check" methods="POST">
+        <default key="_controller">fos_user.security.controller:checkAction</default>
+    </route>
+
+    <route id="fos_user_security_logout" path="/logout" methods="GET POST">
+        <default key="_controller">fos_user.security.controller:logoutAction</default>
+    </route>
+
+</routes>

--- a/src/Resources/config/security.xml
+++ b/src/Resources/config/security.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="fos_user.security.interactive_login_listener.class">Sonata\UserBundle\EventListener\LastLoginListener</parameter>
+        <parameter key="fos_user.security.login_manager.class">Sonata\UserBundle\Security\LoginManager</parameter>
+    </parameters>
+
+    <services>
+        <service id="fos_user.security.interactive_login_listener" class="%fos_user.security.interactive_login_listener.class%">
+            <tag name="kernel.event_subscriber" />
+            <argument type="service" id="fos_user.user_manager" />
+        </service>
+
+        <service id="fos_user.security.login_manager" class="%fos_user.security.login_manager.class%">
+            <argument type="service" id="security.token_storage" />
+            <argument type="service" id="security.user_checker" />
+            <argument type="service" id="security.authentication.session_strategy" />
+            <argument type="service" id="request_stack" />
+            <argument>null</argument> <!-- remember_me service -->
+        </service>
+
+        <service id="Sonata\UserBundle\Security\LoginManagerInterface" alias="fos_user.security.login_manager" public="false" />
+
+        <service id="fos_user.user_provider.username" class="Sonata\UserBundle\Security\UserProvider" public="false">
+            <argument type="service" id="fos_user.user_manager" />
+        </service>
+
+        <service id="fos_user.user_provider.username_email" class="Sonata\UserBundle\Security\EmailUserProvider" public="false">
+            <argument type="service" id="fos_user.user_manager" />
+        </service>
+
+        <service id="fos_user.security.controller" class="Sonata\UserBundle\Controller\SecurityController" public="true">
+            <argument type="service" id="security.csrf.token_manager" on-invalid="null" />
+            <call method="setContainer">
+                <argument type="service" id="service_container" />
+            </call>
+        </service>
+    </services>
+
+</container>

--- a/src/Resources/config/serializer/FOSUserBundle/Model.Group.xml
+++ b/src/Resources/config/serializer/FOSUserBundle/Model.Group.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <serializer>
-    <class name="FOS\UserBundle\Model\Group" exclusion-policy="all" xml-root-name="group">
+    <class name="Sonata\UserBundle\Model\Group" exclusion-policy="all" xml-root-name="group">
         <property name="name" type="string" expose="true" since-version="1.0" groups="sonata_api_read,sonata_api_write,sonata_search"/>
         <property name="createdAt" type="DateTime" expose="true" since-version="1.0" groups="sonata_api_read,sonata_search"/>
         <property name="updatedAt" type="DateTime" expose="true" since-version="1.0" groups="sonata_api_read,sonata_search"/>

--- a/src/Resources/config/serializer/FOSUserBundle/Model.User.xml
+++ b/src/Resources/config/serializer/FOSUserBundle/Model.User.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <serializer>
-    <class name="FOS\UserBundle\Model\User" exclusion-policy="all" xml-root-name="user">
+    <class name="Sonata\UserBundle\Model\FOSUser" exclusion-policy="all" xml-root-name="user">
         <property name="username" type="string" expose="true" since-version="1.0" groups="sonata_api_read,sonata_api_write,sonata_search"/>
         <property name="usernameCanonical" type="string" expose="true" since-version="1.0" groups="sonata_api_read,sonata_search"/>
         <property name="email" type="string" expose="true" since-version="1.0" groups="sonata_api_read,sonata_api_write,sonata_search"/>

--- a/src/Resources/config/storage-validation/couchdb.xml
+++ b/src/Resources/config/storage-validation/couchdb.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" ?>
+<constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping
+        http://symfony.com/schema/dic/constraint-mapping/constraint-mapping-1.0.xsd">
+
+    <class name="Sonata\UserBundle\Model\FOSUser">
+        <constraint name="Doctrine\Bundle\CouchDBBundle\Validator\Constraints\UniqueEntity">
+            <option name="fields">usernameCanonical</option>
+            <option name="errorPath">username</option>
+            <option name="message">fos_user.username.already_used</option>
+            <option name="groups">
+                <value>Registration</value>
+                <value>Profile</value>
+            </option>
+        </constraint>
+
+        <constraint name="Doctrine\Bundle\CouchDBBundle\Validator\Constraints\UniqueEntity">
+            <option name="fields">emailCanonical</option>
+            <option name="errorPath">email</option>
+            <option name="message">fos_user.email.already_used</option>
+            <option name="groups">
+                <value>Registration</value>
+                <value>Profile</value>
+            </option>
+        </constraint>
+    </class>
+
+    <class name="Sonata\UserBundle\Model\Group">
+        <constraint name="Doctrine\Bundle\CouchDBBundle\Validator\Constraints\UniqueEntity">
+            <option name="fields">name</option>
+            <option name="errorPath">name</option>
+            <option name="message">fos_group.name.already_used</option>
+            <option name="groups">
+                <value>Registration</value>
+            </option>
+        </constraint>
+    </class>
+
+</constraint-mapping>

--- a/src/Resources/config/storage-validation/mongodb.xml
+++ b/src/Resources/config/storage-validation/mongodb.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" ?>
+<constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping
+        http://symfony.com/schema/dic/constraint-mapping/constraint-mapping-1.0.xsd">
+
+    <class name="Sonata\UserBundle\Model\FOSUser">
+        <constraint name="Doctrine\Bundle\MongoDBBundle\Validator\Constraints\Unique">
+            <option name="fields">usernameCanonical</option>
+            <option name="errorPath">username</option>
+            <option name="message">fos_user.username.already_used</option>
+            <option name="groups">
+                <value>Registration</value>
+                <value>Profile</value>
+            </option>
+        </constraint>
+
+        <constraint name="Doctrine\Bundle\MongoDBBundle\Validator\Constraints\Unique">
+            <option name="fields">emailCanonical</option>
+            <option name="errorPath">email</option>
+            <option name="message">fos_user.email.already_used</option>
+            <option name="groups">
+                <value>Registration</value>
+                <value>Profile</value>
+            </option>
+        </constraint>
+    </class>
+
+    <class name="Sonata\UserBundle\Model\Group">
+        <constraint name="Doctrine\Bundle\MongoDBBundle\Validator\Constraints\Unique">
+            <option name="fields">name</option>
+            <option name="errorPath">name</option>
+            <option name="message">fos_group.name.already_used</option>
+            <option name="groups">
+                <value>Registration</value>
+            </option>
+        </constraint>
+    </class>
+
+</constraint-mapping>

--- a/src/Resources/config/storage-validation/orm.xml
+++ b/src/Resources/config/storage-validation/orm.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" ?>
+<constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping
+        http://symfony.com/schema/dic/constraint-mapping/constraint-mapping-1.0.xsd">
+
+    <class name="Sonata\UserBundle\Model\FOSUser">
+        <constraint name="Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity">
+            <option name="fields">usernameCanonical</option>
+            <option name="errorPath">username</option>
+            <option name="message">fos_user.username.already_used</option>
+            <option name="groups">
+                <value>Registration</value>
+                <value>Profile</value>
+            </option>
+        </constraint>
+
+        <constraint name="Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity">
+            <option name="fields">emailCanonical</option>
+            <option name="errorPath">email</option>
+            <option name="message">fos_user.email.already_used</option>
+            <option name="groups">
+                <value>Registration</value>
+                <value>Profile</value>
+            </option>
+        </constraint>
+    </class>
+
+    <class name="Sonata\UserBundle\Model\Group">
+        <constraint name="Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity">
+            <option name="fields">name</option>
+            <option name="errorPath">name</option>
+            <option name="message">fos_group.name.already_used</option>
+            <option name="groups">
+                <value>Registration</value>
+            </option>
+        </constraint>
+    </class>
+
+</constraint-mapping>

--- a/src/Resources/config/username_form_type.xml
+++ b/src/Resources/config/username_form_type.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+
+        <service id="fos_user.username_form_type" class="Sonata\UserBundle\Form\Type\UsernameFormType">
+            <tag name="form.type" alias="fos_user_username" />
+            <argument type="service" id="fos_user.user_to_username_transformer" />
+        </service>
+
+        <service id="fos_user.user_to_username_transformer" class="Sonata\UserBundle\Form\DataTransformer\UserToUsernameTransformer" public="false">
+            <argument type="service" id="fos_user.user_manager" />
+        </service>
+
+    </services>
+
+</container>

--- a/src/Resources/config/util.xml
+++ b/src/Resources/config/util.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+
+        <service id="fos_user.util.canonicalizer.default" class="Sonata\UserBundle\Util\Canonicalizer" public="false" />
+
+        <service id="fos_user.util.user_manipulator" class="Sonata\UserBundle\Util\UserManipulator">
+            <argument type="service" id="fos_user.user_manager" />
+            <argument type="service" id="event_dispatcher" />
+            <argument type="service" id="request_stack" />
+        </service>
+
+        <service id="fos_user.util.token_generator.default" class="Sonata\UserBundle\Util\TokenGenerator" public="false" />
+
+        <service id="Sonata\UserBundle\Util\TokenGeneratorInterface" alias="fos_user.util.token_generator" public="false" />
+
+        <service id="fos_user.util.password_updater" class="Sonata\UserBundle\Util\PasswordUpdater" public="false">
+            <argument type="service" id="security.encoder_factory" />
+        </service>
+
+        <service id="Sonata\UserBundle\Util\PasswordUpdaterInterface" alias="fos_user.util.password_updater" public="false" />
+
+        <service id="fos_user.util.canonical_fields_updater" class="Sonata\UserBundle\Util\CanonicalFieldsUpdater" public="false">
+            <argument type="service" id="fos_user.util.username_canonicalizer" />
+            <argument type="service" id="fos_user.util.email_canonicalizer" />
+        </service>
+
+        <service id="Sonata\UserBundle\Util\CanonicalFieldsUpdater" alias="fos_user.util.canonical_fields_updater" public="false" />
+
+        <service id="Sonata\UserBundle\Model\FOSUserManagerInterface" alias="fos_user.user_manager" public="false" />
+    </services>
+
+</container>

--- a/src/Resources/config/validation.xml
+++ b/src/Resources/config/validation.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" ?>
+<constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping
+        http://symfony.com/schema/dic/constraint-mapping/constraint-mapping-1.0.xsd">
+
+    <class name="Sonata\UserBundle\Model\FOSUser">
+
+        <property name="username">
+            <constraint name="NotBlank">
+                <option name="message">fos_user.username.blank</option>
+                <option name="groups">
+                    <value>Registration</value>
+                    <value>Profile</value>
+                </option>
+            </constraint>
+            <constraint name="Length">
+                <option name="min">2</option>
+                <option name="minMessage">fos_user.username.short</option>
+                <option name="max">180</option>
+                <option name="maxMessage">fos_user.username.long</option>
+                <option name="groups">
+                    <value>Registration</value>
+                    <value>Profile</value>
+                </option>
+            </constraint>
+        </property>
+
+        <property name="email">
+            <constraint name="NotBlank">
+                <option name="message">fos_user.email.blank</option>
+                <option name="groups">
+                    <value>Registration</value>
+                    <value>Profile</value>
+                </option>
+            </constraint>
+            <constraint name="Length">
+                <option name="min">2</option>
+                <option name="minMessage">fos_user.email.short</option>
+                <option name="max">180</option>
+                <option name="maxMessage">fos_user.email.long</option>
+                <option name="groups">
+                    <value>Registration</value>
+                    <value>Profile</value>
+                </option>
+            </constraint>
+            <constraint name="Email">
+                <option name="message">fos_user.email.invalid</option>
+                <option name="groups">
+                    <value>Registration</value>
+                    <value>Profile</value>
+                </option>
+            </constraint>
+        </property>
+
+        <property name="plainPassword">
+            <constraint name="NotBlank">
+                <option name="message">fos_user.password.blank</option>
+                <option name="groups">
+                    <value>Registration</value>
+                    <value>ResetPassword</value>
+                    <value>ChangePassword</value>
+                </option>
+            </constraint>
+            <constraint name="Length">
+                <option name="min">2</option>
+                <option name="max">4096</option>
+                <option name="minMessage">fos_user.password.short</option>
+                <option name="groups">
+                    <value>Registration</value>
+                    <value>Profile</value>
+                    <value>ResetPassword</value>
+                    <value>ChangePassword</value>
+                </option>
+            </constraint>
+        </property>
+    </class>
+
+    <class name="Sonata\UserBundle\Model\Group">
+        <property name="name">
+            <constraint name="NotBlank">
+                <option name="message">fos_user.group.blank</option>
+                <option name="groups">Registration</option>
+            </constraint>
+            <constraint name="Length">
+                <option name="min">2</option>
+                <option name="minMessage">fos_user.group.short</option>
+                <option name="max">180</option>
+                <option name="maxMessage">fos_user.group.long</option>
+                <option name="groups">Registration</option>
+            </constraint>
+        </property>
+    </class>
+
+</constraint-mapping>

--- a/src/Resources/config/validator.xml
+++ b/src/Resources/config/validator.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="fos_user.validator.initializer" class="Sonata\UserBundle\Validator\Initializer" public="false">
+            <tag name="validator.initializer" />
+            <argument type="service" id="fos_user.util.canonical_fields_updater" />
+        </service>
+    </services>
+
+</container>

--- a/src/Resources/views/ChangePassword/change_password.html.twig
+++ b/src/Resources/views/ChangePassword/change_password.html.twig
@@ -1,0 +1,5 @@
+{% extends "@FOSUser/layout.html.twig" %}
+
+{% block fos_user_content %}
+{% include "@FOSUser/ChangePassword/change_password_content.html.twig" %}
+{% endblock fos_user_content %}

--- a/src/Resources/views/ChangePassword/change_password_content.html.twig
+++ b/src/Resources/views/ChangePassword/change_password_content.html.twig
@@ -1,0 +1,8 @@
+{% trans_default_domain 'FOSUserBundle' %}
+
+{{ form_start(form, { 'action': path('fos_user_change_password'), 'attr': { 'class': 'fos_user_change_password' } }) }}
+    {{ form_widget(form) }}
+    <div>
+        <input type="submit" value="{{ 'change_password.submit'|trans }}" />
+    </div>
+{{ form_end(form) }}

--- a/src/Resources/views/Group/edit.html.twig
+++ b/src/Resources/views/Group/edit.html.twig
@@ -1,0 +1,5 @@
+{% extends "@FOSUser/layout.html.twig" %}
+
+{% block fos_user_content %}
+{% include "@FOSUser/Group/edit_content.html.twig" %}
+{% endblock fos_user_content %}

--- a/src/Resources/views/Group/edit_content.html.twig
+++ b/src/Resources/views/Group/edit_content.html.twig
@@ -1,0 +1,8 @@
+{% trans_default_domain 'FOSUserBundle' %}
+
+{{ form_start(form, { 'action': path('fos_user_group_edit', {'groupName': group_name}), 'attr': { 'class': 'fos_user_group_edit' } }) }}
+    {{ form_widget(form) }}
+    <div>
+        <input type="submit" value="{{ 'group.edit.submit'|trans }}" />
+    </div>
+{{ form_end(form) }}

--- a/src/Resources/views/Group/list.html.twig
+++ b/src/Resources/views/Group/list.html.twig
@@ -1,0 +1,5 @@
+{% extends "@FOSUser/layout.html.twig" %}
+
+{% block fos_user_content %}
+{% include "@FOSUser/Group/list_content.html.twig" %}
+{% endblock fos_user_content %}

--- a/src/Resources/views/Group/list_content.html.twig
+++ b/src/Resources/views/Group/list_content.html.twig
@@ -1,0 +1,7 @@
+<div class="fos_user_group_list">
+    <ul>
+    {% for group in groups %}
+        <li><a href="{{ path('fos_user_group_show', {'groupName': group.getName()} ) }}">{{ group.getName() }}</a></li>
+    {% endfor %}
+    </ul>
+</div>

--- a/src/Resources/views/Group/new.html.twig
+++ b/src/Resources/views/Group/new.html.twig
@@ -1,0 +1,5 @@
+{% extends "@FOSUser/layout.html.twig" %}
+
+{% block fos_user_content %}
+{% include "@FOSUser/Group/new_content.html.twig" %}
+{% endblock fos_user_content %}

--- a/src/Resources/views/Group/new_content.html.twig
+++ b/src/Resources/views/Group/new_content.html.twig
@@ -1,0 +1,8 @@
+{% trans_default_domain 'FOSUserBundle' %}
+
+{{ form_start(form, { 'action': path('fos_user_group_new'), 'attr': { 'class': 'fos_user_group_new' } }) }}
+    {{ form_widget(form) }}
+    <div>
+        <input type="submit" value="{{ 'group.new.submit'|trans }}" />
+    </div>
+{{ form_end(form) }}

--- a/src/Resources/views/Group/show.html.twig
+++ b/src/Resources/views/Group/show.html.twig
@@ -1,0 +1,5 @@
+{% extends "@FOSUser/layout.html.twig" %}
+
+{% block fos_user_content %}
+{% include "@FOSUser/Group/show_content.html.twig" %}
+{% endblock fos_user_content %}

--- a/src/Resources/views/Group/show_content.html.twig
+++ b/src/Resources/views/Group/show_content.html.twig
@@ -1,0 +1,5 @@
+{% trans_default_domain 'FOSUserBundle' %}
+
+<div class="fos_user_group_show">
+    <p>{{ 'group.show.name'|trans }}: {{ group.getName() }}</p>
+</div>

--- a/src/Resources/views/Profile/edit.html.twig
+++ b/src/Resources/views/Profile/edit.html.twig
@@ -1,0 +1,5 @@
+{% extends "@FOSUser/layout.html.twig" %}
+
+{% block fos_user_content %}
+{% include "@FOSUser/Profile/edit_content.html.twig" %}
+{% endblock fos_user_content %}

--- a/src/Resources/views/Profile/edit_content.html.twig
+++ b/src/Resources/views/Profile/edit_content.html.twig
@@ -1,0 +1,8 @@
+{% trans_default_domain 'FOSUserBundle' %}
+
+{{ form_start(form, { 'action': path('fos_user_profile_edit'), 'attr': { 'class': 'fos_user_profile_edit' } }) }}
+    {{ form_widget(form) }}
+    <div>
+        <input type="submit" value="{{ 'profile.edit.submit'|trans }}" />
+    </div>
+{{ form_end(form) }}

--- a/src/Resources/views/Profile/show.html.twig
+++ b/src/Resources/views/Profile/show.html.twig
@@ -1,0 +1,5 @@
+{% extends "@FOSUser/layout.html.twig" %}
+
+{% block fos_user_content %}
+{% include "@FOSUser/Profile/show_content.html.twig" %}
+{% endblock fos_user_content %}

--- a/src/Resources/views/Profile/show_content.html.twig
+++ b/src/Resources/views/Profile/show_content.html.twig
@@ -1,0 +1,6 @@
+{% trans_default_domain 'FOSUserBundle' %}
+
+<div class="fos_user_user_show">
+    <p>{{ 'profile.show.username'|trans }}: {{ user.username }}</p>
+    <p>{{ 'profile.show.email'|trans }}: {{ user.email }}</p>
+</div>

--- a/src/Resources/views/Registration/check_email.html.twig
+++ b/src/Resources/views/Registration/check_email.html.twig
@@ -1,0 +1,7 @@
+{% extends "@FOSUser/layout.html.twig" %}
+
+{% trans_default_domain 'FOSUserBundle' %}
+
+{% block fos_user_content %}
+    <p>{{ 'registration.check_email'|trans({'%email%': user.email}) }}</p>
+{% endblock fos_user_content %}

--- a/src/Resources/views/Registration/confirmed.html.twig
+++ b/src/Resources/views/Registration/confirmed.html.twig
@@ -1,0 +1,10 @@
+{% extends "@FOSUser/layout.html.twig" %}
+
+{% trans_default_domain 'FOSUserBundle' %}
+
+{% block fos_user_content %}
+    <p>{{ 'registration.confirmed'|trans({'%username%': user.username}) }}</p>
+    {% if targetUrl %}
+    <p><a href="{{ targetUrl }}">{{ 'registration.back'|trans }}</a></p>
+    {% endif %}
+{% endblock fos_user_content %}

--- a/src/Resources/views/Registration/email.txt.twig
+++ b/src/Resources/views/Registration/email.txt.twig
@@ -1,0 +1,13 @@
+{% trans_default_domain 'FOSUserBundle' %}
+{% block subject %}
+{%- autoescape false -%}
+{{ 'registration.email.subject'|trans({'%username%': user.username, '%confirmationUrl%': confirmationUrl}) }}
+{%- endautoescape -%}
+{% endblock %}
+
+{% block body_text %}
+{% autoescape false %}
+{{ 'registration.email.message'|trans({'%username%': user.username, '%confirmationUrl%': confirmationUrl}) }}
+{% endautoescape %}
+{% endblock %}
+{% block body_html %}{% endblock %}

--- a/src/Resources/views/Registration/register.html.twig
+++ b/src/Resources/views/Registration/register.html.twig
@@ -1,0 +1,5 @@
+{% extends "@FOSUser/layout.html.twig" %}
+
+{% block fos_user_content %}
+{% include "@FOSUser/Registration/register_content.html.twig" %}
+{% endblock fos_user_content %}

--- a/src/Resources/views/Registration/register_content.html.twig
+++ b/src/Resources/views/Registration/register_content.html.twig
@@ -1,0 +1,8 @@
+{% trans_default_domain 'FOSUserBundle' %}
+
+{{ form_start(form, {'method': 'post', 'action': path('fos_user_registration_register'), 'attr': {'class': 'fos_user_registration_register'}}) }}
+    {{ form_widget(form) }}
+    <div>
+        <input type="submit" value="{{ 'registration.submit'|trans }}" />
+    </div>
+{{ form_end(form) }}

--- a/src/Resources/views/Resetting/check_email.html.twig
+++ b/src/Resources/views/Resetting/check_email.html.twig
@@ -1,0 +1,9 @@
+{% extends "@FOSUser/layout.html.twig" %}
+
+{% trans_default_domain 'FOSUserBundle' %}
+
+{% block fos_user_content %}
+<p>
+{{ 'resetting.check_email'|trans({'%tokenLifetime%': tokenLifetime})|nl2br }}
+</p>
+{% endblock %}

--- a/src/Resources/views/Resetting/email.txt.twig
+++ b/src/Resources/views/Resetting/email.txt.twig
@@ -1,0 +1,13 @@
+{% trans_default_domain 'FOSUserBundle' %}
+{% block subject %}
+{%- autoescape false -%}
+{{ 'resetting.email.subject'|trans({'%username%': user.username}) }}
+{%- endautoescape -%}
+{% endblock %}
+
+{% block body_text %}
+{% autoescape false %}
+{{ 'resetting.email.message'|trans({'%username%': user.username, '%confirmationUrl%': confirmationUrl}) }}
+{% endautoescape %}
+{% endblock %}
+{% block body_html %}{% endblock %}

--- a/src/Resources/views/Resetting/request.html.twig
+++ b/src/Resources/views/Resetting/request.html.twig
@@ -1,0 +1,5 @@
+{% extends "@FOSUser/layout.html.twig" %}
+
+{% block fos_user_content %}
+{% include "@FOSUser/Resetting/request_content.html.twig" %}
+{% endblock fos_user_content %}

--- a/src/Resources/views/Resetting/request_content.html.twig
+++ b/src/Resources/views/Resetting/request_content.html.twig
@@ -1,0 +1,11 @@
+{% trans_default_domain 'FOSUserBundle' %}
+
+<form action="{{ path('fos_user_resetting_send_email') }}" method="POST" class="fos_user_resetting_request">
+    <div>
+        <label for="username">{{ 'resetting.request.username'|trans }}</label>
+        <input type="text" id="username" name="username" required="required" />
+    </div>
+    <div>
+        <input type="submit" value="{{ 'resetting.request.submit'|trans }}" />
+    </div>
+</form>

--- a/src/Resources/views/Resetting/reset.html.twig
+++ b/src/Resources/views/Resetting/reset.html.twig
@@ -1,0 +1,5 @@
+{% extends "@FOSUser/layout.html.twig" %}
+
+{% block fos_user_content %}
+{% include "@FOSUser/Resetting/reset_content.html.twig" %}
+{% endblock fos_user_content %}

--- a/src/Resources/views/Resetting/reset_content.html.twig
+++ b/src/Resources/views/Resetting/reset_content.html.twig
@@ -1,0 +1,8 @@
+{% trans_default_domain 'FOSUserBundle' %}
+
+{{ form_start(form, { 'action': path('fos_user_resetting_reset', {'token': token}), 'attr': { 'class': 'fos_user_resetting_reset' } }) }}
+    {{ form_widget(form) }}
+    <div>
+        <input type="submit" value="{{ 'resetting.reset.submit'|trans }}" />
+    </div>
+{{ form_end(form) }}

--- a/src/Resources/views/Security/login.html.twig
+++ b/src/Resources/views/Security/login.html.twig
@@ -1,0 +1,5 @@
+{% extends "@FOSUser/layout.html.twig" %}
+
+{% block fos_user_content %}
+    {{ include('@FOSUser/Security/login_content.html.twig') }}
+{% endblock fos_user_content %}

--- a/src/Resources/views/Security/login_content.html.twig
+++ b/src/Resources/views/Security/login_content.html.twig
@@ -1,0 +1,22 @@
+{% trans_default_domain 'FOSUserBundle' %}
+
+{% if error %}
+    <div>{{ error.messageKey|trans(error.messageData, 'security') }}</div>
+{% endif %}
+
+<form action="{{ path("fos_user_security_check") }}" method="post">
+    {% if csrf_token %}
+        <input type="hidden" name="_csrf_token" value="{{ csrf_token }}" />
+    {% endif %}
+
+    <label for="username">{{ 'security.login.username'|trans }}</label>
+    <input type="text" id="username" name="_username" value="{{ last_username }}" required="required" autocomplete="username" />
+
+    <label for="password">{{ 'security.login.password'|trans }}</label>
+    <input type="password" id="password" name="_password" required="required" autocomplete="current-password" />
+
+    <input type="checkbox" id="remember_me" name="_remember_me" value="on" />
+    <label for="remember_me">{{ 'security.login.remember_me'|trans }}</label>
+
+    <input type="submit" id="_submit" name="_submit" value="{{ 'security.login.submit'|trans }}" />
+</form>

--- a/src/Resources/views/layout.html.twig
+++ b/src/Resources/views/layout.html.twig
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="UTF-8" />
+    </head>
+    <body>
+        <div>
+            {% if is_granted("IS_AUTHENTICATED_REMEMBERED") %}
+                {{ 'layout.logged_in_as'|trans({'%username%': app.user.username}, 'FOSUserBundle') }} |
+                <a href="{{ path('fos_user_security_logout') }}">
+                    {{ 'layout.logout'|trans({}, 'FOSUserBundle') }}
+                </a>
+            {% else %}
+                <a href="{{ path('fos_user_security_login') }}">{{ 'layout.login'|trans({}, 'FOSUserBundle') }}</a>
+            {% endif %}
+        </div>
+
+        {% if app.request.hasPreviousSession %}
+            {% for type, messages in app.session.flashbag.all() %}
+                {% for message in messages %}
+                    <div class="flash-{{ type }}">
+                        {{ message }}
+                    </div>
+                {% endfor %}
+            {% endfor %}
+        {% endif %}
+
+        <div>
+            {% block fos_user_content %}
+            {% endblock fos_user_content %}
+        </div>
+    </body>
+</html>

--- a/src/Security/Authorization/Voter/UserAclVoter.php
+++ b/src/Security/Authorization/Voter/UserAclVoter.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\UserBundle\Security\Authorization\Voter;
 
-use FOS\UserBundle\Model\UserInterface;
+use Sonata\UserBundle\Model\FOSUserInterface;
 use Symfony\Component\Security\Acl\Voter\AclVoter;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
@@ -25,7 +25,7 @@ class UserAclVoter extends AclVoter
     public function supportsClass($class)
     {
         // support the Object-Scope ACL
-        return is_subclass_of($class, 'FOS\UserBundle\Model\UserInterface');
+        return is_subclass_of($class, 'Sonata\UserBundle\Model\FOSUserInterface');
     }
 
     /**
@@ -46,7 +46,7 @@ class UserAclVoter extends AclVoter
         }
 
         foreach ($attributes as $attribute) {
-            if ($this->supportsAttribute($attribute) && $subject instanceof UserInterface && $token->getUser() instanceof UserInterface) {
+            if ($this->supportsAttribute($attribute) && $subject instanceof FOSUserInterface && $token->getUser() instanceof FOSUserInterface) {
                 if ($subject->isSuperAdmin() && !$token->getUser()->isSuperAdmin()) {
                     // deny a non super admin user to edit or delete a super admin user
                     return self::ACCESS_DENIED;

--- a/src/Security/EmailUserProvider.php
+++ b/src/Security/EmailUserProvider.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Security;
+
+class EmailUserProvider extends UserProvider
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function findUser($username)
+    {
+        return $this->userManager->findUserByUsernameOrEmail($username);
+    }
+}

--- a/src/Security/LoginManager.php
+++ b/src/Security/LoginManager.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Security;
+
+use Sonata\UserBundle\Model\UserInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\User\UserCheckerInterface;
+use Symfony\Component\Security\Http\RememberMe\RememberMeServicesInterface;
+use Symfony\Component\Security\Http\Session\SessionAuthenticationStrategyInterface;
+
+/**
+ * Abstracts process for manually logging in a user.
+ *
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ */
+class LoginManager implements LoginManagerInterface
+{
+    /**
+     * @var TokenStorageInterface
+     */
+    private $tokenStorage;
+
+    /**
+     * @var UserCheckerInterface
+     */
+    private $userChecker;
+
+    /**
+     * @var SessionAuthenticationStrategyInterface
+     */
+    private $sessionStrategy;
+
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
+    /**
+     * @var RememberMeServicesInterface
+     */
+    private $rememberMeService;
+
+    /**
+     * LoginManager constructor.
+     *
+     * @param TokenStorageInterface                  $tokenStorage
+     * @param UserCheckerInterface                   $userChecker
+     * @param SessionAuthenticationStrategyInterface $sessionStrategy
+     * @param RequestStack                           $requestStack
+     * @param RememberMeServicesInterface|null       $rememberMeService
+     */
+    public function __construct(TokenStorageInterface $tokenStorage, UserCheckerInterface $userChecker,
+                                SessionAuthenticationStrategyInterface $sessionStrategy,
+                                RequestStack $requestStack,
+                                RememberMeServicesInterface $rememberMeService = null
+    ) {
+        $this->tokenStorage = $tokenStorage;
+        $this->userChecker = $userChecker;
+        $this->sessionStrategy = $sessionStrategy;
+        $this->requestStack = $requestStack;
+        $this->rememberMeService = $rememberMeService;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    final public function logInUser($firewallName, UserInterface $user, Response $response = null)
+    {
+        $this->userChecker->checkPreAuth($user);
+
+        $token = $this->createToken($firewallName, $user);
+        $request = $this->requestStack->getCurrentRequest();
+
+        if (null !== $request) {
+            $this->sessionStrategy->onAuthentication($request, $token);
+
+            if (null !== $response && null !== $this->rememberMeService) {
+                $this->rememberMeService->loginSuccess($request, $response, $token);
+            }
+        }
+
+        $this->tokenStorage->setToken($token);
+    }
+
+    /**
+     * @param string        $firewall
+     * @param UserInterface $user
+     *
+     * @return UsernamePasswordToken
+     */
+    protected function createToken($firewall, UserInterface $user)
+    {
+        return new UsernamePasswordToken($user, null, $firewall, $user->getRoles());
+    }
+}

--- a/src/Security/LoginManagerInterface.php
+++ b/src/Security/LoginManagerInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Security;
+
+use Sonata\UserBundle\Model\FOSUserInterface;
+use Symfony\Component\HttpFoundation\Response;
+
+interface LoginManagerInterface
+{
+    /**
+     * @param string        $firewallName
+     * @param FOSUserInterface $user
+     * @param Response|null $response
+     */
+    public function logInUser($firewallName, FOSUserInterface $user, Response $response = null);
+}

--- a/src/Security/UserProvider.php
+++ b/src/Security/UserProvider.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Security;
+
+use Sonata\UserBundle\Model\FOSUserInterface;
+use Sonata\UserBundle\Model\FOSUserManagerInterface;
+use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
+use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
+use Symfony\Component\Security\Core\User\UserInterface as SecurityUserInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+
+class UserProvider implements UserProviderInterface
+{
+    /**
+     * @var FOSUserManagerInterface
+     */
+    protected $userManager;
+
+    /**
+     * Constructor.
+     *
+     * @param FOSUserManagerInterface $userManager
+     */
+    public function __construct(FOSUserManagerInterface $userManager)
+    {
+        $this->userManager = $userManager;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadUserByUsername($username)
+    {
+        $user = $this->findUser($username);
+
+        if (!$user) {
+            throw new UsernameNotFoundException(sprintf('Username "%s" does not exist.', $username));
+        }
+
+        return $user;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function refreshUser(SecurityUserInterface $user)
+    {
+        if (!$user instanceof UserInterface) {
+            throw new UnsupportedUserException(sprintf('Expected an instance of Sonata\UserBundle\Model\FOSUserInterface, but got "%s".', get_class($user)));
+        }
+
+        if (!$this->supportsClass(get_class($user))) {
+            throw new UnsupportedUserException(sprintf('Expected an instance of %s, but got "%s".', $this->userManager->getClass(), get_class($user)));
+        }
+
+        if (null === $reloadedUser = $this->userManager->findUserBy(array('id' => $user->getId()))) {
+            throw new UsernameNotFoundException(sprintf('User with ID "%s" could not be reloaded.', $user->getId()));
+        }
+
+        return $reloadedUser;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsClass($class)
+    {
+        $userClass = $this->userManager->getClass();
+
+        return $userClass === $class || is_subclass_of($class, $userClass);
+    }
+
+    /**
+     * Finds a user by username.
+     *
+     * This method is meant to be an extension point for child classes.
+     *
+     * @param string $username
+     *
+     * @return UserInterface|null
+     */
+    protected function findUser($username)
+    {
+        return $this->userManager->findUserByUsername($username);
+    }
+}

--- a/src/SonataUserBundle.php
+++ b/src/SonataUserBundle.php
@@ -46,12 +46,12 @@ class SonataUserBundle extends Bundle
     public function registerFormMapping(): void
     {
         FormHelper::registerFormTypeMapping([
-            'fos_user_username' => 'FOS\UserBundle\Form\Type\UsernameFormType',
-            'fos_user_profile' => 'FOS\UserBundle\Form\Type\ProfileFormType',
-            'fos_user_registration' => 'FOS\UserBundle\Form\Type\RegistrationFormType',
-            'fos_user_change_password' => 'FOS\UserBundle\Form\Type\ChangePasswordFormType',
-            'fos_user_resetting' => 'FOS\UserBundle\Form\Type\ResettingFormType',
-            'fos_user_group' => 'FOS\UserBundle\Form\Type\GroupFormType',
+            'fos_user_username' => 'Sonata\UserBundle\Form\Type\UsernameFormType',
+            'fos_user_profile' => 'Sonata\UserBundle\Form\Type\ProfileFormType',
+            'fos_user_registration' => 'Sonata\UserBundle\Form\Type\RegistrationFormType',
+            'fos_user_change_password' => 'Sonata\UserBundle\Form\Type\ChangePasswordFormType',
+            'fos_user_resetting' => 'Sonata\UserBundle\Form\Type\ResettingFormType',
+            'fos_user_group' => 'Sonata\UserBundle\Form\Type\GroupFormType',
             'sonata_security_roles' => 'Sonata\UserBundle\Form\Type\SecurityRolesType',
             'sonata_user_profile' => 'Sonata\UserBundle\Form\Type\ProfileType',
             'sonata_user_gender' => 'Sonata\UserBundle\Form\Type\UserGenderListType',

--- a/src/Util/CanonicalFieldsUpdater.php
+++ b/src/Util/CanonicalFieldsUpdater.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Util;
+
+use Sonata\UserBundle\Model\FOSUserInterface;
+
+/**
+ * Class updating the canonical fields of the user.
+ *
+ * @author Christophe Coevoet <stof@notk.org>
+ */
+class CanonicalFieldsUpdater
+{
+    private $usernameCanonicalizer;
+    private $emailCanonicalizer;
+
+    public function __construct(CanonicalizerInterface $usernameCanonicalizer, CanonicalizerInterface $emailCanonicalizer)
+    {
+        $this->usernameCanonicalizer = $usernameCanonicalizer;
+        $this->emailCanonicalizer = $emailCanonicalizer;
+    }
+
+    public function updateCanonicalFields(FOSUserInterface $user)
+    {
+        $user->setUsernameCanonical($this->canonicalizeUsername($user->getUsername()));
+        $user->setEmailCanonical($this->canonicalizeEmail($user->getEmail()));
+    }
+
+    /**
+     * Canonicalizes an email.
+     *
+     * @param string|null $email
+     *
+     * @return string|null
+     */
+    public function canonicalizeEmail($email)
+    {
+        return $this->emailCanonicalizer->canonicalize($email);
+    }
+
+    /**
+     * Canonicalizes a username.
+     *
+     * @param string|null $username
+     *
+     * @return string|null
+     */
+    public function canonicalizeUsername($username)
+    {
+        return $this->usernameCanonicalizer->canonicalize($username);
+    }
+}

--- a/src/Util/Canonicalizer.php
+++ b/src/Util/Canonicalizer.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Util;
+
+class Canonicalizer implements CanonicalizerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function canonicalize($string)
+    {
+        if (null === $string) {
+            return;
+        }
+
+        $encoding = mb_detect_encoding($string);
+        $result = $encoding
+            ? mb_convert_case($string, MB_CASE_LOWER, $encoding)
+            : mb_convert_case($string, MB_CASE_LOWER);
+
+        return $result;
+    }
+}

--- a/src/Util/CanonicalizerInterface.php
+++ b/src/Util/CanonicalizerInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Util;
+
+interface CanonicalizerInterface
+{
+    /**
+     * @param string $string
+     *
+     * @return string
+     */
+    public function canonicalize($string);
+}

--- a/src/Util/PasswordUpdater.php
+++ b/src/Util/PasswordUpdater.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Util;
+
+use Sonata\UserBundle\Model\FOSUserInterface;
+use Symfony\Component\Security\Core\Encoder\BCryptPasswordEncoder;
+use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
+
+/**
+ * Class updating the hashed password in the user when there is a new password.
+ *
+ * @author Christophe Coevoet <stof@notk.org>
+ */
+class PasswordUpdater implements PasswordUpdaterInterface
+{
+    private $encoderFactory;
+
+    public function __construct(EncoderFactoryInterface $encoderFactory)
+    {
+        $this->encoderFactory = $encoderFactory;
+    }
+
+    public function hashPassword(FOSUserInterface $user)
+    {
+        $plainPassword = $user->getPlainPassword();
+
+        if (0 === strlen($plainPassword)) {
+            return;
+        }
+
+        $encoder = $this->encoderFactory->getEncoder($user);
+
+        if ($encoder instanceof BCryptPasswordEncoder) {
+            $user->setSalt(null);
+        } else {
+            $salt = rtrim(str_replace('+', '.', base64_encode(random_bytes(32))), '=');
+            $user->setSalt($salt);
+        }
+
+        $hashedPassword = $encoder->encodePassword($plainPassword, $user->getSalt());
+        $user->setPassword($hashedPassword);
+        $user->eraseCredentials();
+    }
+}

--- a/src/Util/PasswordUpdaterInterface.php
+++ b/src/Util/PasswordUpdaterInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Util;
+
+use Sonata\UserBundle\Model\FOSUserInterface;
+
+/**
+ * @author Christophe Coevoet <stof@notk.org>
+ */
+interface PasswordUpdaterInterface
+{
+    /**
+     * Updates the hashed password in the user when there is a new password.
+     *
+     * The implement should be a no-op in case there is no new password (it should not erase the
+     * existing hash with a wrong one).
+     *
+     * @param FOSUserInterface $user
+     *
+     * @return void
+     */
+    public function hashPassword(FOSUserInterface $user);
+}

--- a/src/Util/TokenGenerator.php
+++ b/src/Util/TokenGenerator.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Util;
+
+class TokenGenerator implements TokenGeneratorInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function generateToken()
+    {
+        return rtrim(strtr(base64_encode(random_bytes(32)), '+/', '-_'), '=');
+    }
+}

--- a/src/Util/TokenGeneratorInterface.php
+++ b/src/Util/TokenGeneratorInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Util;
+
+interface TokenGeneratorInterface
+{
+    /**
+     * @return string
+     */
+    public function generateToken();
+}

--- a/src/Util/UserManipulator.php
+++ b/src/Util/UserManipulator.php
@@ -1,0 +1,230 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Util;
+
+use Sonata\UserBundle\Event\UserEvent;
+use Sonata\UserBundle\FOSUserEvents;
+use Sonata\UserBundle\Model\FOSUserInterface;
+use Sonata\UserBundle\Model\FOSUserManagerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Executes some manipulations on the users.
+ *
+ * @author Christophe Coevoet <stof@notk.org>
+ * @author Luis Cordova <cordoval@gmail.com>
+ */
+class UserManipulator
+{
+    /**
+     * User manager.
+     *
+     * @var FOSUserManagerInterface
+     */
+    private $userManager;
+
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $dispatcher;
+
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
+    /**
+     * UserManipulator constructor.
+     *
+     * @param FOSUserManagerInterface     $userManager
+     * @param EventDispatcherInterface $dispatcher
+     * @param RequestStack             $requestStack
+     */
+    public function __construct(FOSUserManagerInterface $userManager, EventDispatcherInterface $dispatcher, RequestStack $requestStack)
+    {
+        $this->userManager = $userManager;
+        $this->dispatcher = $dispatcher;
+        $this->requestStack = $requestStack;
+    }
+
+    /**
+     * Creates a user and returns it.
+     *
+     * @param string $username
+     * @param string $password
+     * @param string $email
+     * @param bool   $active
+     * @param bool   $superadmin
+     *
+     * @return \Sonata\UserBundle\Model\FOSUserInterface
+     */
+    public function create($username, $password, $email, $active, $superadmin)
+    {
+        $user = $this->userManager->createUser();
+        $user->setUsername($username);
+        $user->setEmail($email);
+        $user->setPlainPassword($password);
+        $user->setEnabled((bool) $active);
+        $user->setSuperAdmin((bool) $superadmin);
+        $this->userManager->updateUser($user);
+
+        $event = new UserEvent($user, $this->getRequest());
+        $this->dispatcher->dispatch(FOSUserEvents::USER_CREATED, $event);
+
+        return $user;
+    }
+
+    /**
+     * Activates the given user.
+     *
+     * @param string $username
+     */
+    public function activate($username)
+    {
+        $user = $this->findUserByUsernameOrThrowException($username);
+        $user->setEnabled(true);
+        $this->userManager->updateUser($user);
+
+        $event = new UserEvent($user, $this->getRequest());
+        $this->dispatcher->dispatch(FOSUserEvents::USER_ACTIVATED, $event);
+    }
+
+    /**
+     * Deactivates the given user.
+     *
+     * @param string $username
+     */
+    public function deactivate($username)
+    {
+        $user = $this->findUserByUsernameOrThrowException($username);
+        $user->setEnabled(false);
+        $this->userManager->updateUser($user);
+
+        $event = new UserEvent($user, $this->getRequest());
+        $this->dispatcher->dispatch(FOSUserEvents::USER_DEACTIVATED, $event);
+    }
+
+    /**
+     * Changes the password for the given user.
+     *
+     * @param string $username
+     * @param string $password
+     */
+    public function changePassword($username, $password)
+    {
+        $user = $this->findUserByUsernameOrThrowException($username);
+        $user->setPlainPassword($password);
+        $this->userManager->updateUser($user);
+
+        $event = new UserEvent($user, $this->getRequest());
+        $this->dispatcher->dispatch(FOSUserEvents::USER_PASSWORD_CHANGED, $event);
+    }
+
+    /**
+     * Promotes the given user.
+     *
+     * @param string $username
+     */
+    public function promote($username)
+    {
+        $user = $this->findUserByUsernameOrThrowException($username);
+        $user->setSuperAdmin(true);
+        $this->userManager->updateUser($user);
+
+        $event = new UserEvent($user, $this->getRequest());
+        $this->dispatcher->dispatch(FOSUserEvents::USER_PROMOTED, $event);
+    }
+
+    /**
+     * Demotes the given user.
+     *
+     * @param string $username
+     */
+    public function demote($username)
+    {
+        $user = $this->findUserByUsernameOrThrowException($username);
+        $user->setSuperAdmin(false);
+        $this->userManager->updateUser($user);
+
+        $event = new UserEvent($user, $this->getRequest());
+        $this->dispatcher->dispatch(FOSUserEvents::USER_DEMOTED, $event);
+    }
+
+    /**
+     * Adds role to the given user.
+     *
+     * @param string $username
+     * @param string $role
+     *
+     * @return bool true if role was added, false if user already had the role
+     */
+    public function addRole($username, $role)
+    {
+        $user = $this->findUserByUsernameOrThrowException($username);
+        if ($user->hasRole($role)) {
+            return false;
+        }
+        $user->addRole($role);
+        $this->userManager->updateUser($user);
+
+        return true;
+    }
+
+    /**
+     * Removes role from the given user.
+     *
+     * @param string $username
+     * @param string $role
+     *
+     * @return bool true if role was removed, false if user didn't have the role
+     */
+    public function removeRole($username, $role)
+    {
+        $user = $this->findUserByUsernameOrThrowException($username);
+        if (!$user->hasRole($role)) {
+            return false;
+        }
+        $user->removeRole($role);
+        $this->userManager->updateUser($user);
+
+        return true;
+    }
+
+    /**
+     * Finds a user by his username and throws an exception if we can't find it.
+     *
+     * @param string $username
+     *
+     * @throws \InvalidArgumentException When user does not exist
+     *
+     * @return FOSUserInterface
+     */
+    private function findUserByUsernameOrThrowException($username)
+    {
+        $user = $this->userManager->findUserByUsername($username);
+
+        if (!$user) {
+            throw new \InvalidArgumentException(sprintf('User identified by "%s" username does not exist.', $username));
+        }
+
+        return $user;
+    }
+
+    /**
+     * @return Request
+     */
+    private function getRequest()
+    {
+        return $this->requestStack->getCurrentRequest();
+    }
+}

--- a/src/Validator/Initializer.php
+++ b/src/Validator/Initializer.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the FOSUserBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Validator;
+
+use Sonata\UserBundle\Model\FOSUserInterface;
+use Sonata\UserBundle\Util\CanonicalFieldsUpdater;
+use Symfony\Component\Validator\ObjectInitializerInterface;
+
+/**
+ * Automatically updates the canonical fields before validation.
+ *
+ * @author Christophe Coevoet <stof@notk.org>
+ */
+class Initializer implements ObjectInitializerInterface
+{
+    private $canonicalFieldsUpdater;
+
+    public function __construct(CanonicalFieldsUpdater $canonicalFieldsUpdater)
+    {
+        $this->canonicalFieldsUpdater = $canonicalFieldsUpdater;
+    }
+
+    /**
+     * @param object $object
+     */
+    public function initialize($object)
+    {
+        if ($object instanceof FOSUserInterface) {
+            $this->canonicalFieldsUpdater->updateCanonicalFields($object);
+        }
+    }
+}

--- a/tests/Action/ResetActionTest.php
+++ b/tests/Action/ResetActionTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace Sonata\UserBundle\Tests\Action;
 
-use FOS\UserBundle\Form\Factory\FactoryInterface;
-use FOS\UserBundle\Model\User;
-use FOS\UserBundle\Model\UserManagerInterface;
-use FOS\UserBundle\Security\LoginManagerInterface;
+use Sonata\UserBundle\Form\Factory\FactoryInterface;
+use Sonata\UserBundle\Model\FOSUser;
+use Sonata\UserBundle\Model\UserManagerInterface;
+use Sonata\UserBundle\Security\LoginManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\Pool;
@@ -151,7 +151,7 @@ class ResetActionTest extends TestCase
     {
         $request = new Request();
 
-        $user = $this->createMock(User::class);
+        $user = $this->createMock(FOSUser::class);
         $user->expects($this->any())
             ->method('isPasswordRequestNonExpired')
             ->willReturn(false);
@@ -184,7 +184,7 @@ class ResetActionTest extends TestCase
             'admin_pool' => $this->pool,
         ];
 
-        $user = $this->createMock(User::class);
+        $user = $this->createMock(FOSUser::class);
         $user->expects($this->any())
             ->method('isPasswordRequestNonExpired')
             ->willReturn(true);
@@ -234,7 +234,7 @@ class ResetActionTest extends TestCase
     {
         $request = new Request();
 
-        $user = $this->createMock(User::class);
+        $user = $this->createMock(FOSUser::class);
         $user->expects($this->any())
             ->method('isPasswordRequestNonExpired')
             ->willReturn(true);

--- a/tests/Action/SendEmailActionTest.php
+++ b/tests/Action/SendEmailActionTest.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace Sonata\UserBundle\Tests\Action;
 
-use FOS\UserBundle\Mailer\MailerInterface;
-use FOS\UserBundle\Model\User;
-use FOS\UserBundle\Model\UserManagerInterface;
-use FOS\UserBundle\Util\TokenGeneratorInterface;
+use Sonata\UserBundle\Mailer\MailerInterface;
+use Sonata\UserBundle\Model\FOSUser;
+use Sonata\UserBundle\Model\UserManagerInterface;
+use Sonata\UserBundle\Util\TokenGeneratorInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\Pool;
@@ -137,7 +137,7 @@ class SendEmailActionTest extends TestCase
     {
         $request = new Request([], ['username' => 'bar']);
 
-        $user = $this->createMock(User::class);
+        $user = $this->createMock(FOSUser::class);
         $user->expects($this->any())
             ->method('isPasswordRequestNonExpired')
             ->willReturn(true);
@@ -166,7 +166,7 @@ class SendEmailActionTest extends TestCase
     {
         $request = new Request([], ['username' => 'bar']);
 
-        $user = $this->createMock(User::class);
+        $user = $this->createMock(FOSUser::class);
         $user->expects($this->any())
             ->method('isPasswordRequestNonExpired')
             ->willReturn(false);
@@ -200,7 +200,7 @@ class SendEmailActionTest extends TestCase
 
         $storedToken = null;
 
-        $user = $this->createMock(User::class);
+        $user = $this->createMock(FOSUser::class);
         $user->expects($this->any())
             ->method('getEmail')
             ->willReturn('user@sonata-project.org');

--- a/tests/Controller/Api/GroupControllerTest.php
+++ b/tests/Controller/Api/GroupControllerTest.php
@@ -24,7 +24,7 @@ class GroupControllerTest extends TestCase
 {
     public function testGetGroupsAction(): void
     {
-        $group = $this->createMock('FOS\UserBundle\Model\GroupInterface');
+        $group = $this->createMock('Sonata\UserBundle\Model\GroupInterface');
         $groupManager = $this->createMock('Sonata\UserBundle\Model\GroupManagerInterface');
         $groupManager->expects($this->once())->method('getPager')->willReturn([$group]);
 
@@ -39,7 +39,7 @@ class GroupControllerTest extends TestCase
 
     public function testGetGroupAction(): void
     {
-        $group = $this->createMock('FOS\UserBundle\Model\GroupInterface');
+        $group = $this->createMock('Sonata\UserBundle\Model\GroupInterface');
         $this->assertSame($group, $this->createGroupController($group)->getGroupAction(1));
     }
 
@@ -53,7 +53,7 @@ class GroupControllerTest extends TestCase
 
     public function testPostGroupAction(): void
     {
-        $group = $this->createMock('FOS\UserBundle\Model\GroupInterface');
+        $group = $this->createMock('Sonata\UserBundle\Model\GroupInterface');
 
         $groupManager = $this->createMock('Sonata\UserBundle\Model\GroupManagerInterface');
         $groupManager->expects($this->once())->method('getClass')->willReturn('Sonata\UserBundle\Entity\BaseGroup');
@@ -91,7 +91,7 @@ class GroupControllerTest extends TestCase
 
     public function testPutGroupAction(): void
     {
-        $group = $this->createMock('FOS\UserBundle\Model\GroupInterface');
+        $group = $this->createMock('Sonata\UserBundle\Model\GroupInterface');
 
         $groupManager = $this->createMock('Sonata\UserBundle\Model\GroupManagerInterface');
         $groupManager->expects($this->once())->method('getClass')->willReturn('Sonata\UserBundle\Entity\BaseGroup');
@@ -113,7 +113,7 @@ class GroupControllerTest extends TestCase
 
     public function testPutGroupInvalidAction(): void
     {
-        $group = $this->createMock('FOS\UserBundle\Model\GroupInterface');
+        $group = $this->createMock('Sonata\UserBundle\Model\GroupInterface');
 
         $groupManager = $this->createMock('Sonata\UserBundle\Model\GroupManagerInterface');
         $groupManager->expects($this->once())->method('getClass')->willReturn('Sonata\UserBundle\Entity\BaseGroup');
@@ -133,7 +133,7 @@ class GroupControllerTest extends TestCase
 
     public function testDeleteGroupAction(): void
     {
-        $group = $this->createMock('FOS\UserBundle\Model\GroupInterface');
+        $group = $this->createMock('Sonata\UserBundle\Model\GroupInterface');
 
         $groupManager = $this->createMock('Sonata\UserBundle\Model\GroupManagerInterface');
         $groupManager->expects($this->once())->method('findGroupBy')->willReturn($group);

--- a/tests/Controller/Api/UserControllerTest.php
+++ b/tests/Controller/Api/UserControllerTest.php
@@ -52,7 +52,7 @@ class UserControllerTest extends TestCase
 
     public function testPostUserAction(): void
     {
-        $user = $this->createMock('FOS\UserBundle\Model\UserInterface');
+        $user = $this->createMock('Sonata\UserBundle\Model\FOSUserInterface');
 
         $userManager = $this->createMock('Sonata\UserBundle\Model\UserManagerInterface');
         $userManager->expects($this->once())->method('updateUser')->willReturn($user);
@@ -88,7 +88,7 @@ class UserControllerTest extends TestCase
 
     public function testPutUserAction(): void
     {
-        $user = $this->createMock('FOS\UserBundle\Model\UserInterface');
+        $user = $this->createMock('Sonata\UserBundle\Model\FOSUserInterface');
 
         $userManager = $this->createMock('Sonata\UserBundle\Model\UserManagerInterface');
         $userManager->expects($this->once())->method('findUserBy')->willReturn($user);
@@ -109,7 +109,7 @@ class UserControllerTest extends TestCase
 
     public function testPutUserInvalidAction(): void
     {
-        $user = $this->createMock('FOS\UserBundle\Model\UserInterface');
+        $user = $this->createMock('Sonata\UserBundle\Model\FOSUserInterface');
 
         $userManager = $this->createMock('Sonata\UserBundle\Model\UserManagerInterface');
         $userManager->expects($this->once())->method('findUserBy')->willReturn($user);
@@ -131,7 +131,7 @@ class UserControllerTest extends TestCase
         $user = $this->createMock('Sonata\UserBundle\Entity\BaseUser');
         $user->expects($this->once())->method('hasGroup')->willReturn(false);
 
-        $group = $this->createMock('FOS\UserBundle\Model\GroupInterface');
+        $group = $this->createMock('Sonata\UserBundle\Model\GroupInterface');
 
         $userManager = $this->createMock('Sonata\UserBundle\Model\UserManagerInterface');
         $userManager->expects($this->once())->method('findUserBy')->willReturn($user);
@@ -150,7 +150,7 @@ class UserControllerTest extends TestCase
         $user = $this->createMock('Sonata\UserBundle\Entity\BaseUser');
         $user->expects($this->once())->method('hasGroup')->willReturn(true);
 
-        $group = $this->createMock('FOS\UserBundle\Model\GroupInterface');
+        $group = $this->createMock('Sonata\UserBundle\Model\GroupInterface');
 
         $userManager = $this->createMock('Sonata\UserBundle\Model\UserManagerInterface');
         $userManager->expects($this->once())->method('findUserBy')->willReturn($user);
@@ -173,7 +173,7 @@ class UserControllerTest extends TestCase
         $user = $this->createMock('Sonata\UserBundle\Entity\BaseUser');
         $user->expects($this->once())->method('hasGroup')->willReturn(true);
 
-        $group = $this->createMock('FOS\UserBundle\Model\GroupInterface');
+        $group = $this->createMock('Sonata\UserBundle\Model\GroupInterface');
 
         $userManager = $this->createMock('Sonata\UserBundle\Model\UserManagerInterface');
         $userManager->expects($this->once())->method('findUserBy')->willReturn($user);
@@ -192,7 +192,7 @@ class UserControllerTest extends TestCase
         $user = $this->createMock('Sonata\UserBundle\Entity\BaseUser');
         $user->expects($this->once())->method('hasGroup')->willReturn(false);
 
-        $group = $this->createMock('FOS\UserBundle\Model\GroupInterface');
+        $group = $this->createMock('Sonata\UserBundle\Model\GroupInterface');
 
         $userManager = $this->createMock('Sonata\UserBundle\Model\UserManagerInterface');
         $userManager->expects($this->once())->method('findUserBy')->willReturn($user);
@@ -212,7 +212,7 @@ class UserControllerTest extends TestCase
 
     public function testDeleteUserAction(): void
     {
-        $user = $this->createMock('FOS\UserBundle\Model\UserInterface');
+        $user = $this->createMock('Sonata\UserBundle\Model\FOSUserInterface');
 
         $userManager = $this->createMock('Sonata\UserBundle\Model\UserManagerInterface');
         $userManager->expects($this->once())->method('findUserBy')->willReturn($user);

--- a/tests/DependencyInjection/SonataUserExtensionTest.php
+++ b/tests/DependencyInjection/SonataUserExtensionTest.php
@@ -36,6 +36,10 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
         $this->setParameter('kernel.bundles', ['SonataAdminBundle' => true]);
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
+     */
     public function testLoadDefault(): void
     {
         $this->load();
@@ -49,31 +53,6 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
             'sonata.user.group_manager',
             'sonata.user.orm.group_manager'
         );
-    }
-
-    public function testFixImpersonatingWithWrongConfig(): void
-    {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('you can\'t have `impersonating` and `impersonating_route` keys defined at the same time');
-
-        $this->load(['impersonating' => ['route' => 'foo'], 'impersonating_route' => 'bar']);
-    }
-
-    /**
-     * @dataProvider fixImpersonatingDataProvider
-     */
-    public function testFixImpersonatingWithImpersonatingConfig(array $expectedConfig, array $providedConfig): void
-    {
-        $extension = new SonataUserExtension();
-
-        $this->assertSame($expectedConfig, $extension->fixImpersonating($providedConfig));
-    }
-
-    public function fixImpersonatingDataProvider(): \Generator
-    {
-        yield 'with impersonating with route' => [['impersonating' => ['route' => 'foo', 'parameters' => []]], ['impersonating' => ['route' => 'foo', 'parameters' => []]]];
-        yield 'with impersonating without route' => [['impersonating' => false], ['impersonating' => ['parameters' => []]]];
-        yield 'with impersonating_route' => [['impersonating_route' => 'foo', 'impersonating' => ['route' => 'foo', 'parameters' => []]], ['impersonating_route' => 'foo']];
     }
 
     public function testTwigConfigParameterIsSetting(): void
@@ -98,6 +77,10 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
         }
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
+     */
     public function testTwigConfigParameterIsSet(): void
     {
         $fakeTwigExtension = $this->getMockBuilder(TwigExtension::class)
@@ -122,6 +105,10 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
         );
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
+     */
     public function testTwigConfigParameterIsNotSet(): void
     {
         $this->load();
@@ -131,21 +118,37 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
         $this->assertArrayNotHasKey(0, $twigConfigurations);
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
+     */
     public function testCorrectModelClass(): void
     {
         $this->load(['class' => ['user' => 'Sonata\UserBundle\Tests\Entity\User']]);
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
+     */
     public function testCorrectModelClassWithLeadingSlash(): void
     {
         $this->load(['class' => ['user' => '\Sonata\UserBundle\Tests\Entity\User']]);
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
+     */
     public function testCorrectAdminClass(): void
     {
         $this->load(['admin' => ['user' => ['class' => '\Sonata\UserBundle\Tests\Admin\Entity\UserAdmin']]]);
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
+     */
     public function testCorrectModelClassWithNotDefaultManagerType(): void
     {
         $this->load([
@@ -161,7 +164,23 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
         ]);
     }
 
-    public function testIncorrectModelClass(): void
+    /**
+     * @group legacy
+     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
+     */
+    public function testFosUserBundleModelClasses(): void
+    {
+        $this->load(['manager_type' => 'orm', 'class' => [
+            'user' => 'Sonata\UserBundle\Model\FOSUserInterface',
+            'group' => 'Sonata\UserBundle\Model\GroupInterface',
+        ]]);
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
+     */
+    public function testNotCorrespondingUserClass(): void
     {
         $this->expectException('InvalidArgumentException');
 
@@ -172,7 +191,11 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
         $this->load(['manager_type' => 'mongodb', 'class' => ['user' => 'Sonata\UserBundle\Entity\BaseUser']]);
     }
 
-    public function testNotCorrespondingModelClass(): void
+    /**
+     * @group legacy
+     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
+     */
+    public function testNotCorrespondingGroupClass(): void
     {
         $this->expectException('InvalidArgumentException');
 
@@ -186,6 +209,10 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
         ]]);
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
+     */
     public function testConfigureGoogleAuthenticatorDisabled(): void
     {
         $this->load(['google_authenticator' => ['enabled' => false]]);
@@ -197,6 +224,10 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderNotHasService('sonata.user.google.authenticator.request_listener');
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
+     */
     public function testConfigureGoogleAuthenticatorEnabled(): void
     {
         $this->load(['google_authenticator' => ['enabled' => true, 'forced_for_role' => ['ROLE_USER'], 'ip_white_list' => ['0.0.0.1'],
@@ -210,6 +241,28 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderHasParameter('sonata.user.google.authenticator.forced_for_role', ['ROLE_ADMIN', 'ROLE_USER']);
         $this->assertContainerBuilderHasParameter('sonata.user.google.authenticator.ip_white_list', ['127.0.0.1', '0.0.0.1']);
         $this->assertContainerBuilderHasServiceDefinitionWithArgument('sonata.user.google.authenticator.provider', 0, 'bar');
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
+     */
+    public function testMailerConfigParameterIfNotSet(): void
+    {
+        $this->load();
+
+        $this->assertContainerBuilderHasAlias('sonata.user.mailer', 'sonata.user.mailer.default');
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
+     */
+    public function testMailerConfigParameter(): void
+    {
+        $this->load(['mailer' => 'custom.mailer.service.id']);
+
+        $this->assertContainerBuilderHasAlias('sonata.user.mailer', 'custom.mailer.service.id');
     }
 
     /**

--- a/tests/Document/BaseUserTest.php
+++ b/tests/Document/BaseUserTest.php
@@ -75,9 +75,9 @@ class BaseUserTest extends TestCase
     {
         // Given
         $user = new BaseUser();
-        $group1 = $this->createMock('FOS\UserBundle\Model\GroupInterface');
+        $group1 = $this->createMock('Sonata\UserBundle\Model\GroupInterface');
         $group1->expects($this->any())->method('getName')->willReturn('Group 1');
-        $group2 = $this->createMock('FOS\UserBundle\Model\GroupInterface');
+        $group2 = $this->createMock('Sonata\UserBundle\Model\GroupInterface');
         $group2->expects($this->any())->method('getName')->willReturn('Group 2');
 
         // When

--- a/tests/Entity/BaseUserTest.php
+++ b/tests/Entity/BaseUserTest.php
@@ -75,9 +75,9 @@ class BaseUserTest extends TestCase
     {
         // Given
         $user = new BaseUser();
-        $group1 = $this->createMock('FOS\UserBundle\Model\GroupInterface');
+        $group1 = $this->createMock('Sonata\UserBundle\Model\GroupInterface');
         $group1->expects($this->any())->method('getName')->willReturn('Group 1');
-        $group2 = $this->createMock('FOS\UserBundle\Model\GroupInterface');
+        $group2 = $this->createMock('Sonata\UserBundle\Model\GroupInterface');
         $group2->expects($this->any())->method('getName')->willReturn('Group 2');
 
         // When

--- a/tests/Entity/UserManagerTest.php
+++ b/tests/Entity/UserManagerTest.php
@@ -113,8 +113,8 @@ class UserManagerTest extends TestCase
             'email',
         ]);
 
-        $passwordUpdater = $this->createMock('FOS\UserBundle\Util\PasswordUpdaterInterface');
-        $canonical = $this->createMock('FOS\UserBundle\Util\CanonicalFieldsUpdater');
+        $passwordUpdater = $this->createMock('Sonata\UserBundle\Util\PasswordUpdaterInterface');
+        $canonical = $this->createMock('Sonata\UserBundle\Util\CanonicalFieldsUpdater');
 
         return new UserManager($passwordUpdater, $canonical, $om, 'Sonata\UserBundle\Entity\BaseUser');
     }

--- a/tests/EventListener/TwoFactorLoginSuccessHandlerTest.php
+++ b/tests/EventListener/TwoFactorLoginSuccessHandlerTest.php
@@ -11,9 +11,9 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-use FOS\UserBundle\Model\UserManagerInterface;
+use Sonata\UserBundle\Model\UserManagerInterface;
+use Google\Authenticator\GoogleAuthenticator;
 use PHPUnit\Framework\TestCase;
-use Sonata\GoogleAuthenticator\GoogleAuthenticator;
 use Sonata\UserBundle\Entity\BaseUser;
 use Sonata\UserBundle\EventListener\TwoFactorLoginSuccessHandler;
 use Sonata\UserBundle\GoogleAuthenticator\Helper;
@@ -87,7 +87,7 @@ class TwoFactorLoginSuccessHandlerTest extends TestCase
 
     private function createTestClass(string $secret, string $userRole, string $remoteAddr, bool $needSession): void
     {
-        $this->user = (new BaseUser())->setUsername('username');
+        $this->user = new BaseUser();
         if ($secret) {
             $this->user->setTwoStepVerificationCode($secret);
         }

--- a/tests/Mailer/MailerTest.php
+++ b/tests/Mailer/MailerTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\UserBundle\Tests\DependencyInjection;
 
-use FOS\UserBundle\Model\UserInterface;
+use Sonata\UserBundle\Model\FOSUserInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sonata\UserBundle\Mailer\Mailer;
@@ -61,7 +61,7 @@ class MailerTest extends TestCase
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('This method is not implemented.');
 
-        $user = $this->createMock(UserInterface::class);
+        $user = $this->createMock(FOSUserInterface::class);
 
         $this->getMailer()->sendConfirmationEmailMessage($user);
     }
@@ -71,7 +71,7 @@ class MailerTest extends TestCase
      */
     public function testSendResettingEmailMessage($template, $subject, $body): void
     {
-        $user = $this->createMock(UserInterface::class);
+        $user = $this->createMock(FOSUserInterface::class);
         $user->expects($this->any())
             ->method('getConfirmationToken')
             ->willReturn('user-token');

--- a/tests/Security/Authorization/Voter/UserAclVoterTest.php
+++ b/tests/Security/Authorization/Voter/UserAclVoterTest.php
@@ -23,10 +23,10 @@ class UserAclVoterTest extends TestCase
     public function testVoteWillAbstainWhenAUserIsLoggedInAndASuperAdmin(): void
     {
         // Given
-        $user = $this->createMock('FOS\UserBundle\Model\UserInterface');
+        $user = $this->createMock('Sonata\UserBundle\Model\FOSUserInterface');
         $user->expects($this->any())->method('isSuperAdmin')->willReturn(true);
 
-        $loggedInUser = $this->createMock('FOS\UserBundle\Model\UserInterface');
+        $loggedInUser = $this->createMock('Sonata\UserBundle\Model\FOSUserInterface');
         $loggedInUser->expects($this->any())->method('isSuperAdmin')->willReturn(true);
 
         $token = $this->createMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
@@ -49,10 +49,10 @@ class UserAclVoterTest extends TestCase
     public function testVoteWillDenyAccessWhenAUserIsLoggedInAndNotASuperAdmin(): void
     {
         // Given
-        $user = $this->createMock('FOS\UserBundle\Model\UserInterface');
+        $user = $this->createMock('Sonata\UserBundle\Model\FOSUserInterface');
         $user->expects($this->any())->method('isSuperAdmin')->willReturn(true);
 
-        $loggedInUser = $this->createMock('FOS\UserBundle\Model\UserInterface');
+        $loggedInUser = $this->createMock('Sonata\UserBundle\Model\FOSUserInterface');
         $loggedInUser->expects($this->any())->method('isSuperAdmin')->willReturn(false);
 
         $token = $this->createMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
@@ -75,7 +75,7 @@ class UserAclVoterTest extends TestCase
     public function testVoteWillAbstainWhenAUserIsNotAvailable(): void
     {
         // Given
-        $user = $this->createMock('FOS\UserBundle\Model\UserInterface');
+        $user = $this->createMock('Sonata\UserBundle\Model\FOSUserInterface');
         $user->expects($this->any())->method('isSuperAdmin')->willReturn(true);
 
         $loggedInUser = null;
@@ -100,7 +100,7 @@ class UserAclVoterTest extends TestCase
     public function testVoteWillAbstainWhenAUserIsLoggedInButIsNotAFOSUser(): void
     {
         // Given
-        $user = $this->createMock('FOS\UserBundle\Model\UserInterface');
+        $user = $this->createMock('Sonata\UserBundle\Model\FOSUserInterface');
         $user->expects($this->any())->method('isSuperAdmin')->willReturn(true);
 
         $loggedInUser = $this->createMock(UserInterface::class);


### PR DESCRIPTION
## Subject
This PR is a **WORK IN PROGRESS**. See Todo for missing changes.
Based on #1112 The lack of maintenance of FOSUserBundle will impact SonataUserBundle and this dependency must be removed.

Removing this bundle will obviously imply breaking changes due to existing : 
- FOSUserBundle configuration
- security configuration (Encoder, User provider)
- collection/table names
- forms (login, reset..)
- overriden templates
- what else ?

Looking at the impact this PR should be part of a Major Release (5.x ?)

Closes #1112 

When I looked at all the dependencies on FOSUserBundle and the coupling behind it I went with : 
1. copying all files from FOS to Sonata
2. migrating namespace and class name

in order to make all tests pass.

The rest is in the Todo =>

## Changelog

```markdown
### Added

- Migrated FOSUserBundle files into SonataUserBundle

### Changed

- Replaced FOS namespaces with Sonata

```

 ## To do
- [ ] Define the scope/list of features part of FOSUserBundle that should be kept in Sonata
- [ ] Apply changes based on previous definition
- [ ] Import required FOSUserBundle Configuration into SonataUserBundle
- [ ] Update the documentation
- [ ] Add an upgrade note

I am not used to this kind of refactoring so there might be total different opinions or different approaches. I am open to suggestion :-)