### PR TITLE
Fix compatibility with doctrine/persistence 2.0

### DIFF
--- a/src/DependencyInjection/SonataUserExtension.php
+++ b/src/DependencyInjection/SonataUserExtension.php
@@ -126,8 +126,6 @@ class SonataUserExtension extends Extension implements PrependExtensionInterface
         $container->setParameter('sonata.user.impersonating', $config['impersonating']);
 
         $this->configureGoogleAuthenticator($config, $container);
-
-        $this->createDoctrineCommonBackwardCompatibilityAliases();
     }
 
     /**
@@ -370,20 +368,5 @@ class SonataUserExtension extends Extension implements PrependExtensionInterface
                     'onDelete' => 'CASCADE',
                 ]])
         );
-    }
-
-    /**
-     * We MUST remove this method when support for "friendsofsymfony/user-bundle" is dropped
-     * or adapted to work with "doctrine/common:^3".
-     */
-    private function createDoctrineCommonBackwardCompatibilityAliases(): void
-    {
-        if (!interface_exists(\Doctrine\Common\Persistence\ObjectManager::class)) {
-            class_alias(\Doctrine\Persistence\ObjectManager::class, \Doctrine\Common\Persistence\ObjectManager::class);
-        }
-
-        if (!class_exists(\Doctrine\Common\Persistence\Event\LifecycleEventArgs::class)) {
-            class_alias(\Doctrine\Persistence\Event\LifecycleEventArgs::class, \Doctrine\Common\Persistence\Event\LifecycleEventArgs::class);
-        }
     }
 }

--- a/src/SonataUserBundle.php
+++ b/src/SonataUserBundle.php
@@ -32,6 +32,7 @@ class SonataUserBundle extends Bundle
     public function boot(): void
     {
         $this->registerFormMapping();
+        $this->createDoctrineCommonBackwardCompatibilityAliases();
     }
 
     /**
@@ -56,6 +57,21 @@ class SonataUserBundle extends Bundle
                 'sonata_user_api_form_group' => 'Sonata\UserBundle\Form\Type\ApiGroupType',
                 'sonata_user_api_form_user' => 'Sonata\UserBundle\Form\Type\ApiUserType',
             ]);
+        }
+    }
+
+    /**
+     * We MUST remove this method when support for "friendsofsymfony/user-bundle" is dropped
+     * or adapted to work with "doctrine/common:^3".
+     */
+    private function createDoctrineCommonBackwardCompatibilityAliases(): void
+    {
+        if (!interface_exists(\Doctrine\Common\Persistence\ObjectManager::class)) {
+            class_alias(\Doctrine\Persistence\ObjectManager::class, \Doctrine\Common\Persistence\ObjectManager::class);
+        }
+
+        if (!class_exists(\Doctrine\Common\Persistence\Event\LifecycleEventArgs::class)) {
+            class_alias(\Doctrine\Persistence\Event\LifecycleEventArgs::class, \Doctrine\Common\Persistence\Event\LifecycleEventArgs::class);
         }
     }
 }

--- a/tests/custom_bootstrap.php
+++ b/tests/custom_bootstrap.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/*
+ * We MUST remove file this when support for "friendsofsymfony/user-bundle" is dropped
+ * or adapted to work with "doctrine/common:^3".
+ */
+
+if (!interface_exists(\Doctrine\Common\Persistence\ObjectManager::class)) {
+    class_alias(\Doctrine\Persistence\ObjectManager::class, \Doctrine\Common\Persistence\ObjectManager::class);
+}
+
+if (!class_exists(\Doctrine\Common\Persistence\Event\LifecycleEventArgs::class)) {
+    class_alias(\Doctrine\Persistence\Event\LifecycleEventArgs::class, \Doctrine\Common\Persistence\Event\LifecycleEventArgs::class);
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Class aliases need to be created on a place that it is always executed,
previous code was only executed on an empty cache. Next request were
always broken. Moving to the bundle class ensures the code is always
executed.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is a bugfix and BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1331
Closes #1336

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataUserBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fix compatibility with doctrine/persistence 2.0
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
