### PR TITLE
Fix REST API routing paths

### DIFF
--- a/UPGRADE-4.x.md
+++ b/UPGRADE-4.x.md
@@ -1,12 +1,23 @@
 UPGRADE 4.x
 ===========
 
-UPGRADE FROM 3.x to 3.x
+UPGRADE FROM 4.x to 4.x
 =======================
 
 ### Support for NelmioApiDocBundle > 3.6 is added
 
 Controllers for NelmioApiDocBundle v2 were moved under `Sonata\UserBundle\Controller\Api\Legacy\` namespace and controllers for NelmioApiDocBundle v3 were added as replacement. If you extend them, you must ensure they are using the corresponding inheritance.
+
+### Fix REST API routing paths
+
+In version 4.6.0 some extra REST API routes were added by mistake, creating new duplicated paths pointing to existing actions (by instance `/groups/{id}.{_format}` was duplicated as `/group/{id}.{_format}`, `/users/{id}.{_format}` was duplicated as `/user/{id}.{_format}`, etc).
+You MUST avoid importing these routes in order to keep your API routing clean and consistent with previous versions. To do so, make sure to import some of these routing files, depending on your needs:
+
+    sonata_api_user:
+        prefix: /api/user
+        resource: "@SonataUserBundle/Resources/config/routing/standard_api.xml"
+        # or for NelmioApiDocBundle v3
+        #resource: "@SonataUserBundle/Resources/config/routing/standard_api_nelmio_v3.xml"
 
 UPGRADE FROM 4.6 to 4.7
 ========================

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -47,7 +47,7 @@ In order to activate the API's, you'll also need to add this to your routing:
 
     sonata_api_user:
         prefix: /api/user
-        resource: "@SonataUserBundle/Resources/config/routing/api_nelmio_v3.xml"
+        resource: "@SonataUserBundle/Resources/config/routing/standard_api_nelmio_v3.xml"
 
 Serialization
 -------------

--- a/src/Resources/config/routing/api.xml
+++ b/src/Resources/config/routing/api.xml
@@ -1,39 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <routes xmlns="http://symfony.com/schema/routing" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/routing https://symfony.com/schema/routing/routing-1.0.xsd">
-    <route id="sonata_api_user_group_delete_group" path="/group/{id}.{_format}" methods="DELETE" controller="Sonata\UserBundle\Controller\Api\GroupController::deleteGroupAction" format="json">
+    <import type="xml" resource="./api/group.xml" name-prefix="sonata_api_user_group_"/>
+    <import type="xml" resource="./api/user.xml" name-prefix="sonata_api_user_user_"/>
+    <!-- NEXT_MAJOR: Remove these wrong routes introduced in version 4.6.0 -->
+    <route id="sonata_api_user_group_delete_group_2" path="/group/{id}.{_format}" methods="DELETE" controller="Sonata\UserBundle\Controller\Api\Legacy\GroupController::deleteGroupAction" format="json">
         <requirement key="_format">json|xml|html</requirement>
     </route>
-    <route id="sonata_api_user_group_get_group" path="/group/{id}.{_format}" methods="GET" controller="Sonata\UserBundle\Controller\Api\Legacy\GroupController::getGroupAction" format="json">
+    <route id="sonata_api_user_group_get_group_2" path="/group/{id}.{_format}" methods="GET" controller="Sonata\UserBundle\Controller\Api\Legacy\GroupController::getGroupAction" format="json">
         <requirement key="_format">json|xml|html</requirement>
     </route>
-    <route id="sonata_api_user_group_get_groups" path="/groups.{_format}" methods="GET" controller="Sonata\UserBundle\Controller\Api\Legacy\GroupController::getGroupsAction" format="json">
+    <route id="sonata_api_user_group_post_group_2" path="/group.{_format}" methods="POST" controller="Sonata\UserBundle\Controller\Api\Legacy\GroupController::postGroupAction" format="json">
         <requirement key="_format">json|xml|html</requirement>
     </route>
-    <route id="sonata_api_user_group_post_group" path="/group.{_format}" methods="POST" controller="Sonata\UserBundle\Controller\Api\Legacy\GroupController::postGroupAction" format="json">
+    <route id="sonata_api_user_group_put_group_2" path="/group/{id}.{_format}" methods="PUT" controller="Sonata\UserBundle\Controller\Api\Legacy\GroupController::putGroupAction" format="json">
         <requirement key="_format">json|xml|html</requirement>
     </route>
-    <route id="sonata_api_user_group_put_group" path="/group/{id}.{_format}" methods="PUT" controller="Sonata\UserBundle\Controller\Api\Legacy\GroupController::putGroupAction" format="json">
+    <route id="sonata_api_user_user_delete_user_2" path="/user/{id}.{_format}" methods="DELETE" controller="Sonata\UserBundle\Controller\Api\Legacy\UserController::deleteUserAction" format="json">
         <requirement key="_format">json|xml|html</requirement>
     </route>
-    <route id="sonata_api_user_user_delete_user" path="/user/{id}.{_format}" methods="DELETE" controller="Sonata\UserBundle\Controller\Api\Legacy\UserController::deleteUserAction" format="json">
+    <route id="sonata_api_user_user_delete_user_group_2" path="/user/{userId}/{groupId}.{_format}" methods="DELETE" controller="Sonata\UserBundle\Controller\Api\Legacy\UserController::deleteUserGroupAction" format="json">
         <requirement key="_format">json|xml|html</requirement>
     </route>
-    <route id="sonata_api_user_user_delete_user_group" path="/user/{userId}/{groupId}.{_format}" methods="DELETE" controller="Sonata\UserBundle\Controller\Api\Legacy\UserController::deleteUserGroupAction" format="json">
+    <route id="sonata_api_user_user_get_user_2" path="/user/{id}.{_format}" methods="GET" controller="Sonata\UserBundle\Controller\Api\Legacy\UserController::getUserAction" format="json">
         <requirement key="_format">json|xml|html</requirement>
     </route>
-    <route id="sonata_api_user_user_get_user" path="/user/{id}.{_format}" methods="GET" controller="Sonata\UserBundle\Controller\Api\Legacy\UserController::getUserAction" format="json">
+    <route id="sonata_api_user_user_post_user_2" path="/user.{_format}" methods="POST" controller="Sonata\UserBundle\Controller\Api\Legacy\UserController::postUserAction" format="json">
         <requirement key="_format">json|xml|html</requirement>
     </route>
-    <route id="sonata_api_user_user_get_users" path="/users.{_format}" methods="GET" controller="Sonata\UserBundle\Controller\Api\Legacy\UserController::getUsersAction" format="json">
+    <route id="sonata_api_user_user_post_user_group_2" path="/user/{userId}/{groupId}.{_format}" methods="POST" controller="Sonata\UserBundle\Controller\Legacy\Api\UserController::postUserGroupAction" format="json">
         <requirement key="_format">json|xml|html</requirement>
     </route>
-    <route id="sonata_api_user_user_post_user" path="/user.{_format}" methods="POST" controller="Sonata\UserBundle\Controller\Api\Legacy\UserController::postUsersAction" format="json">
-        <requirement key="_format">json|xml|html</requirement>
-    </route>
-    <route id="sonata_api_user_user_post_user_group" path="/user/{userId}/{groupId}.{_format}" methods="POST" controller="Sonata\UserBundle\Controller\Legacy\Api\UserController::postUserGroupAction" format="json">
-        <requirement key="_format">json|xml|html</requirement>
-    </route>
-    <route id="sonata_api_user_user_put_user" path="/user/{id}.{_format}" methods="PUT" controller="Sonata\UserBundle\Controller\Api\Legacy\UserController::putUsersAction" format="json">
+    <route id="sonata_api_user_user_put_user_2" path="/user/{id}.{_format}" methods="PUT" controller="Sonata\UserBundle\Controller\Api\Legacy\UserController::putUserAction" format="json">
         <requirement key="_format">json|xml|html</requirement>
     </route>
 </routes>

--- a/src/Resources/config/routing/api/group.xml
+++ b/src/Resources/config/routing/api/group.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<routes xmlns="http://symfony.com/schema/routing" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/routing https://symfony.com/schema/routing/routing-1.0.xsd">
+    <route id="delete_group" path="/groups/{id}.{_format}" methods="DELETE" controller="Sonata\UserBundle\Controller\Api\Legacy\GroupController::deleteGroupAction" format="json">
+        <requirement key="_format">json|xml|html</requirement>
+    </route>
+    <route id="get_group" path="/groups/{id}.{_format}" methods="GET" controller="Sonata\UserBundle\Controller\Api\Legacy\GroupController::getGroupAction" format="json">
+        <requirement key="_format">json|xml|html</requirement>
+    </route>
+    <route id="get_groups" path="/groups.{_format}" methods="GET" controller="Sonata\UserBundle\Controller\Api\Legacy\GroupController::getGroupsAction" format="json">
+        <requirement key="_format">json|xml|html</requirement>
+    </route>
+    <route id="post_group" path="/groups.{_format}" methods="POST" controller="Sonata\UserBundle\Controller\Api\Legacy\GroupController::postGroupAction" format="json">
+        <requirement key="_format">json|xml|html</requirement>
+    </route>
+    <route id="put_group" path="/groups/{id}.{_format}" methods="PUT" controller="Sonata\UserBundle\Controller\Api\Legacy\GroupController::putGroupAction" format="json">
+        <requirement key="_format">json|xml|html</requirement>
+    </route>
+</routes>

--- a/src/Resources/config/routing/api/user.xml
+++ b/src/Resources/config/routing/api/user.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<routes xmlns="http://symfony.com/schema/routing" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/routing https://symfony.com/schema/routing/routing-1.0.xsd">
+    <route id="delete_user" path="/users/{id}.{_format}" methods="DELETE" controller="Sonata\UserBundle\Controller\Api\Legacy\UserController::deleteUserAction" format="json">
+        <requirement key="_format">json|xml|html</requirement>
+    </route>
+    <route id="delete_user_group" path="/users/{userId}/groups/{groupId}.{_format}" methods="DELETE" controller="Sonata\UserBundle\Controller\Api\Legacy\UserController::deleteUserGroupAction" format="json">
+        <requirement key="_format">json|xml|html</requirement>
+    </route>
+    <route id="get_user" path="/users/{id}.{_format}" methods="GET" controller="Sonata\UserBundle\Controller\Api\Legacy\UserController::getUserAction" format="json">
+        <requirement key="_format">json|xml|html</requirement>
+    </route>
+    <route id="get_users" path="/users.{_format}" methods="GET" controller="Sonata\UserBundle\Controller\Api\Legacy\UserController::getUsersAction" format="json">
+        <requirement key="_format">json|xml|html</requirement>
+    </route>
+    <route id="post_user" path="/users.{_format}" methods="POST" controller="Sonata\UserBundle\Controller\Api\Legacy\UserController::putUserAction" format="json">
+        <requirement key="_format">json|xml|html</requirement>
+    </route>
+    <route id="post_user_group" path="/users/{userId}/groups/{groupId}.{_format}" methods="POST" controller="Sonata\UserBundle\Controller\Legacy\Api\UserController::postUserGroupAction" format="json">
+        <requirement key="_format">json|xml|html</requirement>
+    </route>
+    <route id="put_user" path="/users/{id}.{_format}" methods="PUT" controller="Sonata\UserBundle\Controller\Api\Legacy\UserController::putUserAction" format="json">
+        <requirement key="_format">json|xml|html</requirement>
+    </route>
+</routes>

--- a/src/Resources/config/routing/api_nelmio3/group.xml
+++ b/src/Resources/config/routing/api_nelmio3/group.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<routes xmlns="http://symfony.com/schema/routing" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/routing https://symfony.com/schema/routing/routing-1.0.xsd">
+    <route id="delete_group" path="/groups/{id}.{_format}" methods="DELETE" controller="Sonata\UserBundle\Controller\Api\GroupController::deleteGroupAction" format="json">
+        <requirement key="_format">json|xml|html</requirement>
+    </route>
+    <route id="get_group" path="/groups/{id}.{_format}" methods="GET" controller="Sonata\UserBundle\Controller\Api\GroupController::getGroupAction" format="json">
+        <requirement key="_format">json|xml|html</requirement>
+    </route>
+    <route id="get_groups" path="/groups.{_format}" methods="GET" controller="Sonata\UserBundle\Controller\Api\GroupController::getGroupsAction" format="json">
+        <requirement key="_format">json|xml|html</requirement>
+    </route>
+    <route id="post_group" path="/groups.{_format}" methods="POST" controller="Sonata\UserBundle\Controller\Api\GroupController::postGroupAction" format="json">
+        <requirement key="_format">json|xml|html</requirement>
+    </route>
+    <route id="put_group" path="/groups/{id}.{_format}" methods="PUT" controller="Sonata\UserBundle\Controller\Api\GroupController::putGroupAction" format="json">
+        <requirement key="_format">json|xml|html</requirement>
+    </route>
+</routes>

--- a/src/Resources/config/routing/api_nelmio3/user.xml
+++ b/src/Resources/config/routing/api_nelmio3/user.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<routes xmlns="http://symfony.com/schema/routing" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/routing https://symfony.com/schema/routing/routing-1.0.xsd">
+    <route id="delete_user" path="/users/{id}.{_format}" methods="DELETE" controller="Sonata\UserBundle\Controller\Api\UserController::deleteUserAction" format="json">
+        <requirement key="_format">json|xml|html</requirement>
+    </route>
+    <route id="delete_user_group" path="/users/{userId}/groups/{groupId}.{_format}" methods="DELETE" controller="Sonata\UserBundle\Controller\Api\UserController::deleteUserGroupAction" format="json">
+        <requirement key="_format">json|xml|html</requirement>
+    </route>
+    <route id="get_user" path="/users/{id}.{_format}" methods="GET" controller="Sonata\UserBundle\Controller\Api\UserController::getUserAction" format="json">
+        <requirement key="_format">json|xml|html</requirement>
+    </route>
+    <route id="get_users" path="/users.{_format}" methods="GET" controller="Sonata\UserBundle\Controller\Api\UserController::getUsersAction" format="json">
+        <requirement key="_format">json|xml|html</requirement>
+    </route>
+    <route id="post_user" path="/users.{_format}" methods="POST" controller="Sonata\UserBundle\Controller\Api\UserController::postUserAction" format="json">
+        <requirement key="_format">json|xml|html</requirement>
+    </route>
+    <route id="post_user_group" path="/users/{userId}/groups/{groupId}.{_format}" methods="POST" controller="Sonata\UserBundle\Controller\Api\UserController::postUserGroupAction" format="json">
+        <requirement key="_format">json|xml|html</requirement>
+    </route>
+    <route id="put_user" path="/users/{id}.{_format}" methods="PUT" controller="Sonata\UserBundle\Controller\Api\UserController::putUserAction" format="json">
+        <requirement key="_format">json|xml|html</requirement>
+    </route>
+</routes>

--- a/src/Resources/config/routing/api_nelmio_v3.xml
+++ b/src/Resources/config/routing/api_nelmio_v3.xml
@@ -1,39 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <routes xmlns="http://symfony.com/schema/routing" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/routing https://symfony.com/schema/routing/routing-1.0.xsd">
-    <route id="sonata_api_user_group_delete_group" path="/group/{id}.{_format}" methods="DELETE" controller="Sonata\UserBundle\Controller\Api\GroupController::deleteGroupAction" format="json">
+    <import type="xml" resource="./api_nelmio3/group.xml" name-prefix="sonata_api_user_group_"/>
+    <import type="xml" resource="./api_nelmio3/user.xml" name-prefix="sonata_api_user_user_"/>
+    <!-- NEXT_MAJOR: Remove these wrong routes introduced in version 4.6.0 -->
+    <route id="sonata_api_user_group_delete_group_2" path="/group/{id}.{_format}" methods="DELETE" controller="Sonata\UserBundle\Controller\Api\GroupController::deleteGroupAction" format="json">
         <requirement key="_format">json|xml|html</requirement>
     </route>
-    <route id="sonata_api_user_group_get_group" path="/group/{id}.{_format}" methods="GET" controller="Sonata\UserBundle\Controller\Api\GroupController::getGroupAction" format="json">
+    <route id="sonata_api_user_group_get_group_2" path="/group/{id}.{_format}" methods="GET" controller="Sonata\UserBundle\Controller\Api\GroupController::getGroupAction" format="json">
         <requirement key="_format">json|xml|html</requirement>
     </route>
-    <route id="sonata_api_user_group_get_groups" path="/groups.{_format}" methods="GET" controller="Sonata\UserBundle\Controller\Api\GroupController::getGroupsAction" format="json">
+    <route id="sonata_api_user_group_post_group_2" path="/group.{_format}" methods="POST" controller="Sonata\UserBundle\Controller\Api\GroupController::postGroupAction" format="json">
         <requirement key="_format">json|xml|html</requirement>
     </route>
-    <route id="sonata_api_user_group_post_group" path="/group.{_format}" methods="POST" controller="Sonata\UserBundle\Controller\Api\GroupController::postGroupAction" format="json">
+    <route id="sonata_api_user_group_put_group_2" path="/group/{id}.{_format}" methods="PUT" controller="Sonata\UserBundle\Controller\Api\GroupController::putGroupAction" format="json">
         <requirement key="_format">json|xml|html</requirement>
     </route>
-    <route id="sonata_api_user_group_put_group" path="/group/{id}.{_format}" methods="PUT" controller="Sonata\UserBundle\Controller\Api\GroupController::putGroupAction" format="json">
+    <route id="sonata_api_user_user_delete_user_2" path="/user/{id}.{_format}" methods="DELETE" controller="Sonata\UserBundle\Controller\Api\UserController::deleteUserAction" format="json">
         <requirement key="_format">json|xml|html</requirement>
     </route>
-    <route id="sonata_api_user_user_delete_user" path="/user/{id}.{_format}" methods="DELETE" controller="Sonata\UserBundle\Controller\Api\UserController::deleteUserAction" format="json">
+    <route id="sonata_api_user_user_delete_user_group_2" path="/user/{userId}/{groupId}.{_format}" methods="DELETE" controller="Sonata\UserBundle\Controller\Api\UserController::deleteUserGroupAction" format="json">
         <requirement key="_format">json|xml|html</requirement>
     </route>
-    <route id="sonata_api_user_user_delete_user_group" path="/user/{userId}/{groupId}.{_format}" methods="DELETE" controller="Sonata\UserBundle\Controller\Api\UserController::deleteUserGroupAction" format="json">
+    <route id="sonata_api_user_user_get_user_2" path="/user/{id}.{_format}" methods="GET" controller="Sonata\UserBundle\Controller\Api\UserController::getUserAction" format="json">
         <requirement key="_format">json|xml|html</requirement>
     </route>
-    <route id="sonata_api_user_user_get_user" path="/user/{id}.{_format}" methods="GET" controller="Sonata\UserBundle\Controller\Api\UserController::getUserAction" format="json">
+    <route id="sonata_api_user_user_post_user_2" path="/user.{_format}" methods="POST" controller="Sonata\UserBundle\Controller\Api\UserController::postUserAction" format="json">
         <requirement key="_format">json|xml|html</requirement>
     </route>
-    <route id="sonata_api_user_user_get_users" path="/users.{_format}" methods="GET" controller="Sonata\UserBundle\Controller\Api\UserController::getUsersAction" format="json">
+    <route id="sonata_api_user_user_post_user_group_2" path="/user/{userId}/{groupId}.{_format}" methods="POST" controller="Sonata\UserBundle\Controller\Api\UserController::postUserGroupAction" format="json">
         <requirement key="_format">json|xml|html</requirement>
     </route>
-    <route id="sonata_api_user_user_post_user" path="/user.{_format}" methods="POST" controller="Sonata\UserBundle\Controller\Api\UserController::postUsersAction" format="json">
-        <requirement key="_format">json|xml|html</requirement>
-    </route>
-    <route id="sonata_api_user_user_post_user_group" path="/user/{userId}/{groupId}.{_format}" methods="POST" controller="Sonata\UserBundle\Controller\Api\UserController::postUserGroupAction" format="json">
-        <requirement key="_format">json|xml|html</requirement>
-    </route>
-    <route id="sonata_api_user_user_put_user" path="/user/{id}.{_format}" methods="PUT" controller="Sonata\UserBundle\Controller\Api\UserController::putUsersAction" format="json">
+    <route id="sonata_api_user_user_put_user_2" path="/user/{id}.{_format}" methods="PUT" controller="Sonata\UserBundle\Controller\Api\UserController::putUserAction" format="json">
         <requirement key="_format">json|xml|html</requirement>
     </route>
 </routes>

--- a/src/Resources/config/routing/standard_api.xml
+++ b/src/Resources/config/routing/standard_api.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<routes xmlns="http://symfony.com/schema/routing" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/routing https://symfony.com/schema/routing/routing-1.0.xsd">
+    <import type="xml" resource="./api/group.xml" name-prefix="sonata_api_user_group_"/>
+    <import type="xml" resource="./api/user.xml" name-prefix="sonata_api_user_user_"/>
+</routes>

--- a/src/Resources/config/routing/standard_api_nelmio_v3.xml
+++ b/src/Resources/config/routing/standard_api_nelmio_v3.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<routes xmlns="http://symfony.com/schema/routing" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/routing https://symfony.com/schema/routing/routing-1.0.xsd">
+    <import type="xml" resource="./api_nelmio3/group.xml" name-prefix="sonata_api_user_group_"/>
+    <import type="xml" resource="./api_nelmio3/user.xml" name-prefix="sonata_api_user_user_"/>
+</routes>

--- a/tests/Functional/Routing/RoutingTest.php
+++ b/tests/Functional/Routing/RoutingTest.php
@@ -85,19 +85,19 @@ final class RoutingTest extends WebTestCase
 
         // API - User
         yield ['sonata_api_user_user_get_users', '/api/user/users.{_format}', ['GET']];
-        yield ['sonata_api_user_user_get_user', '/api/user/user/{id}.{_format}', ['GET']];
-        yield ['sonata_api_user_user_post_user', '/api/user/user.{_format}', ['POST']];
-        yield ['sonata_api_user_user_put_user', '/api/user/user/{id}.{_format}', ['PUT']];
-        yield ['sonata_api_user_user_delete_user', '/api/user/user/{id}.{_format}', ['DELETE']];
-        yield ['sonata_api_user_user_post_user_group', '/api/user/user/{userId}/{groupId}.{_format}', ['POST']];
-        yield ['sonata_api_user_user_delete_user_group', '/api/user/user/{userId}/{groupId}.{_format}', ['DELETE']];
+        yield ['sonata_api_user_user_get_user', '/api/user/users/{id}.{_format}', ['GET']];
+        yield ['sonata_api_user_user_post_user', '/api/user/users.{_format}', ['POST']];
+        yield ['sonata_api_user_user_put_user', '/api/user/users/{id}.{_format}', ['PUT']];
+        yield ['sonata_api_user_user_delete_user', '/api/user/users/{id}.{_format}', ['DELETE']];
+        yield ['sonata_api_user_user_post_user_group', '/api/user/users/{userId}/groups/{groupId}.{_format}', ['POST']];
+        yield ['sonata_api_user_user_delete_user_group', '/api/user/users/{userId}/groups/{groupId}.{_format}', ['DELETE']];
 
         // API - Group
         yield ['sonata_api_user_group_get_groups', '/api/user/groups.{_format}', ['GET']];
-        yield ['sonata_api_user_group_get_group', '/api/user/group/{id}.{_format}', ['GET']];
-        yield ['sonata_api_user_group_post_group', '/api/user/group.{_format}', ['POST']];
-        yield ['sonata_api_user_group_put_group', '/api/user/group/{id}.{_format}', ['PUT']];
-        yield ['sonata_api_user_group_delete_group', '/api/user/group/{id}.{_format}', ['DELETE']];
+        yield ['sonata_api_user_group_get_group', '/api/user/groups/{id}.{_format}', ['GET']];
+        yield ['sonata_api_user_group_post_group', '/api/user/groups.{_format}', ['POST']];
+        yield ['sonata_api_user_group_put_group', '/api/user/groups/{id}.{_format}', ['PUT']];
+        yield ['sonata_api_user_group_delete_group', '/api/user/groups/{id}.{_format}', ['DELETE']];
     }
 
     protected static function getKernelClass(): string


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Change API was in: https://github.com/sonata-project/SonataUserBundle/pull/1185/files
Revert API routing names: https://github.com/sonata-project/SonataUserBundle/pull/1194/files

This PR will revert API routing paths.
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because it must be fix here and change respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataUserBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- API routing paths after move routing type from 'REST' to 'XML' in v4.6.0
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
