### PR TITLE
Don't break 2FA when mixing user-providers

### DIFF
--- a/src/EventListener/TwoFactorLoginSuccessHandler.php
+++ b/src/EventListener/TwoFactorLoginSuccessHandler.php
@@ -72,7 +72,7 @@ final class TwoFactorLoginSuccessHandler implements AuthenticationSuccessHandler
         $user = $token->getUser();
         $needToHave2FA = $this->googleAuthenticator->needToHaveGoogle2FACode($request);
 
-        if ($needToHave2FA && !$user->getTwoStepVerificationCode()) {
+        if ($needToHave2FA && method_exists($user, 'getTwoStepVerificationCode') && !$user->getTwoStepVerificationCode()) {
             $secret = $this->googleAuthenticator->generateSecret();
             $user->setTwoStepVerificationCode($secret);
 
@@ -88,7 +88,7 @@ final class TwoFactorLoginSuccessHandler implements AuthenticationSuccessHandler
                     'error' => [],
                 ]
             ));
-        } elseif ($needToHave2FA && $user->getTwoStepVerificationCode()) {
+        } elseif ($needToHave2FA && method_exists($user, 'getTwoStepVerificationCode') && $user->getTwoStepVerificationCode()) {
             $request->getSession()->set($this->googleAuthenticator->getSessionKey($token), null);
         }
 


### PR DESCRIPTION
## Don't break 2FA when mixing user-providers

`getTwoStepVerificationCode` is not always present on every user-object, e.g. the in-memory user (https://github.com/symfony/security-core/blob/5.x/User/User.php) does not have this method. 
The current implementation makes it impossible to mix different user-providers.

I am targeting this branch, because it's a patch.


## Changelog


```markdown
### Changed
- `TwoFactorLoginSuccessHandler` verifies if 2FA business-logic can be executed.
```
