### PR TITLE
Avoid leaking usernames in password recover

### DIFF
--- a/src/Action/SendEmailAction.php
+++ b/src/Action/SendEmailAction.php
@@ -92,19 +92,7 @@ final class SendEmailAction
 
         $user = $this->userManager->findUserByUsernameOrEmail($username);
 
-        if (null === $user) {
-            return new Response($this->twig->render('@SonataUser/Admin/Security/Resetting/request.html.twig', [
-                'base_template' => $this->templateRegistry->getTemplate('layout'),
-                'admin_pool' => $this->adminPool,
-                'invalid_username' => $username,
-            ]));
-        }
-
-        if (null !== $user && !$user->isPasswordRequestNonExpired($this->resetTtl)) {
-            if (!$user->isAccountNonLocked()) {
-                return new RedirectResponse($this->urlGenerator->generate('sonata_user_admin_resetting_request'));
-            }
-
+        if (null !== $user && !$user->isPasswordRequestNonExpired($this->resetTtl) && $user->isAccountNonLocked()) {
             if (null === $user->getConfirmationToken()) {
                 $user->setConfirmationToken($this->tokenGenerator->generateToken());
             }

--- a/src/Resources/views/Admin/Security/Resetting/request.html.twig
+++ b/src/Resources/views/Admin/Security/Resetting/request.html.twig
@@ -41,13 +41,6 @@ file that was distributed with this source code.
         {% endblock %}
         <div class="login-box-body">
             {% block sonata_user_reset_request_form %}
-                {% block sonata_user_reset_request_error %}
-                    {% if invalid_username is defined %}
-                        <div class="alert alert-danger">
-                            {{ 'resetting.request.invalid_username'|trans({'%username%': invalid_username}, 'FOSUserBundle') }}
-                        </div>
-                    {% endif %}
-                {% endblock %}
                 <p class="login-box-msg">{{ 'resetting.request.submit'|trans({}, 'FOSUserBundle') }}</p>
                 <form action="{{ path('sonata_user_admin_resetting_send_email') }}" method="post" role="form">
                     <div class="form-group has-feedback">

--- a/tests/Action/SendEmailActionTest.php
+++ b/tests/Action/SendEmailActionTest.php
@@ -110,25 +110,24 @@ class SendEmailActionTest extends TestCase
             'invalid_username' => 'bar',
         ];
 
-        $this->templating->expects($this->once())
-            ->method('render')
-            ->with('@SonataUser/Admin/Security/Resetting/request.html.twig', $parameters)
-            ->willReturn('template content');
-
-        $this->templateRegistry
-            ->method('getTemplate')
-            ->with('layout')
-            ->willReturn('base.html.twig');
-
         $this->userManager
             ->method('findUserByUsernameOrEmail')
             ->with('bar')
             ->willReturn(null);
 
+        $this->mailer->expects($this->never())
+            ->method('sendResettingEmailMessage');
+
+        $this->urlGenerator
+            ->method('generate')
+            ->with('sonata_user_admin_resetting_check_email')
+            ->willReturn('/foo');
+
         $action = $this->getAction();
         $result = $action($request);
 
-        $this->assertSame('template content', $result->getContent());
+        $this->assertInstanceOf(RedirectResponse::class, $result);
+        $this->assertSame('/foo', $result->getTargetUrl());
     }
 
     public function testPasswordRequestNonExpired(): void
@@ -182,7 +181,7 @@ class SendEmailActionTest extends TestCase
 
         $this->urlGenerator
             ->method('generate')
-            ->with('sonata_user_admin_resetting_request')
+            ->with('sonata_user_admin_resetting_check_email')
             ->willReturn('/foo');
 
         $action = $this->getAction();


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/4.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC and a security issue.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1086 

Partially reverts https://github.com/sonata-project/SonataUserBundle/pull/1044

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataUserBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Security
- Avoid leaking usernames in password recovery
```

<!--
    If this is a work in progress, uncomment this section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
    
    ## To do
    
    - [ ] Update the tests
    - [ ] Update the documentation
    - [ ] Add an upgrade note
-->