### PR TITLE
Removed config line causing issue on google authenticator

### DIFF
--- a/src/Resources/config/google_authenticator.xml
+++ b/src/Resources/config/google_authenticator.xml
@@ -19,8 +19,6 @@
             <tag name="kernel.event_listener" event="kernel.request" method="onCoreRequest" priority="-1"/>
             <argument type="service" id="sonata.user.google.authenticator.provider"/>
             <argument type="service" id="security.token_storage"/>
-            <!-- NEXT_MAJOR: Remove "sonata.templating" argument -->
-            <argument type="service" id="sonata.templating" on-invalid="null"/>
             <argument type="service" id="twig"/>
         </service>
         <service id="sonata.user.google.authenticator.success_handler" class="Sonata\UserBundle\EventListener\TwoFactorLoginSuccessHandler" public="false">


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
This fixes the following error:
Stop sonata-project/google-authenticator throwing this exception: Exception thrown when handling an exception (ErrorException: Warning: get_class() expects parameter 1 to be object, null given at /sonata-project/user-bundle/src/GoogleAuthenticator/RequestListener.php line 77

## Changelog

```markdown

### Fixed
- Removed sonata.templating argument from google_authenticator.xml
```
