### PR TITLE
Fix API route names

### DIFF
--- a/src/Controller/Api/GroupController.php
+++ b/src/Controller/Api/GroupController.php
@@ -64,7 +64,7 @@ class GroupController
      *  output={"class"="Sonata\DatagridBundle\Pager\PagerInterface", "groups"={"sonata_api_read"}}
      * )
      *
-     * @Get("/groups")
+     * @Get("/groups", name="get_groups")
      *
      * @QueryParam(name="page", requirements="\d+", default="1", description="Page for groups list pagination (1-indexed)")
      * @QueryParam(name="count", requirements="\d+", default="10", description="Number of groups by page")
@@ -115,7 +115,7 @@ class GroupController
      *  }
      * )
      *
-     * @Get("/group/{id}")
+     * @Get("/group/{id}", name="get_group")
      *
      * @View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
@@ -140,7 +140,7 @@ class GroupController
      *  }
      * )
      *
-     * @Post("/group")
+     * @Post("/group", name="post_group")
      *
      * @param Request $request A Symfony request
      *
@@ -169,7 +169,7 @@ class GroupController
      *  }
      * )
      *
-     * @Put("/group/{id}")
+     * @Put("/group/{id}", name="put_group")
      *
      * @param int     $id      Group identifier
      * @param Request $request A Symfony request
@@ -197,7 +197,7 @@ class GroupController
      *  }
      * )
      *
-     * @Delete("/group/{id}")
+     * @Delete("/group/{id}", name="delete_group")
      *
      * @param int $id A Group identifier
      *

--- a/src/Controller/Api/UserController.php
+++ b/src/Controller/Api/UserController.php
@@ -68,7 +68,7 @@ class UserController
      *  output={"class"="Sonata\DatagridBundle\Pager\PagerInterface", "groups"={"sonata_api_read"}}
      * )
      *
-     * @Get("/users")
+     * @Get("/users", name="get_users")
      *
      * @QueryParam(name="page", requirements="\d+", default="1", description="Page for users list pagination (1-indexed)")
      * @QueryParam(name="count", requirements="\d+", default="10", description="Number of users by page")
@@ -119,7 +119,7 @@ class UserController
      *  }
      * )
      *
-     * @Get("/user/(id}")
+     * @Get("/user/(id}", name="get_user")
      *
      * @View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
@@ -144,7 +144,7 @@ class UserController
      *  }
      * )
      *
-     * @Post("/user")
+     * @Post("/user", name="post_user")
      *
      * @param Request $request A Symfony request
      *
@@ -173,7 +173,7 @@ class UserController
      *  }
      * )
      *
-     * @Put("/user/(id}")
+     * @Put("/user/(id}", name="put_user")
      *
      * @param int     $id      User id
      * @param Request $request A Symfony request
@@ -201,7 +201,7 @@ class UserController
      *  }
      * )
      *
-     * @Delete("/user/(id}")
+     * @Delete("/user/(id}", name="delete_user")
      *
      * @param int $id An User identifier
      *
@@ -234,7 +234,7 @@ class UserController
      *  }
      * )
      *
-     * @Post("/user/(userId}/{groupId}")
+     * @Post("/user/(userId}/{groupId}", name="post_user_group")
      *
      * @param int $userId  A User identifier
      * @param int $groupId A Group identifier
@@ -277,7 +277,7 @@ class UserController
      *  }
      * )
      *
-     * @Delete("/user/(userId}/{groupId}")
+     * @Delete("/user/(userId}/{groupId}", name="delete_user_group")
      *
      * @param int $userId  A User identifier
      * @param int $groupId A Group identifier

--- a/tests/Functional/Routing/RoutingTest.php
+++ b/tests/Functional/Routing/RoutingTest.php
@@ -41,18 +41,18 @@ final class RoutingTest extends WebTestCase
     public function getRoutes(): iterable
     {
         yield ['nelmio_api_doc_index', '/api/doc/{view}', ['GET']];
-        yield ['sonata_api_user_user_sonata_user_api_user_getusers', '/api/user/users', ['GET']];
-        yield ['sonata_api_user_user_sonata_user_api_user_getuser', '/api/user/user/(id}', ['GET']];
-        yield ['sonata_api_user_user_sonata_user_api_user_postuser', '/api/user/user', ['POST']];
-        yield ['sonata_api_user_user_sonata_user_api_user_putuser', '/api/user/user/(id}', ['PUT']];
-        yield ['sonata_api_user_user_sonata_user_api_user_deleteuser', '/api/user/user/(id}', ['DELETE']];
-        yield ['sonata_api_user_user_sonata_user_api_user_postusergroup', '/api/user/user/(userId}/{groupId}', ['POST']];
-        yield ['sonata_api_user_user_sonata_user_api_user_deleteusergroup', '/api/user/user/(userId}/{groupId}', ['DELETE']];
-        yield ['sonata_api_user_group_sonata_user_api_group_getgroups', '/api/user/groups', ['GET']];
-        yield ['sonata_api_user_group_sonata_user_api_group_getgroup', '/api/user/group/{id}', ['GET']];
-        yield ['sonata_api_user_group_sonata_user_api_group_postgroup', '/api/user/group', ['POST']];
-        yield ['sonata_api_user_group_sonata_user_api_group_putgroup', '/api/user/group/{id}', ['PUT']];
-        yield ['sonata_api_user_group_sonata_user_api_group_deletegroup', '/api/user/group/{id}', ['DELETE']];
+        yield ['sonata_api_user_user_get_users', '/api/user/users', ['GET']];
+        yield ['sonata_api_user_user_get_user', '/api/user/user/(id}', ['GET']];
+        yield ['sonata_api_user_user_post_user', '/api/user/user', ['POST']];
+        yield ['sonata_api_user_user_put_user', '/api/user/user/(id}', ['PUT']];
+        yield ['sonata_api_user_user_delete_user', '/api/user/user/(id}', ['DELETE']];
+        yield ['sonata_api_user_user_post_user_group', '/api/user/user/(userId}/{groupId}', ['POST']];
+        yield ['sonata_api_user_user_delete_user_group', '/api/user/user/(userId}/{groupId}', ['DELETE']];
+        yield ['sonata_api_user_group_get_groups', '/api/user/groups', ['GET']];
+        yield ['sonata_api_user_group_get_group', '/api/user/group/{id}', ['GET']];
+        yield ['sonata_api_user_group_post_group', '/api/user/group', ['POST']];
+        yield ['sonata_api_user_group_put_group', '/api/user/group/{id}', ['PUT']];
+        yield ['sonata_api_user_group_delete_group', '/api/user/group/{id}', ['DELETE']];
     }
 
     protected static function getKernelClass(): string


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Fix API route names in order to be consistent with the previous names (see https://github.com/sonata-project/dev-kit/issues/778#issuecomment-662596088).

The naming update was introduced at #1185.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/4.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Related to #1185.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataUserBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed API route names.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
