### PR TITLE
Fix getPager return type on Document

### DIFF
--- a/src/Document/GroupManager.php
+++ b/src/Document/GroupManager.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\UserBundle\Document;
 
 use FOS\UserBundle\Doctrine\GroupManager as BaseGroupManager;
+use Sonata\DatagridBundle\Pager\PagerInterface;
 use Sonata\UserBundle\Model\GroupManagerInterface;
 
 /**
@@ -32,7 +33,7 @@ class GroupManager extends BaseGroupManager implements GroupManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function getPager(array $criteria, $page, $limit = 10, array $sort = []): void
+    public function getPager(array $criteria, int $page, int $limit = 10, array $sort = []): PagerInterface
     {
         new \RuntimeException('method not implemented');
     }

--- a/src/Document/UserManager.php
+++ b/src/Document/UserManager.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\UserBundle\Document;
 
 use FOS\UserBundle\Doctrine\UserManager as BaseUserManager;
+use Sonata\DatagridBundle\Pager\PagerInterface;
 use Sonata\UserBundle\Model\UserManagerInterface;
 
 /**
@@ -32,7 +33,7 @@ class UserManager extends BaseUserManager implements UserManagerInterface
     /**
      * {@inheritdoc}
      */
-    public function getPager(array $criteria, $page, $limit = 10, array $sort = []): void
+    public function getPager(array $criteria, int $page, int $limit = 10, array $sort = []): PagerInterface
     {
         new \RuntimeException('method not implemented');
     }


### PR DESCRIPTION
## Subject
Fix getPager return type on Document (for MongoDB)

Return type is now compatible with the interface. This is related to the datagrid-bundle bump to version ^3.0

This has been done for the Entity [here](https://github.com/sonata-project/SonataUserBundle/blob/b7c820c9597515a110582e57021c60b033662076/src/Entity/UserManager.php#L119) **but not for Document**

I am targeting this branch, because it is where the issue is

## Changelog

```markdown

### Changed
- `GroupManager::getPager()` return type is `Sonata\DatagridBundle\Pager\PagerInterface`.
- `UserManager::getPager()` return type is `Sonata\DatagridBundle\Pager\PagerInterface`.

```
