### PR TITLE
Allow overwriting users to define their own validation groups

### DIFF
--- a/src/Admin/Model/UserAdmin.php
+++ b/src/Admin/Model/UserAdmin.php
@@ -43,7 +43,7 @@ class UserAdmin extends AbstractAdmin
         $this->formOptions['data_class'] = $this->getClass();
 
         $options = $this->formOptions;
-        $options['validation_groups'] = (!$this->getSubject() || null === $this->getSubject()->getId()) ? 'Registration' : 'Profile';
+        $options['validation_groups'][] = (!$this->getSubject() || null === $this->getSubject()->getId()) ? 'Registration' : 'Profile';
 
         $formBuilder = $this->getFormContractor()->getFormBuilder($this->getUniqid(), $options);
 


### PR DESCRIPTION
## Allow overwriting users to define their own validation groups

### Changed:
Changed validation groups to add to the existing validation group and
not overwrite it

This is important, if you want to define your own user overwriting the user admin

### Why:
- It should be possible to do so

On branch 4.x
Changes to be committed:
- modified:   src/Admin/Model/UserAdmin.php

## Changelog
In File: `src/Admin/Model/UserAdmin.php`
changed: `UserAdmin::getFormBuilder

```
$options['validation_groups'][] = (!$this->getSubject() || null === $this->getSubject()->getId()) ? 'Registration' : 'Profile';
```

## Changed
This allows the user to use this (for example) in their class definitions:

```
    protected $formOptions = [
        'validation_groups' => ['Default']
    ];
```
To allow for the regular validation groups to take effect.