### PR TITLE
Added default value for asserts validation

### DIFF
--- a/src/Admin/Model/UserAdmin.php
+++ b/src/Admin/Model/UserAdmin.php
@@ -43,7 +43,11 @@ class UserAdmin extends AbstractAdmin
         $this->formOptions['data_class'] = $this->getClass();
 
         $options = $this->formOptions;
-        $options['validation_groups'] = (!$this->getSubject() || null === $this->getSubject()->getId()) ? 'Registration' : 'Profile';
+        $options['validation_groups'] = ['Default', 'Profile'];
+
+        if (!$this->getSubject() || null === $this->getSubject()->getId()) {
+            $options['validation_groups'] = ['Default', 'Registration'];
+        }
 
         $formBuilder = $this->getFormContractor()->getFormBuilder($this->getUniqid(), $options);
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Default validation group to UserModel

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backward compatible, like patches, features, and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch Because the last version of SonatauserBundle is not working for the Default group.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Fix #1234.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataUserBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed Asserts validation for Default group.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
