### PR TITLE
:bug: Remove duplicate translation on nl

### DIFF
--- a/src/Resources/translations/SonataUserBundle.nl.xliff
+++ b/src/Resources/translations/SonataUserBundle.nl.xliff
@@ -6,10 +6,6 @@
                 <source>title_user_registration</source>
                 <target>Gebruiker registratie</target>
             </trans-unit>
-            <trans-unit id="sonata_user">
-                <source>sonata_user</source>
-                <target>Gebruikersbeheer</target>
-            </trans-unit>
             <trans-unit id="title_user_account">
                 <source>title_user_account</source>
                 <target>Gebruikers profiel</target>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Upon installation, an error is triggered (when composer tries to clear the cache). This error is caused by a duplicate key in a translation file.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because there is a duplicate key in one of the translations.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1287 .

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataUserBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Duplicate translation in `src/Resources/translations/SonataUserBundle.nl.xliff`
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
