### PR TITLE
Use service ids instead of controller paths at API routing config definitions

### DIFF
--- a/src/Resources/config/routing/api.xml
+++ b/src/Resources/config/routing/api.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <routes xmlns="http://symfony.com/schema/routing" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/routing https://symfony.com/schema/routing/routing-1.0.xsd">
-    <import resource="../../../Controller/Api/UserController.php" type="annotation" name-prefix="sonata_api_user_user_"/>
-    <import resource="../../../Controller/Api/GroupController.php" type="annotation" name-prefix="sonata_api_user_group_"/>
+    <import resource="Sonata\UserBundle\Controller\Api\UserController" type="annotation" name-prefix="sonata_api_user_user_"/>
+    <import resource="Sonata\UserBundle\Controller\Api\GroupController" type="annotation" name-prefix="sonata_api_user_group_"/>
 </routes>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Use service ids instead of controller paths at API routing config definitions.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/4.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this change respects BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataUserBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Changed API routing config definitions in order to use service ids instead of controller paths.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
