### PR TITLE
Improve swagger models

### DIFF
--- a/docs/reference/advanced_configuration.rst
+++ b/docs/reference/advanced_configuration.rst
@@ -55,13 +55,14 @@ Full configuration options:
 
         mailer: sonata.user.mailer.default # Service used to send emails
 
-    # override FOSUser default serialization
+
     jms_serializer:
         metadata:
             directories:
-                App:
-                    path: "%kernel.root_dir%/../vendor/sonata-project/user-bundle/Sonata/UserBundle/Resources/config/serializer/FOSUserBundle"
-                    namespace_prefix: 'FOS\UserBundle'
+                - { name: 'sonata_datagrid', path: "%kernel.project_dir%/vendor/sonata-project/datagrid-bundle/src/Resources/config/serializer", namespace_prefix: 'Sonata\DatagridBundle' }
+                - { name: 'sonata_user', path: "%kernel.project_dir%/vendor/sonata-project/user-bundle/src/Resources/config/serializer", namespace_prefix: 'Sonata\UserBundle' }
+                # override FOSUser default serialization
+                - { name: 'fos_user', path: "%kernel.project_dir%/vendor/sonata-project/user-bundle/src/Resources/config/serializer/FOSUserBundle", namespace_prefix: 'FOS\UserBundle' }
 
     # Enable Doctrine to map the provided entities
     doctrine:

--- a/docs/reference/api.rst
+++ b/docs/reference/api.rst
@@ -35,6 +35,14 @@ Here's the configuration we used, you may adapt it to your needs:
         router: { annotations: true }
         request: { converters: true }
 
+    jms_serializer:
+        metadata:
+            directories:
+                - { name: 'sonata_datagrid', path: "%kernel.project_dir%/vendor/sonata-project/datagrid-bundle/src/Resources/config/serializer", namespace_prefix: 'Sonata\DatagridBundle' }
+                - { name: 'sonata_user', path: "%kernel.project_dir%/vendor/sonata-project/user-bundle/src/Resources/config/serializer", namespace_prefix: 'Sonata\UserBundle' }
+                # override FOSUser default serialization
+                - { name: 'fos_user', path: "%kernel.project_dir%/vendor/sonata-project/user-bundle/src/Resources/config/serializer/FOSUserBundle", namespace_prefix: 'FOS\UserBundle' }
+
     twig:
         exception_controller: null
 

--- a/src/Controller/Api/GroupController.php
+++ b/src/Controller/Api/GroupController.php
@@ -18,9 +18,11 @@ use FOS\RestBundle\Controller\Annotations\QueryParam;
 use FOS\RestBundle\Controller\Annotations\View;
 use FOS\RestBundle\Request\ParamFetcherInterface;
 use FOS\RestBundle\View\View as FOSRestView;
+use FOS\UserBundle\Model\Group;
 use FOS\UserBundle\Model\GroupInterface;
 use Nelmio\ApiDocBundle\Annotation\Model;
 use Nelmio\ApiDocBundle\Annotation\Operation;
+use Sonata\DatagridBundle\Pager\BasePager;
 use Sonata\DatagridBundle\Pager\PagerInterface;
 use Sonata\UserBundle\Model\GroupManagerInterface;
 use Swagger\Annotations as SWG;
@@ -44,10 +46,6 @@ class GroupController
      */
     protected $formFactory;
 
-    /**
-     * @param GroupManagerInterface $groupManager Sonata group manager
-     * @param FormFactoryInterface  $formFactory  Symfony form factory
-     */
     public function __construct(GroupManagerInterface $groupManager, FormFactoryInterface $formFactory)
     {
         $this->groupManager = $groupManager;
@@ -91,7 +89,7 @@ class GroupController
      *     @SWG\Response(
      *         response="200",
      *         description="Returned when successful",
-     *         @SWG\Schema(ref=@Model(type="Sonata\DatagridBundle\Pager\PagerInterface"))
+     *         @SWG\Schema(ref=@Model(type=BasePager::class, groups={"sonata_api_read"}))
      *     )
      * )
      *
@@ -137,7 +135,7 @@ class GroupController
      *     @SWG\Response(
      *         response="200",
      *         description="Returned when successful",
-     *         @SWG\Schema(ref=@Model(type="FOS\UserBundle\Model\GroupInterface"))
+     *         @SWG\Schema(ref=@Model(type=Group::class, groups={"sonata_api_read"}))
      *     ),
      *     @SWG\Response(
      *         response="404",
@@ -147,7 +145,7 @@ class GroupController
      *
      * @View(serializerGroups={"sonata_api_read"}, serializerEnableMaxDepthChecks=true)
      *
-     * @param string $id
+     * @param string $id Group identifier
      *
      * @return GroupInterface
      */
@@ -165,15 +163,13 @@ class GroupController
      *     @SWG\Response(
      *         response="200",
      *         description="Returned when successful",
-     *         @SWG\Schema(ref=@Model(type="Sonata\UserBundle\Model\Group"))
+     *         @SWG\Schema(ref=@Model(type=Group::class, groups={"sonata_api_read"}))
      *     ),
      *     @SWG\Response(
      *         response="400",
      *         description="Returned when an error has occurred during the group creation"
      *     )
      * )
-     *
-     * @param Request $request A Symfony request
      *
      * @throws NotFoundHttpException
      *
@@ -193,7 +189,7 @@ class GroupController
      *     @SWG\Response(
      *         response="200",
      *         description="Returned when successful",
-     *         @SWG\Schema(ref=@Model(type="Sonata\UserBundle\Model\Group"))
+     *         @SWG\Schema(ref=@Model(type=Group::class, groups={"sonata_api_read"}))
      *     ),
      *     @SWG\Response(
      *         response="400",
@@ -205,8 +201,7 @@ class GroupController
      *     )
      * )
      *
-     * @param string  $id      Group identifier
-     * @param Request $request A Symfony request
+     * @param string $id Group identifier
      *
      * @throws NotFoundHttpException
      *

--- a/src/Controller/Api/UserController.php
+++ b/src/Controller/Api/UserController.php
@@ -18,11 +18,14 @@ use FOS\RestBundle\Controller\Annotations\QueryParam;
 use FOS\RestBundle\Controller\Annotations\View;
 use FOS\RestBundle\Request\ParamFetcherInterface;
 use FOS\RestBundle\View\View as FOSRestView;
+use FOS\UserBundle\Model\Group;
 use FOS\UserBundle\Model\GroupInterface;
 use Nelmio\ApiDocBundle\Annotation\Model;
 use Nelmio\ApiDocBundle\Annotation\Operation;
+use Sonata\DatagridBundle\Pager\BasePager;
 use Sonata\DatagridBundle\Pager\PagerInterface;
 use Sonata\UserBundle\Model\GroupManagerInterface;
+use Sonata\UserBundle\Model\User;
 use Sonata\UserBundle\Model\UserInterface;
 use Sonata\UserBundle\Model\UserManagerInterface;
 use Swagger\Annotations as SWG;
@@ -95,7 +98,7 @@ class UserController
      *     @SWG\Response(
      *         response="200",
      *         description="Returned when successful",
-     *         @SWG\Schema(ref=@Model(type="Sonata\DatagridBundle\Pager\PagerInterface"))
+     *         @SWG\Schema(ref=@Model(type=BasePager::class, groups={"sonata_api_read"}))
      *     )
      * )
      *
@@ -141,7 +144,7 @@ class UserController
      *     @SWG\Response(
      *         response="200",
      *         description="Returned when successful",
-     *         @SWG\Schema(ref=@Model(type="Sonata\UserBundle\Model\UserInterface"))
+     *         @SWG\Schema(ref=@Model(type=User::class, groups={"sonata_api_read"}))
      *     ),
      *     @SWG\Response(
      *         response="404",
@@ -169,15 +172,13 @@ class UserController
      *     @SWG\Response(
      *         response="200",
      *         description="Returned when successful",
-     *         @SWG\Schema(ref=@Model(type="Sonata\UserBundle\Model\Group"))
+     *         @SWG\Schema(ref=@Model(type=Group::class, groups={"sonata_api_read"}))
      *     ),
      *     @SWG\Response(
      *         response="400",
      *         description="Returned when an error has occurred during the user creation"
      *     )
      * )
-     *
-     * @param Request $request A Symfony request
      *
      * @throws NotFoundHttpException
      *
@@ -197,7 +198,7 @@ class UserController
      *     @SWG\Response(
      *         response="200",
      *         description="Returned when successful",
-     *         @SWG\Schema(ref=@Model(type="Sonata\UserBundle\Model\User"))
+     *         @SWG\Schema(ref=@Model(type=User::class, groups={"sonata_api_read"}))
      *     ),
      *     @SWG\Response(
      *         response="400",
@@ -209,8 +210,7 @@ class UserController
      *     )
      * )
      *
-     * @param string  $id      User id
-     * @param Request $request A Symfony request
+     * @param string $id User identifier
      *
      * @throws NotFoundHttpException
      *
@@ -241,7 +241,7 @@ class UserController
      *     )
      * )
      *
-     * @param string $id An User identifier
+     * @param string $id User identifier
      *
      * @throws NotFoundHttpException
      *
@@ -265,7 +265,7 @@ class UserController
      *     @SWG\Response(
      *         response="200",
      *         description="Returned when successful",
-     *         @SWG\Schema(ref=@Model(type="Sonata\UserBundle\Model\User"))
+     *         @SWG\Schema(ref=@Model(type=User::class, groups={"sonata_api_read"}))
      *     ),
      *     @SWG\Response(
      *         response="400",
@@ -277,8 +277,8 @@ class UserController
      *     )
      * )
      *
-     * @param string $userId  A User identifier
-     * @param string $groupId A Group identifier
+     * @param string $userId  User identifier
+     * @param string $groupId Group identifier
      *
      * @throws NotFoundHttpException
      * @throws \RuntimeException
@@ -311,7 +311,7 @@ class UserController
      *     @SWG\Response(
      *         response="200",
      *         description="Returned when successful",
-     *         @SWG\Schema(ref=@Model(type="Sonata\UserBundle\Model\User"))
+     *         @SWG\Schema(ref=@Model(type=User::class, groups={"sonata_api_read"}))
      *     ),
      *     @SWG\Response(
      *         response="400",
@@ -323,8 +323,8 @@ class UserController
      *     )
      * )
      *
-     * @param string $userId  A User identifier
-     * @param string $groupId A Group identifier
+     * @param string $userId  User identifier
+     * @param string $groupId Group identifier
      *
      * @throws NotFoundHttpException
      * @throws \RuntimeException
@@ -351,7 +351,7 @@ class UserController
     /**
      * Retrieves user with id $id or throws an exception if it doesn't exist.
      *
-     * @param string $id
+     * @param string $id User identifier
      *
      * @throws NotFoundHttpException
      *
@@ -371,7 +371,7 @@ class UserController
     /**
      * Retrieves user with id $id or throws an exception if it doesn't exist.
      *
-     * @param string $id
+     * @param string $id Group identifier
      *
      * @throws NotFoundHttpException
      *
@@ -392,7 +392,7 @@ class UserController
      * Write an User, this method is used by both POST and PUT action methods.
      *
      * @param Request     $request Symfony request
-     * @param string|null $id      An User identifier
+     * @param string|null $id      User identifier
      *
      * @return FormInterface
      */

--- a/src/Resources/config/routing/api/group.xml
+++ b/src/Resources/config/routing/api/group.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <routes xmlns="http://symfony.com/schema/routing" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/routing https://symfony.com/schema/routing/routing-1.0.xsd">
-    <route id="delete_group" path="/groups/{id}.{_format}" methods="DELETE" controller="Sonata\UserBundle\Controller\Api\Legacy\GroupController::deleteGroupAction" format="json">
-        <requirement key="_format">json|xml|html</requirement>
-    </route>
-    <route id="get_group" path="/groups/{id}.{_format}" methods="GET" controller="Sonata\UserBundle\Controller\Api\Legacy\GroupController::getGroupAction" format="json">
-        <requirement key="_format">json|xml|html</requirement>
-    </route>
     <route id="get_groups" path="/groups.{_format}" methods="GET" controller="Sonata\UserBundle\Controller\Api\Legacy\GroupController::getGroupsAction" format="json">
         <requirement key="_format">json|xml|html</requirement>
     </route>
     <route id="post_group" path="/groups.{_format}" methods="POST" controller="Sonata\UserBundle\Controller\Api\Legacy\GroupController::postGroupAction" format="json">
+        <requirement key="_format">json|xml|html</requirement>
+    </route>
+    <route id="delete_group" path="/groups/{id}.{_format}" methods="DELETE" controller="Sonata\UserBundle\Controller\Api\Legacy\GroupController::deleteGroupAction" format="json">
+        <requirement key="_format">json|xml|html</requirement>
+    </route>
+    <route id="get_group" path="/groups/{id}.{_format}" methods="GET" controller="Sonata\UserBundle\Controller\Api\Legacy\GroupController::getGroupAction" format="json">
         <requirement key="_format">json|xml|html</requirement>
     </route>
     <route id="put_group" path="/groups/{id}.{_format}" methods="PUT" controller="Sonata\UserBundle\Controller\Api\Legacy\GroupController::putGroupAction" format="json">

--- a/src/Resources/config/routing/api/user.xml
+++ b/src/Resources/config/routing/api/user.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <routes xmlns="http://symfony.com/schema/routing" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/routing https://symfony.com/schema/routing/routing-1.0.xsd">
-    <route id="delete_user" path="/users/{id}.{_format}" methods="DELETE" controller="Sonata\UserBundle\Controller\Api\Legacy\UserController::deleteUserAction" format="json">
-        <requirement key="_format">json|xml|html</requirement>
-    </route>
-    <route id="delete_user_group" path="/users/{userId}/groups/{groupId}.{_format}" methods="DELETE" controller="Sonata\UserBundle\Controller\Api\Legacy\UserController::deleteUserGroupAction" format="json">
-        <requirement key="_format">json|xml|html</requirement>
-    </route>
-    <route id="get_user" path="/users/{id}.{_format}" methods="GET" controller="Sonata\UserBundle\Controller\Api\Legacy\UserController::getUserAction" format="json">
-        <requirement key="_format">json|xml|html</requirement>
-    </route>
     <route id="get_users" path="/users.{_format}" methods="GET" controller="Sonata\UserBundle\Controller\Api\Legacy\UserController::getUsersAction" format="json">
         <requirement key="_format">json|xml|html</requirement>
     </route>
     <route id="post_user" path="/users.{_format}" methods="POST" controller="Sonata\UserBundle\Controller\Api\Legacy\UserController::putUserAction" format="json">
         <requirement key="_format">json|xml|html</requirement>
     </route>
-    <route id="post_user_group" path="/users/{userId}/groups/{groupId}.{_format}" methods="POST" controller="Sonata\UserBundle\Controller\Legacy\Api\UserController::postUserGroupAction" format="json">
+    <route id="delete_user" path="/users/{id}.{_format}" methods="DELETE" controller="Sonata\UserBundle\Controller\Api\Legacy\UserController::deleteUserAction" format="json">
+        <requirement key="_format">json|xml|html</requirement>
+    </route>
+    <route id="get_user" path="/users/{id}.{_format}" methods="GET" controller="Sonata\UserBundle\Controller\Api\Legacy\UserController::getUserAction" format="json">
         <requirement key="_format">json|xml|html</requirement>
     </route>
     <route id="put_user" path="/users/{id}.{_format}" methods="PUT" controller="Sonata\UserBundle\Controller\Api\Legacy\UserController::putUserAction" format="json">
+        <requirement key="_format">json|xml|html</requirement>
+    </route>
+    <route id="delete_user_group" path="/users/{userId}/groups/{groupId}.{_format}" methods="DELETE" controller="Sonata\UserBundle\Controller\Api\Legacy\UserController::deleteUserGroupAction" format="json">
+        <requirement key="_format">json|xml|html</requirement>
+    </route>
+    <route id="post_user_group" path="/users/{userId}/groups/{groupId}.{_format}" methods="POST" controller="Sonata\UserBundle\Controller\Legacy\Api\UserController::postUserGroupAction" format="json">
         <requirement key="_format">json|xml|html</requirement>
     </route>
 </routes>

--- a/src/Resources/config/routing/api_nelmio3/group.xml
+++ b/src/Resources/config/routing/api_nelmio3/group.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <routes xmlns="http://symfony.com/schema/routing" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/routing https://symfony.com/schema/routing/routing-1.0.xsd">
-    <route id="delete_group" path="/groups/{id}.{_format}" methods="DELETE" controller="Sonata\UserBundle\Controller\Api\GroupController::deleteGroupAction" format="json">
-        <requirement key="_format">json|xml|html</requirement>
-    </route>
-    <route id="get_group" path="/groups/{id}.{_format}" methods="GET" controller="Sonata\UserBundle\Controller\Api\GroupController::getGroupAction" format="json">
-        <requirement key="_format">json|xml|html</requirement>
-    </route>
     <route id="get_groups" path="/groups.{_format}" methods="GET" controller="Sonata\UserBundle\Controller\Api\GroupController::getGroupsAction" format="json">
         <requirement key="_format">json|xml|html</requirement>
     </route>
     <route id="post_group" path="/groups.{_format}" methods="POST" controller="Sonata\UserBundle\Controller\Api\GroupController::postGroupAction" format="json">
+        <requirement key="_format">json|xml|html</requirement>
+    </route>
+    <route id="delete_group" path="/groups/{id}.{_format}" methods="DELETE" controller="Sonata\UserBundle\Controller\Api\GroupController::deleteGroupAction" format="json">
+        <requirement key="_format">json|xml|html</requirement>
+    </route>
+    <route id="get_group" path="/groups/{id}.{_format}" methods="GET" controller="Sonata\UserBundle\Controller\Api\GroupController::getGroupAction" format="json">
         <requirement key="_format">json|xml|html</requirement>
     </route>
     <route id="put_group" path="/groups/{id}.{_format}" methods="PUT" controller="Sonata\UserBundle\Controller\Api\GroupController::putGroupAction" format="json">

--- a/src/Resources/config/routing/api_nelmio3/user.xml
+++ b/src/Resources/config/routing/api_nelmio3/user.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <routes xmlns="http://symfony.com/schema/routing" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/routing https://symfony.com/schema/routing/routing-1.0.xsd">
-    <route id="delete_user" path="/users/{id}.{_format}" methods="DELETE" controller="Sonata\UserBundle\Controller\Api\UserController::deleteUserAction" format="json">
+    <route id="get_users" path="/users.{_format}" methods="GET" controller="Sonata\UserBundle\Controller\Api\UserController::getUsersAction" format="json">
         <requirement key="_format">json|xml|html</requirement>
     </route>
-    <route id="delete_user_group" path="/users/{userId}/groups/{groupId}.{_format}" methods="DELETE" controller="Sonata\UserBundle\Controller\Api\UserController::deleteUserGroupAction" format="json">
+    <route id="post_user" path="/users.{_format}" methods="POST" controller="Sonata\UserBundle\Controller\Api\UserController::putUserAction" format="json">
+        <requirement key="_format">json|xml|html</requirement>
+    </route>
+    <route id="delete_user" path="/users/{id}.{_format}" methods="DELETE" controller="Sonata\UserBundle\Controller\Api\UserController::deleteUserAction" format="json">
         <requirement key="_format">json|xml|html</requirement>
     </route>
     <route id="get_user" path="/users/{id}.{_format}" methods="GET" controller="Sonata\UserBundle\Controller\Api\UserController::getUserAction" format="json">
         <requirement key="_format">json|xml|html</requirement>
     </route>
-    <route id="get_users" path="/users.{_format}" methods="GET" controller="Sonata\UserBundle\Controller\Api\UserController::getUsersAction" format="json">
+    <route id="put_user" path="/users/{id}.{_format}" methods="PUT" controller="Sonata\UserBundle\Controller\Api\UserController::putUserAction" format="json">
         <requirement key="_format">json|xml|html</requirement>
     </route>
-    <route id="post_user" path="/users.{_format}" methods="POST" controller="Sonata\UserBundle\Controller\Api\UserController::postUserAction" format="json">
+    <route id="delete_user_group" path="/users/{userId}/groups/{groupId}.{_format}" methods="DELETE" controller="Sonata\UserBundle\Controller\Api\UserController::deleteUserGroupAction" format="json">
         <requirement key="_format">json|xml|html</requirement>
     </route>
     <route id="post_user_group" path="/users/{userId}/groups/{groupId}.{_format}" methods="POST" controller="Sonata\UserBundle\Controller\Api\UserController::postUserGroupAction" format="json">
-        <requirement key="_format">json|xml|html</requirement>
-    </route>
-    <route id="put_user" path="/users/{id}.{_format}" methods="PUT" controller="Sonata\UserBundle\Controller\Api\UserController::putUserAction" format="json">
         <requirement key="_format">json|xml|html</requirement>
     </route>
 </routes>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

This PR consists:
- fix api order to previus (like in [demo](demo.sonata-project.org/api/doc)) - `pedantic`
- change swagger models to selialized models - this will allow see correct return example in documentation (under `/api/doc`)  
![image](https://user-images.githubusercontent.com/2255674/94293255-5073da80-ff5e-11ea-9d7a-5d8061885e6f.png)

- clean up docblocks - remove unnesessery commets
- improve doc

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this change respect BC.
