### PR TITLE
Fix passing "format" parameter to API routes

### DIFF
--- a/src/Controller/Api/GroupController.php
+++ b/src/Controller/Api/GroupController.php
@@ -30,9 +30,12 @@ use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Annotation\Route;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
+ *
+ * @Route(requirements={"_format": "json|xml|html"}, defaults={"_format": "json"})
  */
 class GroupController
 {
@@ -64,7 +67,7 @@ class GroupController
      *  output={"class"="Sonata\DatagridBundle\Pager\PagerInterface", "groups"={"sonata_api_read"}}
      * )
      *
-     * @Get("/groups", name="get_groups")
+     * @Get("/groups.{_format}", name="get_groups")
      *
      * @QueryParam(name="page", requirements="\d+", default="1", description="Page for groups list pagination (1-indexed)")
      * @QueryParam(name="count", requirements="\d+", default="10", description="Number of groups by page")
@@ -115,7 +118,7 @@ class GroupController
      *  }
      * )
      *
-     * @Get("/group/{id}", name="get_group")
+     * @Get("/group/{id}.{_format}", name="get_group")
      *
      * @View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
@@ -140,7 +143,7 @@ class GroupController
      *  }
      * )
      *
-     * @Post("/group", name="post_group")
+     * @Post("/group.{_format}", name="post_group")
      *
      * @param Request $request A Symfony request
      *
@@ -169,7 +172,7 @@ class GroupController
      *  }
      * )
      *
-     * @Put("/group/{id}", name="put_group")
+     * @Put("/group/{id}.{_format}", name="put_group")
      *
      * @param int     $id      Group identifier
      * @param Request $request A Symfony request
@@ -197,7 +200,7 @@ class GroupController
      *  }
      * )
      *
-     * @Delete("/group/{id}", name="delete_group")
+     * @Delete("/group/{id}.{_format}", name="delete_group")
      *
      * @param int $id A Group identifier
      *

--- a/src/Controller/Api/UserController.php
+++ b/src/Controller/Api/UserController.php
@@ -32,9 +32,12 @@ use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Annotation\Route;
 
 /**
  * @author Hugo Briand <briand@ekino.com>
+ *
+ * @Route(requirements={"_format": "json|xml|html"}, defaults={"_format": "json"})
  */
 class UserController
 {
@@ -68,7 +71,7 @@ class UserController
      *  output={"class"="Sonata\DatagridBundle\Pager\PagerInterface", "groups"={"sonata_api_read"}}
      * )
      *
-     * @Get("/users", name="get_users")
+     * @Get("/users.{_format}", name="get_users")
      *
      * @QueryParam(name="page", requirements="\d+", default="1", description="Page for users list pagination (1-indexed)")
      * @QueryParam(name="count", requirements="\d+", default="10", description="Number of users by page")
@@ -119,7 +122,7 @@ class UserController
      *  }
      * )
      *
-     * @Get("/user/(id}", name="get_user")
+     * @Get("/user/(id}.{_format}", name="get_user")
      *
      * @View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
@@ -144,7 +147,7 @@ class UserController
      *  }
      * )
      *
-     * @Post("/user", name="post_user")
+     * @Post("/user.{_format}", name="post_user")
      *
      * @param Request $request A Symfony request
      *
@@ -173,7 +176,7 @@ class UserController
      *  }
      * )
      *
-     * @Put("/user/(id}", name="put_user")
+     * @Put("/user/(id}.{_format}", name="put_user")
      *
      * @param int     $id      User id
      * @param Request $request A Symfony request
@@ -201,7 +204,7 @@ class UserController
      *  }
      * )
      *
-     * @Delete("/user/(id}", name="delete_user")
+     * @Delete("/user/(id}.{_format}", name="delete_user")
      *
      * @param int $id An User identifier
      *
@@ -234,7 +237,7 @@ class UserController
      *  }
      * )
      *
-     * @Post("/user/(userId}/{groupId}", name="post_user_group")
+     * @Post("/user/(userId}/{groupId}.{_format}", name="post_user_group")
      *
      * @param int $userId  A User identifier
      * @param int $groupId A Group identifier
@@ -277,7 +280,7 @@ class UserController
      *  }
      * )
      *
-     * @Delete("/user/(userId}/{groupId}", name="delete_user_group")
+     * @Delete("/user/(userId}/{groupId}.{_format}", name="delete_user_group")
      *
      * @param int $userId  A User identifier
      * @param int $groupId A Group identifier

--- a/tests/Functional/Routing/RoutingTest.php
+++ b/tests/Functional/Routing/RoutingTest.php
@@ -36,23 +36,57 @@ final class RoutingTest extends WebTestCase
         $this->assertNotNull($route);
         $this->assertSame($path, $route->getPath());
         $this->assertEmpty(array_diff($methods, $route->getMethods()));
+
+        $matchingPath = $path;
+        $matchingFormat = '';
+        if (false !== strpos($matchingPath, '.{_format}', -10)) {
+            $matchingFormat = '.json';
+            $matchingPath = str_replace('.{_format}', $matchingFormat, $path);
+        }
+
+        $matcher = $router->getMatcher();
+        $requestContext = $router->getContext();
+
+        foreach ($methods as $method) {
+            $requestContext->setMethod($method);
+
+            // Check paths like "/api/user/users.json".
+            $match = $matcher->match($matchingPath);
+
+            $this->assertSame($name, $match['_route']);
+
+            if ($matchingFormat) {
+                $this->assertSame(ltrim($matchingFormat, '.'), $match['_format']);
+            }
+
+            $matchingPathWithStrippedFormat = str_replace('.{_format}', '', $path);
+
+            // Check paths like "/api/user/users".
+            $match = $matcher->match($matchingPathWithStrippedFormat);
+
+            $this->assertSame($name, $match['_route']);
+
+            if ($matchingFormat) {
+                $this->assertSame(ltrim($matchingFormat, '.'), $match['_format']);
+            }
+        }
     }
 
     public function getRoutes(): iterable
     {
         yield ['nelmio_api_doc_index', '/api/doc/{view}', ['GET']];
-        yield ['sonata_api_user_user_get_users', '/api/user/users', ['GET']];
-        yield ['sonata_api_user_user_get_user', '/api/user/user/(id}', ['GET']];
-        yield ['sonata_api_user_user_post_user', '/api/user/user', ['POST']];
-        yield ['sonata_api_user_user_put_user', '/api/user/user/(id}', ['PUT']];
-        yield ['sonata_api_user_user_delete_user', '/api/user/user/(id}', ['DELETE']];
-        yield ['sonata_api_user_user_post_user_group', '/api/user/user/(userId}/{groupId}', ['POST']];
-        yield ['sonata_api_user_user_delete_user_group', '/api/user/user/(userId}/{groupId}', ['DELETE']];
-        yield ['sonata_api_user_group_get_groups', '/api/user/groups', ['GET']];
-        yield ['sonata_api_user_group_get_group', '/api/user/group/{id}', ['GET']];
-        yield ['sonata_api_user_group_post_group', '/api/user/group', ['POST']];
-        yield ['sonata_api_user_group_put_group', '/api/user/group/{id}', ['PUT']];
-        yield ['sonata_api_user_group_delete_group', '/api/user/group/{id}', ['DELETE']];
+        yield ['sonata_api_user_user_get_users', '/api/user/users.{_format}', ['GET']];
+        yield ['sonata_api_user_user_get_user', '/api/user/user/(id}.{_format}', ['GET']];
+        yield ['sonata_api_user_user_post_user', '/api/user/user.{_format}', ['POST']];
+        yield ['sonata_api_user_user_put_user', '/api/user/user/(id}.{_format}', ['PUT']];
+        yield ['sonata_api_user_user_delete_user', '/api/user/user/(id}.{_format}', ['DELETE']];
+        yield ['sonata_api_user_user_post_user_group', '/api/user/user/(userId}/{groupId}.{_format}', ['POST']];
+        yield ['sonata_api_user_user_delete_user_group', '/api/user/user/(userId}/{groupId}.{_format}', ['DELETE']];
+        yield ['sonata_api_user_group_get_groups', '/api/user/groups.{_format}', ['GET']];
+        yield ['sonata_api_user_group_get_group', '/api/user/group/{id}.{_format}', ['GET']];
+        yield ['sonata_api_user_group_post_group', '/api/user/group.{_format}', ['POST']];
+        yield ['sonata_api_user_group_put_group', '/api/user/group/{id}.{_format}', ['PUT']];
+        yield ['sonata_api_user_group_delete_group', '/api/user/group/{id}.{_format}', ['DELETE']];
     }
 
     protected static function getKernelClass(): string


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Fix passing "format" parameter to API routes.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/4.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Related to https://github.com/sonata-project/SonataMediaBundle/pull/1767#issuecomment-663496518.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataUserBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed passing "format' parameter to API routes.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
