### PR TITLE
Update constraints in order to allow some "symfony/*:^5.2" deps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,16 +29,16 @@
         "sonata-project/datagrid-bundle": "^3.0.1",
         "sonata-project/doctrine-extensions": "^1.10.1",
         "sonata-project/form-extensions": "^0.1 || ^1.4",
-        "symfony/config": "^4.4",
+        "symfony/config": "^4.4 || ^5.2",
         "symfony/console": "^4.4",
-        "symfony/dependency-injection": "^4.4",
+        "symfony/dependency-injection": "^4.4 || ^5.2",
         "symfony/form": "^4.4",
         "symfony/framework-bundle": "^4.4",
-        "symfony/http-foundation": "^4.4",
+        "symfony/http-foundation": "^4.4 || ^5.2",
         "symfony/http-kernel": "^4.4",
-        "symfony/mailer": "^4.4 || ^5.1",
-        "symfony/mime": "^4.4.10 || ^5.1",
-        "symfony/options-resolver": "^4.4 || ^5.1",
+        "symfony/mailer": "^4.4 || ^5.2",
+        "symfony/mime": "^4.4.10 || ^5.2",
+        "symfony/options-resolver": "^4.4 || ^5.2",
         "symfony/security-acl": "^3.0",
         "symfony/security-core": "^4.4",
         "symfony/translation": "^4.4",
@@ -47,7 +47,7 @@
     "conflict": {
         "friendsofsymfony/rest-bundle": "<2.1",
         "jms/serializer": "<1.3 || >=4.0",
-        "nelmio/api-doc-bundle": "<2.13 || >=4.0",
+        "nelmio/api-doc-bundle": "<2.13.5 || >=4.0",
         "sonata-project/core-bundle": "<3.20",
         "sonata-project/doctrine-orm-admin-bundle": "<3.0",
         "sonata-project/google-authenticator": "<1.0"
@@ -61,19 +61,19 @@
         "jms/serializer-bundle": "^1.0 || ^2.0 || ^3.0",
         "matthiasnoback/symfony-config-test": "^4.2",
         "matthiasnoback/symfony-dependency-injection-test": "^4.0",
-        "nelmio/api-doc-bundle": "^2.13.4 || ^3.6",
+        "nelmio/api-doc-bundle": "^2.13.5 || ^3.6",
         "sonata-project/doctrine-orm-admin-bundle": "^3.18",
         "sonata-project/google-authenticator": "^1.0 || ^2.0",
-        "symfony/browser-kit": "^4.4 || ^5.1",
-        "symfony/phpunit-bridge": "^5.1.8",
+        "symfony/browser-kit": "^4.4 || ^5.2",
+        "symfony/phpunit-bridge": "^5.2",
         "symfony/swiftmailer-bundle": "^3.4"
     },
     "suggest": {
         "friendsofsymfony/rest-bundle": "For using the public API methods.",
         "jms/serializer": "For using the public API methods.",
         "nelmio/api-doc-bundle": "For using the public API methods.",
-        "sonata-project/doctrine-orm-admin-bundle": "For persisting entities",
-        "sonata-project/google-authenticator": "For google auth user login"
+        "sonata-project/doctrine-orm-admin-bundle": "For persisting entities.",
+        "sonata-project/google-authenticator": "For google auth user login."
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Update constraints in order to allow some "symfony/*:^5.2" deps.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataUserBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Support for "symfony/http-foundation:^5.2";
- Support for "symfony/dependency-injection:^5.2";
- Support for "symfony/config:^5.2".
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
