### PR TITLE
Fix: sonata_user_already_authenticated was not being translated (#1265)

### DIFF
--- a/src/Resources/config/actions.xml
+++ b/src/Resources/config/actions.xml
@@ -51,6 +51,7 @@
             <argument type="service" id="sonata.admin.global_template_registry"/>
             <argument type="service" id="security.token_storage"/>
             <argument type="service" id="session"/>
+            <argument type="service" id="translator"/>
             <call method="setCsrfTokenManager">
                 <argument type="service" id="security.csrf.token_manager" on-invalid="ignore"/>
             </call>

--- a/tests/Action/LoginActionTest.php
+++ b/tests/Action/LoginActionTest.php
@@ -30,6 +30,7 @@ use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Csrf\CsrfToken;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 use Twig\Environment;
 
 class LoginActionTest extends TestCase
@@ -74,6 +75,11 @@ class LoginActionTest extends TestCase
      */
     protected $csrfTokenManager;
 
+    /**
+     * @var TranslatorInterface|MockObject
+     */
+    private $translator;
+
     protected function setUp(): void
     {
         $this->templating = $this->createMock(Environment::class);
@@ -83,6 +89,7 @@ class LoginActionTest extends TestCase
         $this->templateRegistry = $this->createMock(TemplateRegistryInterface::class);
         $this->tokenStorage = $this->createMock(TokenStorageInterface::class);
         $this->session = $this->createMock(Session::class);
+        $this->translator = $this->createMock(TranslatorInterface::class);
         $this->csrfTokenManager = $this->createMock(CsrfTokenManagerInterface::class);
     }
 
@@ -101,10 +108,15 @@ class LoginActionTest extends TestCase
             ->method('getToken')
             ->willReturn($token);
 
+        $this->translator->expects($this->once())
+            ->method('trans')
+            ->with('sonata_user_already_authenticated')
+            ->willReturn('Already Authenticated');
+
         $bag = $this->createMock(FlashBag::class);
         $bag->expects($this->once())
             ->method('add')
-            ->with('sonata_user_error', 'sonata_user_already_authenticated');
+            ->with('sonata_user_error', 'Already Authenticated');
 
         $this->session
             ->method('getFlashBag')
@@ -253,7 +265,8 @@ class LoginActionTest extends TestCase
             $this->pool,
             $this->templateRegistry,
             $this->tokenStorage,
-            $this->session
+            $this->session,
+            $this->translator
         );
         $action->setCsrfTokenManager($this->csrfTokenManager);
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Fixes the problem of the message "sonata_user_already_authenticated" not being translated.
The message is triggered when going to the login page while logged in.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because it is the current version and this is where the bug was found.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1265.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataUserBundle/releases,
    please keep it short and clear and to the point
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed the problem of the message "sonata_user_already_authenticated" not being translated.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
