### PR TITLE
Fix deprecation messages in `AdminResettingController` and `AdminResettingController`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
         "sonata-project/doctrine-orm-admin-bundle": "^3.18",
         "sonata-project/google-authenticator": "^1.0 || ^2.0",
         "symfony/browser-kit": "^4.4 || ^5.1",
-        "symfony/phpunit-bridge": "^5.1"
+        "symfony/phpunit-bridge": "^5.1.1"
     },
     "suggest": {
         "friendsofsymfony/rest-bundle": "For using the public API methods.",

--- a/src/Controller/AdminResettingController.php
+++ b/src/Controller/AdminResettingController.php
@@ -13,13 +13,6 @@ declare(strict_types=1);
 
 namespace Sonata\UserBundle\Controller;
 
-// NEXT_MAJOR: remove this file
-@trigger_error(
-    'The '.__NAMESPACE__.'\AdminResettingController class is deprecated since version 4.3.0 and will be removed in 5.0.'
-    .' Use '.__NAMESPACE__.'\RequestAction, '.__NAMESPACE__.'\CheckEmailAction, '.__NAMESPACE__.'\ResetAction or '.__NAMESPACE__.'\SendEmailAction instead.',
-    E_USER_DEPRECATED
-);
-
 use Sonata\UserBundle\Action\CheckEmailAction;
 use Sonata\UserBundle\Action\RequestAction;
 use Sonata\UserBundle\Action\ResetAction;
@@ -27,6 +20,13 @@ use Sonata\UserBundle\Action\SendEmailAction;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+
+// NEXT_MAJOR: remove this file
+@trigger_error(
+    'The '.__NAMESPACE__.'\AdminResettingController class is deprecated since version 4.3.0 and will be removed in 5.0.'
+    .' Use '.RequestAction::class.', '.CheckEmailAction::class.', '.ResetAction::class.' or '.SendEmailAction::class.' instead.',
+    E_USER_DEPRECATED
+);
 
 class AdminResettingController extends Controller
 {

--- a/src/Controller/AdminSecurityController.php
+++ b/src/Controller/AdminSecurityController.php
@@ -13,19 +13,19 @@ declare(strict_types=1);
 
 namespace Sonata\UserBundle\Controller;
 
-// NEXT_MAJOR: remove this file
-@trigger_error(
-    'The '.__NAMESPACE__.'\AdminSecurityController class is deprecated since version 4.3.0 and will be removed in 5.0.'
-    .' Use '.__NAMESPACE__.'\CheckLoginAction, '.__NAMESPACE__.'\LoginAction or '.__NAMESPACE__.'\LogoutAction instead.',
-    E_USER_DEPRECATED
-);
-
 use Sonata\UserBundle\Action\CheckLoginAction;
 use Sonata\UserBundle\Action\LoginAction;
 use Sonata\UserBundle\Action\LogoutAction;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+
+// NEXT_MAJOR: remove this file
+@trigger_error(
+    'The '.__NAMESPACE__.'\AdminSecurityController class is deprecated since version 4.3.0 and will be removed in 5.0.'
+    .' Use '.CheckLoginAction::class.', '.LoginAction::class.' or '.LogoutAction::class.' instead.',
+    E_USER_DEPRECATED
+);
 
 class AdminSecurityController extends Controller
 {

--- a/tests/Controller/AdminResettingControllerTest.php
+++ b/tests/Controller/AdminResettingControllerTest.php
@@ -75,7 +75,7 @@ class AdminResettingControllerTest extends TestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation The Sonata\UserBundle\Controller\AdminResettingController class is deprecated since version 4.3.0 and will be removed in 5.0. Use Sonata\UserBundle\Controller\RequestAction, Sonata\UserBundle\Controller\CheckEmailAction, Sonata\UserBundle\Controller\ResetAction or Sonata\UserBundle\Controller\SendEmailAction instead.
+     * @expectedDeprecation The Sonata\UserBundle\Controller\AdminResettingController class is deprecated since version 4.3.0 and will be removed in 5.0. Use Sonata\UserBundle\Action\RequestAction, Sonata\UserBundle\Action\CheckEmailAction, Sonata\UserBundle\Action\ResetAction or Sonata\UserBundle\Action\SendEmailAction instead.
      */
     public function testCheckEmailAction(): void
     {

--- a/tests/Controller/AdminResettingControllerTest.php
+++ b/tests/Controller/AdminResettingControllerTest.php
@@ -20,12 +20,15 @@ use Sonata\UserBundle\Action\RequestAction;
 use Sonata\UserBundle\Action\ResetAction;
 use Sonata\UserBundle\Action\SendEmailAction;
 use Sonata\UserBundle\Controller\AdminResettingController;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 class AdminResettingControllerTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     /**
      * @var RequestStack|MockObject
      */
@@ -75,7 +78,6 @@ class AdminResettingControllerTest extends TestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation The Sonata\UserBundle\Controller\AdminResettingController class is deprecated since version 4.3.0 and will be removed in 5.0. Use Sonata\UserBundle\Action\RequestAction, Sonata\UserBundle\Action\CheckEmailAction, Sonata\UserBundle\Action\ResetAction or Sonata\UserBundle\Action\SendEmailAction instead.
      */
     public function testCheckEmailAction(): void
     {
@@ -85,7 +87,14 @@ class AdminResettingControllerTest extends TestCase
             ->method('getCurrentRequest')
             ->willReturn($request);
 
+        $this->expectDeprecation(
+            'The Sonata\UserBundle\Controller\AdminResettingController class is deprecated since version 4.3.0'
+            .' and will be removed in 5.0. Use Sonata\UserBundle\Action\RequestAction, Sonata\UserBundle\Action\CheckEmailAction'
+            .', Sonata\UserBundle\Action\ResetAction or Sonata\UserBundle\Action\SendEmailAction instead.'
+        );
+
         $controller = $this->getController();
+
         $result = $controller->checkEmailAction($request);
 
         $this->assertSame('ok', $result);

--- a/tests/Controller/AdminSecurityControllerTest.php
+++ b/tests/Controller/AdminSecurityControllerTest.php
@@ -67,7 +67,7 @@ class AdminSecurityControllerTest extends TestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation The Sonata\UserBundle\Controller\AdminSecurityController class is deprecated since version 4.3.0 and will be removed in 5.0. Use Sonata\UserBundle\Controller\CheckLoginAction, Sonata\UserBundle\Controller\LoginAction or Sonata\UserBundle\Controller\LogoutAction instead.
+     * @expectedDeprecation The Sonata\UserBundle\Controller\AdminSecurityController class is deprecated since version 4.3.0 and will be removed in 5.0. Use Sonata\UserBundle\Action\CheckLoginAction, Sonata\UserBundle\Action\LoginAction or Sonata\UserBundle\Action\LogoutAction instead.
      */
     public function testLogoutAction(): void
     {

--- a/tests/Controller/AdminSecurityControllerTest.php
+++ b/tests/Controller/AdminSecurityControllerTest.php
@@ -19,12 +19,15 @@ use Sonata\UserBundle\Action\CheckLoginAction;
 use Sonata\UserBundle\Action\LoginAction;
 use Sonata\UserBundle\Action\LogoutAction;
 use Sonata\UserBundle\Controller\AdminSecurityController;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 class AdminSecurityControllerTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     /**
      * @var TestSecurityAction
      */
@@ -67,10 +70,15 @@ class AdminSecurityControllerTest extends TestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation The Sonata\UserBundle\Controller\AdminSecurityController class is deprecated since version 4.3.0 and will be removed in 5.0. Use Sonata\UserBundle\Action\CheckLoginAction, Sonata\UserBundle\Action\LoginAction or Sonata\UserBundle\Action\LogoutAction instead.
      */
     public function testLogoutAction(): void
     {
+        $this->expectDeprecation(
+            'The Sonata\UserBundle\Controller\AdminSecurityController class is deprecated since version 4.3.0'
+            .' and will be removed in 5.0. Use Sonata\UserBundle\Action\CheckLoginAction, Sonata\UserBundle\Action\LoginAction'
+            .' or Sonata\UserBundle\Action\LogoutAction instead.'
+        );
+
         $controller = $this->getController();
         $controller->logoutAction();
     }

--- a/tests/DependencyInjection/SonataUserExtensionTest.php
+++ b/tests/DependencyInjection/SonataUserExtensionTest.php
@@ -24,6 +24,7 @@ use Sonata\UserBundle\Tests\Admin\Document\GroupAdmin;
 use Sonata\UserBundle\Tests\Admin\Document\UserAdmin;
 use Sonata\UserBundle\Tests\Document\Group;
 use Sonata\UserBundle\Tests\Document\User;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Bundle\TwigBundle\DependencyInjection\TwigExtension;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -34,6 +35,8 @@ use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
  */
 final class SonataUserExtensionTest extends AbstractExtensionTestCase
 {
+    use ExpectDeprecationTrait;
+
     /**
      * {@inheritdoc}
      */
@@ -49,10 +52,11 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
      */
     public function testLoadDefault(): void
     {
+        $this->expectDeprecation('The \'Google\Authenticator\' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.');
+
         $this->load();
 
         $this->assertContainerBuilderHasAlias(
@@ -90,7 +94,6 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
      */
     public function testTwigConfigParameterIsSet(): void
     {
@@ -103,6 +106,8 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
             ->willReturn('twig');
 
         $this->container->registerExtension($fakeTwigExtension);
+
+        $this->expectDeprecation('The \'Google\Authenticator\' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.');
 
         $this->load();
 
@@ -118,10 +123,11 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
      */
     public function testTwigConfigParameterIsNotSet(): void
     {
+        $this->expectDeprecation('The \'Google\Authenticator\' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.');
+
         $this->load();
 
         $twigConfigurations = $this->container->getExtensionConfig('twig');
@@ -131,37 +137,41 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
      */
     public function testCorrectModelClass(): void
     {
+        $this->expectDeprecation('The \'Google\Authenticator\' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.');
+
         $this->load(['class' => ['user' => \Sonata\UserBundle\Tests\Entity\User::class]]);
     }
 
     /**
      * @group legacy
-     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
      */
     public function testCorrectModelClassWithLeadingSlash(): void
     {
+        $this->expectDeprecation('The \'Google\Authenticator\' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.');
+
         $this->load(['class' => ['user' => \Sonata\UserBundle\Tests\Entity\User::class]]);
     }
 
     /**
      * @group legacy
-     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
      */
     public function testCorrectAdminClass(): void
     {
+        $this->expectDeprecation('The \'Google\Authenticator\' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.');
+
         $this->load(['admin' => ['user' => ['class' => \Sonata\UserBundle\Tests\Admin\Entity\UserAdmin::class]]]);
     }
 
     /**
      * @group legacy
-     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
      */
     public function testCorrectModelClassWithNotDefaultManagerType(): void
     {
+        $this->expectDeprecation('The \'Google\Authenticator\' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.');
+
         $this->load([
             'manager_type' => 'mongodb',
             'class' => [
@@ -177,10 +187,11 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
      */
     public function testFosUserBundleModelClasses(): void
     {
+        $this->expectDeprecation('The \'Google\Authenticator\' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.');
+
         $this->load(['manager_type' => 'orm', 'class' => [
             'user' => UserInterface::class,
             'group' => GroupInterface::class,
@@ -189,7 +200,6 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
      */
     public function testNotCorrespondingUserClass(): void
     {
@@ -199,12 +209,13 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
             'Model class "Sonata\UserBundle\Entity\BaseUser" does not correspond to manager type "mongodb".'
         );
 
+        $this->expectDeprecation('The \'Google\Authenticator\' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.');
+
         $this->load(['manager_type' => 'mongodb', 'class' => ['user' => \Sonata\UserBundle\Entity\BaseUser::class]]);
     }
 
     /**
      * @group legacy
-     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
      */
     public function testNotCorrespondingGroupClass(): void
     {
@@ -214,6 +225,8 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
             'Model class "Sonata\UserBundle\Entity\BaseGroup" does not correspond to manager type "mongodb".'
         );
 
+        $this->expectDeprecation('The \'Google\Authenticator\' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.');
+
         $this->load(['manager_type' => 'mongodb', 'class' => [
             'user' => BaseUser::class,
             'group' => BaseGroup::class,
@@ -222,10 +235,11 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
      */
     public function testConfigureGoogleAuthenticatorDisabled(): void
     {
+        $this->expectDeprecation('The \'Google\Authenticator\' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.');
+
         $this->load(['google_authenticator' => ['enabled' => false]]);
 
         $this->assertContainerBuilderHasParameter('sonata.user.google.authenticator.enabled', false);
@@ -237,10 +251,11 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
      */
     public function testConfigureGoogleAuthenticatorEnabled(): void
     {
+        $this->expectDeprecation('The \'Google\Authenticator\' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.');
+
         $this->load(['google_authenticator' => ['enabled' => true, 'forced_for_role' => ['ROLE_USER'], 'ip_white_list' => ['0.0.0.1'],
                                                 'server' => 'bar', ]]);
 
@@ -256,10 +271,11 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
      */
     public function testMailerConfigParameterIfNotSet(): void
     {
+        $this->expectDeprecation('The \'Google\Authenticator\' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.');
+
         $this->load();
 
         $this->assertContainerBuilderHasAlias('sonata.user.mailer', 'sonata.user.mailer.default');
@@ -267,10 +283,11 @@ final class SonataUserExtensionTest extends AbstractExtensionTestCase
 
     /**
      * @group legacy
-     * @expectedDeprecation The 'Google\Authenticator' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.
      */
     public function testMailerConfigParameter(): void
     {
+        $this->expectDeprecation('The \'Google\Authenticator\' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.');
+
         $this->load(['mailer' => 'custom.mailer.service.id']);
 
         $this->assertContainerBuilderHasAlias('sonata.user.mailer', 'custom.mailer.service.id');


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Fix deprecation messages in `AdminResettingController` and `AdminResettingController`, since currently they are making references to non existing classes.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/4.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
