### PR TITLE
Translation fix 4.x

### DIFF
--- a/src/Resources/translations/SonataUserBundle.en.xliff
+++ b/src/Resources/translations/SonataUserBundle.en.xliff
@@ -235,19 +235,19 @@
         <target>Users</target>
       </trans-unit>
       <trans-unit id="form_general">
-        <source>General</source>
+        <source>form_general</source>
         <target>General</target>
       </trans-unit>
       <trans-unit id="form_groups">
-        <source>Groups</source>
+        <source>form_groups</source>
         <target>Groups</target>
       </trans-unit>
       <trans-unit id="form_management">
-        <source>Management</source>
+        <source>form_management</source>
         <target>Management</target>
       </trans-unit>
       <trans-unit id="form_status">
-        <source>Status</source>
+        <source>form_status</source>
         <target>Status</target>
       </trans-unit>
       <trans-unit id="field.label_roles_editable">

--- a/src/Resources/translations/SonataUserBundle.lt.xliff
+++ b/src/Resources/translations/SonataUserBundle.lt.xliff
@@ -227,15 +227,15 @@
         <target>Naudotojai</target>
       </trans-unit>
       <trans-unit id="form_general">
-        <source>General</source>
+        <source>form_general</source>
         <target>Pagrindinis</target>
       </trans-unit>
       <trans-unit id="form_groups">
-        <source>Groups</source>
+        <source>form_groups</source>
         <target>Grupės</target>
       </trans-unit>
       <trans-unit id="form_management">
-        <source>Management</source>
+        <source>form_management</source>
         <target>Valdymas</target>
       </trans-unit>
       <trans-unit id="field.label_roles_editable">

--- a/src/Resources/translations/SonataUserBundle.ru.xliff
+++ b/src/Resources/translations/SonataUserBundle.ru.xliff
@@ -263,27 +263,27 @@
         <target>Пользователи</target>
       </trans-unit>
       <trans-unit id="form_general">
-        <source>General</source>
+        <source>form_general</source>
         <target>Основные сведения</target>
       </trans-unit>
       <trans-unit id="form_groups">
-        <source>Groups</source>
+        <source>form_groups</source>
         <target>Группы</target>
       </trans-unit>
       <trans-unit id="form_management">
-        <source>Management</source>
+        <source>form_management</source>
         <target>Управление ролями</target>
       </trans-unit>
       <trans-unit id="form_profile">
-        <source>Profile</source>
+        <source>form_profile</source>
         <target>Профиль</target>
       </trans-unit>
       <trans-unit id="form_social">
-        <source>Social</source>
+        <source>form_social</source>
         <target>Социальные сети</target>
       </trans-unit>
       <trans-unit id="form_security">
-        <source>Security</source>
+        <source>form_security</source>
         <target>Безопасность</target>
       </trans-unit>
       <trans-unit id="form.label_website">


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Fixed translation keys for en lt and ru languages.

## Changelog

```markdown
### Fixed
- `en`, `lt`, and `ru` translation keys
```
