### PR TITLE
FosUserBundle require doctrine/common 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     ],
     "require": {
         "php": "^7.2",
+        "doctrine/common": "^2.0",
         "friendsofsymfony/user-bundle": "^2.0",
         "sonata-project/admin-bundle": "^3.34",
         "sonata-project/datagrid-bundle": "^3.0.1",


### PR DESCRIPTION
Tests are currently failing because it install doctrine common 3 and doctrine persistence 2.

But FOSUserBundle is requiring doctrine common 2.

Until FosUser is removed, cf https://github.com/sonata-project/SonataUserBundle/issues/1112, this fix the tests.