### PR TITLE
fix(google-authenticator): correctly retrieve all forwarded client ips

### DIFF
--- a/src/GoogleAuthenticator/Helper.php
+++ b/src/GoogleAuthenticator/Helper.php
@@ -99,7 +99,7 @@ class Helper
 
     public function needToHaveGoogle2FACode(Request $request): bool
     {
-        $ip = $request->server->get('HTTP_X_FORWARDED_FOR', $request->server->get('REMOTE_ADDR'));
+        $ip = $request->getClientIp();
         if (\in_array($ip, $this->ipWhiteList, true)) {
             return false;
         }

--- a/src/GoogleAuthenticator/Helper.php
+++ b/src/GoogleAuthenticator/Helper.php
@@ -99,8 +99,7 @@ class Helper
 
     public function needToHaveGoogle2FACode(Request $request): bool
     {
-        $ip = $request->getClientIp();
-        if (\in_array($ip, $this->ipWhiteList, true)) {
+        if (\in_array($request->getClientIp(), $this->ipWhiteList, true)) {
             return false;
         }
 


### PR DESCRIPTION
## Subject

The forwarded ip header can be different than the one hardcoded. We should use the request `getClientIp()` method here.

I am targeting this branch, because this is a bug fix, backward compatible if the trusted proxy header is correctly configured.

## Changelog

```markdown
### Fixed
- Fixed retrieving all forwarded ip headers in the google authenticator helper
```
