### PR TITLE
Change ContainerAwareCommand to Command

### DIFF
--- a/src/Command/TwoStepVerificationCommand.php
+++ b/src/Command/TwoStepVerificationCommand.php
@@ -26,14 +26,7 @@ class TwoStepVerificationCommand extends Command
 {
     protected static $defaultName = 'sonata:user:two-step-verification';
 
-    /**
-     * @var ?Helper
-     */
     private $helper;
-
-    /**
-     * @var ?UserManagerInterface
-     */
     private $userManager;
 
     public function __construct(
@@ -68,35 +61,9 @@ class TwoStepVerificationCommand extends Command
      */
     public function execute(InputInterface $input, OutputInterface $output): int
     {
-        //todo maybe need to remove container ....
-        if (null === $this->helper && !$this->getContainer()->has('sonata.user.google.authenticator.provider')) {
-            throw new \RuntimeException('Two Step Verification process is not enabled');
-        }
-
-        if (null === $this->helper) {
-            @trigger_error(sprintf(
-                'Not providing the $helper argument of "%s::__construct()" is deprecated since 4.3.0 and will no longer be possible in 5.0',
-                __CLASS__
-            ), E_USER_DEPRECATED);
-            $helper = $this->getContainer()->get('sonata.user.google.authenticator.provider');
-            \assert($helper instanceof Helper);
-            $this->helper = $helper;
-        }
-
-        if (null === $this->userManager) {
-            @trigger_error(sprintf(
-                'Not providing the $userManager argument of "%s::__construct()" is deprecated since 4.3.0 and will no longer be possible in 5.0',
-                __CLASS__
-            ), E_USER_DEPRECATED);
-            $manager = $this->getContainer()->get('fos_user.user_manager');
-            \assert($manager instanceof UserManagerInterface);
-            $this->userManager = $manager;
-        }
-
         $user = $this->userManager->findUserByUsernameOrEmail($input->getArgument('username'));
-        \assert($user instanceof UserInterface);
 
-        if (!$user) {
+        if (false === $user instanceof UserInterface) {
             throw new \RuntimeException(sprintf('Unable to find the username : %s', $input->getArgument('username')));
         }
 

--- a/src/Command/TwoStepVerificationCommand.php
+++ b/src/Command/TwoStepVerificationCommand.php
@@ -22,17 +22,24 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class TwoStepVerificationCommand extends Command
+final class TwoStepVerificationCommand extends Command
 {
     protected static $defaultName = 'sonata:user:two-step-verification';
 
+    /**
+     * @var Helper
+     */
     private $helper;
+
+    /**
+     * @var UserManagerInterface
+     */
     private $userManager;
 
     public function __construct(
-        string $name = null,
-        Helper $helper = null,
-        UserManagerInterface $userManager = null
+        ?string $name,
+        Helper $helper,
+        UserManagerInterface $userManager
     ) {
         parent::__construct($name);
 

--- a/src/Command/TwoStepVerificationCommand.php
+++ b/src/Command/TwoStepVerificationCommand.php
@@ -16,17 +16,16 @@ namespace Sonata\UserBundle\Command;
 use FOS\UserBundle\Model\UserManagerInterface;
 use Sonata\UserBundle\GoogleAuthenticator\Helper;
 use Sonata\UserBundle\Model\UserInterface;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-/**
- * NEXT_MAJOR: stop extending ContainerAwareCommand.
- */
-class TwoStepVerificationCommand extends ContainerAwareCommand
+class TwoStepVerificationCommand extends Command
 {
+    protected static $defaultName = 'sonata:user:two-step-verification';
+
     /**
      * @var ?Helper
      */
@@ -37,13 +36,10 @@ class TwoStepVerificationCommand extends ContainerAwareCommand
      */
     private $userManager;
 
-    /**
-     * NEXT_MAJOR: make $helper and $userManager mandatory (but still nullable).
-     */
     public function __construct(
-        ?string $name,
-        ?Helper $helper = null,
-        ?UserManagerInterface $userManager = null
+        string $name = null,
+        Helper $helper = null,
+        UserManagerInterface $userManager = null
     ) {
         parent::__construct($name);
 
@@ -56,7 +52,6 @@ class TwoStepVerificationCommand extends ContainerAwareCommand
      */
     public function configure(): void
     {
-        $this->setName('sonata:user:two-step-verification');
         $this->addArgument(
             'username',
             InputArgument::REQUIRED,
@@ -71,8 +66,9 @@ class TwoStepVerificationCommand extends ContainerAwareCommand
     /**
      * {@inheritdoc}
      */
-    public function execute(InputInterface $input, OutputInterface $output): void
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
+        //todo maybe need to remove container ....
         if (null === $this->helper && !$this->getContainer()->has('sonata.user.google.authenticator.provider')) {
             throw new \RuntimeException('Two Step Verification process is not enabled');
         }
@@ -114,5 +110,7 @@ class TwoStepVerificationCommand extends ContainerAwareCommand
             sprintf('<info>Secret</info> : %s', $user->getTwoStepVerificationCode()),
             sprintf('<info>Url</info> : %s', $this->helper->getUrl($user)),
         ]);
+
+        return 0;
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because it's deprecated since [Symfony version 4.2](https://symfony.com/blog/new-in-symfony-4-2-important-deprecations#deprecated-containerawarecommand) and there is BC break.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1270.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataUserBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Changed `ContainerAwareCommand` to `Command` in  `src/Command/TwoStepVerificationCommand.php`
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
