### PR TITLE
Leverage `$this` binding in anonymous functions

### DIFF
--- a/tests/Entity/GroupManagerTest.php
+++ b/tests/Entity/GroupManagerTest.php
@@ -26,16 +26,15 @@ class GroupManagerTest extends TestCase
 
     public function testGetPager(): void
     {
-        $self = $this;
         $this
-            ->getUserManager(static function (MockObject $qb) use ($self): void {
-                $qb->expects($self->once())->method('getRootAliases')->willReturn(['g']);
-                $qb->expects($self->never())->method('andWhere');
-                $qb->expects($self->once())->method('orderBy')->with(
-                    $self->equalTo('g.name'),
-                    $self->equalTo('ASC')
+            ->getUserManager(function (MockObject $qb): void {
+                $qb->expects($this->once())->method('getRootAliases')->willReturn(['g']);
+                $qb->expects($this->never())->method('andWhere');
+                $qb->expects($this->once())->method('orderBy')->with(
+                    $this->equalTo('g.name'),
+                    $this->equalTo('ASC')
                 );
-                $qb->expects($self->once())->method('setParameters')->with($self->equalTo([]));
+                $qb->expects($this->once())->method('setParameters')->with($this->equalTo([]));
             })
             ->getPager([], 1);
     }
@@ -45,44 +44,41 @@ class GroupManagerTest extends TestCase
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Invalid sort field \'invalid\' in \'className\' class');
 
-        $self = $this;
         $this
-            ->getUserManager(static function (MockObject $qb) use ($self): void {
-                $qb->expects($self->never())->method('andWhere');
-                $qb->expects($self->never())->method('orderBy');
-                $qb->expects($self->never())->method('setParameters');
+            ->getUserManager(function (MockObject $qb): void {
+                $qb->expects($this->never())->method('andWhere');
+                $qb->expects($this->never())->method('orderBy');
+                $qb->expects($this->never())->method('setParameters');
             })
             ->getPager([], 1, 10, ['invalid' => 'ASC']);
     }
 
     public function testGetPagerWithEnabledUsers(): void
     {
-        $self = $this;
         $this
-            ->getUserManager(static function (MockObject $qb) use ($self): void {
-                $qb->expects($self->once())->method('getRootAliases')->willReturn(['g']);
-                $qb->expects($self->once())->method('andWhere')->with($self->equalTo('g.enabled = :enabled'));
-                $qb->expects($self->once())->method('orderBy')->with(
-                    $self->equalTo('g.name'),
-                    $self->equalTo('ASC')
+            ->getUserManager(function (MockObject $qb): void {
+                $qb->expects($this->once())->method('getRootAliases')->willReturn(['g']);
+                $qb->expects($this->once())->method('andWhere')->with($this->equalTo('g.enabled = :enabled'));
+                $qb->expects($this->once())->method('orderBy')->with(
+                    $this->equalTo('g.name'),
+                    $this->equalTo('ASC')
                 );
-                $qb->expects($self->once())->method('setParameters')->with($self->equalTo(['enabled' => true]));
+                $qb->expects($this->once())->method('setParameters')->with($this->equalTo(['enabled' => true]));
             })
             ->getPager(['enabled' => true], 1);
     }
 
     public function testGetPagerWithDisabledUsers(): void
     {
-        $self = $this;
         $this
-            ->getUserManager(static function (MockObject $qb) use ($self): void {
-                $qb->expects($self->once())->method('getRootAliases')->willReturn(['g']);
-                $qb->expects($self->once())->method('andWhere')->with($self->equalTo('g.enabled = :enabled'));
-                $qb->expects($self->once())->method('orderBy')->with(
-                    $self->equalTo('g.name'),
-                    $self->equalTo('ASC')
+            ->getUserManager(function (MockObject $qb): void {
+                $qb->expects($this->once())->method('getRootAliases')->willReturn(['g']);
+                $qb->expects($this->once())->method('andWhere')->with($this->equalTo('g.enabled = :enabled'));
+                $qb->expects($this->once())->method('orderBy')->with(
+                    $this->equalTo('g.name'),
+                    $this->equalTo('ASC')
                 );
-                $qb->expects($self->once())->method('setParameters')->with($self->equalTo(['enabled' => false]));
+                $qb->expects($this->once())->method('setParameters')->with($this->equalTo(['enabled' => false]));
             })
             ->getPager(['enabled' => false], 1);
     }

--- a/tests/Entity/UserManagerTest.php
+++ b/tests/Entity/UserManagerTest.php
@@ -27,14 +27,13 @@ class UserManagerTest extends TestCase
 
     public function testGetPager(): void
     {
-        $self = $this;
         $this
-            ->getUserManager(static function (MockObject $qb) use ($self): void {
-                $qb->expects($self->once())->method('getRootAliases')->willReturn(['u']);
-                $qb->expects($self->never())->method('andWhere');
-                $qb->expects($self->once())->method('orderBy')->with(
-                    $self->equalTo('u.username'),
-                    $self->equalTo('ASC')
+            ->getUserManager(function (MockObject $qb): void {
+                $qb->expects($this->once())->method('getRootAliases')->willReturn(['u']);
+                $qb->expects($this->never())->method('andWhere');
+                $qb->expects($this->once())->method('orderBy')->with(
+                    $this->equalTo('u.username'),
+                    $this->equalTo('ASC')
                 );
             })
             ->getPager([], 1);
@@ -45,30 +44,28 @@ class UserManagerTest extends TestCase
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Invalid sort field \'invalid\' in \'Sonata\UserBundle\Entity\BaseUser\' class');
 
-        $self = $this;
         $this
-            ->getUserManager(static function (MockObject $qb) use ($self): void {
-                $qb->expects($self->never())->method('andWhere');
-                $qb->expects($self->never())->method('orderBy');
-                $qb->expects($self->never())->method('setParameters');
+            ->getUserManager(function (MockObject $qb): void {
+                $qb->expects($this->never())->method('andWhere');
+                $qb->expects($this->never())->method('orderBy');
+                $qb->expects($this->never())->method('setParameters');
             })
             ->getPager([], 1, 10, ['invalid' => 'ASC']);
     }
 
     public function testGetPagerWithValidSortDesc(): void
     {
-        $self = $this;
         $this
-            ->getUserManager(static function (MockObject $qb) use ($self): void {
-                $qb->expects($self->once())->method('getRootAliases')->willReturn(['u']);
-                $qb->expects($self->once())->method('andWhere')->with($self->equalTo('u.enabled = :enabled'));
-                $qb->expects($self->once())->method('setParameter')->with(
-                    $self->equalTo('enabled'),
-                    $self->equalTo(true)
+            ->getUserManager(function (MockObject $qb): void {
+                $qb->expects($this->once())->method('getRootAliases')->willReturn(['u']);
+                $qb->expects($this->once())->method('andWhere')->with($this->equalTo('u.enabled = :enabled'));
+                $qb->expects($this->once())->method('setParameter')->with(
+                    $this->equalTo('enabled'),
+                    $this->equalTo(true)
                 );
-                $qb->expects($self->once())->method('orderBy')->with(
-                    $self->equalTo('u.email'),
-                    $self->equalTo('DESC')
+                $qb->expects($this->once())->method('orderBy')->with(
+                    $this->equalTo('u.email'),
+                    $this->equalTo('DESC')
                 );
             })
             ->getPager(['enabled' => true], 1, 10, ['email' => 'DESC']);
@@ -76,18 +73,17 @@ class UserManagerTest extends TestCase
 
     public function testGetPagerWithEnabledUsers(): void
     {
-        $self = $this;
         $this
-            ->getUserManager(static function (MockObject $qb) use ($self): void {
-                $qb->expects($self->once())->method('getRootAliases')->willReturn(['u']);
-                $qb->expects($self->once())->method('andWhere')->with($self->equalTo('u.enabled = :enabled'));
-                $qb->expects($self->once())->method('setParameter')->with(
-                    $self->equalTo('enabled'),
-                    $self->equalTo(true)
+            ->getUserManager(function (MockObject $qb): void {
+                $qb->expects($this->once())->method('getRootAliases')->willReturn(['u']);
+                $qb->expects($this->once())->method('andWhere')->with($this->equalTo('u.enabled = :enabled'));
+                $qb->expects($this->once())->method('setParameter')->with(
+                    $this->equalTo('enabled'),
+                    $this->equalTo(true)
                 );
-                $qb->expects($self->once())->method('orderBy')->with(
-                    $self->equalTo('u.username'),
-                    $self->equalTo('ASC')
+                $qb->expects($this->once())->method('orderBy')->with(
+                    $this->equalTo('u.username'),
+                    $this->equalTo('ASC')
                 );
             })
             ->getPager(['enabled' => true], 1);
@@ -95,18 +91,17 @@ class UserManagerTest extends TestCase
 
     public function testGetPagerWithDisabledUsers(): void
     {
-        $self = $this;
         $this
-            ->getUserManager(static function (MockObject $qb) use ($self): void {
-                $qb->expects($self->once())->method('getRootAliases')->willReturn(['u']);
-                $qb->expects($self->once())->method('andWhere')->with($self->equalTo('u.enabled = :enabled'));
-                $qb->expects($self->once())->method('setParameter')->with(
-                    $self->equalTo('enabled'),
-                    $self->equalTo(false)
+            ->getUserManager(function (MockObject $qb): void {
+                $qb->expects($this->once())->method('getRootAliases')->willReturn(['u']);
+                $qb->expects($this->once())->method('andWhere')->with($this->equalTo('u.enabled = :enabled'));
+                $qb->expects($this->once())->method('setParameter')->with(
+                    $this->equalTo('enabled'),
+                    $this->equalTo(false)
                 );
-                $qb->expects($self->once())->method('orderBy')->with(
-                    $self->equalTo('u.username'),
-                    $self->equalTo('ASC')
+                $qb->expects($this->once())->method('orderBy')->with(
+                    $this->equalTo('u.username'),
+                    $this->equalTo('ASC')
                 );
             })
             ->getPager(['enabled' => false], 1);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Leverage `$this` binding in anonymous functions.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are pedantic.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->