### PR TITLE
Stop extending `AbstractAdmin::getExportFields()`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "php": "^7.2",
         "doctrine/common": "^2.0",
         "friendsofsymfony/user-bundle": "^2.0",
-        "sonata-project/admin-bundle": "^3.34",
+        "sonata-project/admin-bundle": "^3.76",
         "sonata-project/datagrid-bundle": "^3.0.1",
         "sonata-project/doctrine-extensions": "^1.8",
         "sonata-project/form-extensions": "^0.1 || ^1.4",

--- a/src/Admin/Model/UserAdmin.php
+++ b/src/Admin/Model/UserAdmin.php
@@ -59,17 +59,6 @@ class UserAdmin extends AbstractAdmin
     /**
      * {@inheritdoc}
      */
-    public function getExportFields()
-    {
-        // avoid security field to be exported
-        return array_filter(parent::getExportFields(), static function ($v) {
-            return !\in_array($v, ['password', 'salt'], true);
-        });
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function preUpdate($user): void
     {
         $this->getUserManager()->updateCanonicalFields($user);
@@ -248,5 +237,13 @@ class UserAdmin extends AbstractAdmin
                 ->end()
             ->end()
         ;
+    }
+
+    protected function configureExportFields(): array
+    {
+        // Avoid sensitive properties to be exported.
+        return array_filter(parent::configureExportFields(), static function (string $v): bool {
+            return !\in_array($v, ['password', 'salt'], true);
+        });
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Stop extending `AbstractAdmin::getExportFields()`, since this method is marked as final.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this change respects BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataUserBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Deprecation about the extension of `AbstractAdmin::getExportFields()` method in `UserAdmin`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
