### PR TITLE
Revert of previous commit. Actual code relays on Session class.

### DIFF
--- a/src/Action/ResetAction.php
+++ b/src/Action/ResetAction.php
@@ -23,7 +23,7 @@ use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
@@ -81,7 +81,7 @@ final class ResetAction
     private $translator;
 
     /**
-     * @var SessionInterface
+     * @var Session
      */
     private $session;
 
@@ -105,7 +105,7 @@ final class ResetAction
         UserManagerInterface $userManager,
         LoginManagerInterface $loginManager,
         TranslatorInterface $translator,
-        SessionInterface $session,
+        Session $session,
         int $resetTtl,
         string $firewallName
     ) {

--- a/tests/Action/ResetActionTest.php
+++ b/tests/Action/ResetActionTest.php
@@ -28,7 +28,6 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBag;
 use Symfony\Component\HttpFoundation\Session\Session;
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
@@ -108,7 +107,7 @@ class ResetActionTest extends TestCase
         $this->userManager = $this->createMock(UserManagerInterface::class);
         $this->loginManager = $this->createMock(LoginManagerInterface::class);
         $this->translator = $this->createMock(TranslatorInterface::class);
-        $this->session = $this->createMock(SessionInterface::class);
+        $this->session = $this->createMock(Session::class);
         $this->resetTtl = 60;
         $this->firewallName = 'default';
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Actual code relays on Session class

<!-- Describe your Pull Request content here -->
Actual code relays on `Session` class. Not `SessionInterface` class. Problem is in the method `getFlashBag()` of `Session` class. This method is widely used in code in many classes. If we want relay on  `SessionInterface` class, we need to solve the problem with using `getFlashBag()`.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/4.x/CONTRIBUTING.md#the-base-branch
-->


<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

It is revert of changes from the #1174 

## Changelog
Actual code still relays on `Session` class, not `SessionInterface` class. 
<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataUserBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Reverting use of Session class instead of SessionInterface class
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
