### PR TITLE
Fix: display errors in reset template

### DIFF
--- a/src/Resources/views/Admin/Security/Resetting/reset.html.twig
+++ b/src/Resources/views/Admin/Security/Resetting/reset.html.twig
@@ -48,12 +48,14 @@ file that was distributed with this source code.
                             'class': 'form-control',
                             'placeholder': 'form.new_password'|trans({}, 'FOSUserBundle')
                         }}) }}
+                        {{ form_errors(form.plainPassword.first) }}
                     </div>
                     <div class="form-group">
                         {{ form_widget(form.plainPassword.second, {'attr': {
                             'class': 'form-control',
                             'placeholder': 'form.new_password_confirmation'|trans({}, 'FOSUserBundle')
                         }}) }}
+                        {{ form_errors(form.plainPassword.second) }}
                     </div>
                     <div class="row">
                         <div class="col-xs-12">


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Currently the reset form do not display errors message.
I have added a line after the form widget for display errors messages.
The best would be to replace form widget with a form row to display bootstrap template.
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/4.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is a bug fix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1179

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataUserBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed display errors in reset template
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
