### PR TITLE
Update login.html.twig

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "doctrine/common": "^2.0 || ^3.1",
         "doctrine/persistence": "^1.3 || ^2.1",
         "friendsofsymfony/user-bundle": "^2.0",
-        "sonata-project/admin-bundle": "^3.76",
+        "sonata-project/admin-bundle": "^3.104",
         "sonata-project/datagrid-bundle": "^3.0.1",
         "sonata-project/doctrine-extensions": "^1.10.1",
         "sonata-project/form-extensions": "^0.1 || ^1.4",

--- a/src/Resources/views/Admin/Security/Resetting/checkEmail.html.twig
+++ b/src/Resources/views/Admin/Security/Resetting/checkEmail.html.twig
@@ -28,13 +28,19 @@ file that was distributed with this source code.
         {% block login_box_header %}
             <div class="login-logo">
                 <a href="{{ path('sonata_admin_dashboard') }}">
-                    {% if admin_pool.getOption('title_mode') in ['single_image', 'both'] %}
+                    {% if 'icon' == sonata_config.getOption('logo_content')
+                        or 'all' == sonata_config.getOption('logo_content')
+                        and ('single_image' == sonata_config.getOption('title_mode') or 'both' == sonata_config.getOption('title_mode'))
+                    %}
                         <div>
-                            <img style="width:64px;" src="{{ asset(admin_pool.titlelogo) }}" alt="{{ admin_pool.title }}">
+                            <img style="width:64px;" src="{{ asset(sonata_config.logo) }}" alt="{{ sonata_config.title }}">
                         </div>
                     {% endif %}
-                    {% if admin_pool.getOption('title_mode') in ['single_text', 'both'] %}
-                        <span>{{ admin_pool.title }}</span>
+                    {% if 'text' == sonata_config.getOption('logo_content')
+                        or 'all' == sonata_config.getOption('logo_content')
+                        and ('single_text' == sonata_config.getOption('title_mode') or 'both' == sonata_config.getOption('title_mode'))
+                    %}
+                        <span>{{ sonata_config.title }}</span>
                     {% endif %}
                 </a>
             </div>

--- a/src/Resources/views/Admin/Security/Resetting/request.html.twig
+++ b/src/Resources/views/Admin/Security/Resetting/request.html.twig
@@ -28,13 +28,19 @@ file that was distributed with this source code.
         {% block login_box_header %}
             <div class="login-logo">
                 <a href="{{ path('sonata_admin_dashboard') }}">
-                    {% if admin_pool.getOption('title_mode') in ['single_image', 'both'] %}
+                    {% if 'icon' == sonata_config.getOption('logo_content')
+                        or 'all' == sonata_config.getOption('logo_content')
+                        and ('single_image' == sonata_config.getOption('title_mode') or 'both' == sonata_config.getOption('title_mode'))
+                    %}
                         <div>
-                            <img style="width:64px;" src="{{ asset(admin_pool.titlelogo) }}" alt="{{ admin_pool.title }}">
+                            <img style="width:64px;" src="{{ asset(sonata_config.logo) }}" alt="{{ sonata_config.title }}">
                         </div>
                     {% endif %}
-                    {% if admin_pool.getOption('title_mode') in ['single_text', 'both'] %}
-                        <span>{{ admin_pool.title }}</span>
+                    {% if 'text' == sonata_config.getOption('logo_content')
+                        or 'all' == sonata_config.getOption('logo_content')
+                        and ('single_text' == sonata_config.getOption('title_mode') or 'both' == sonata_config.getOption('title_mode'))
+                    %}
+                        <span>{{ sonata_config.title }}</span>
                     {% endif %}
                 </a>
             </div>

--- a/src/Resources/views/Admin/Security/Resetting/reset.html.twig
+++ b/src/Resources/views/Admin/Security/Resetting/reset.html.twig
@@ -28,13 +28,19 @@ file that was distributed with this source code.
         {% block login_box_header %}
             <div class="login-logo">
                 <a href="{{ path('sonata_admin_dashboard') }}">
-                    {% if admin_pool.getOption('title_mode') in ['single_image', 'both'] %}
+                    {% if 'icon' == sonata_config.getOption('logo_content')
+                        or 'all' == sonata_config.getOption('logo_content')
+                        and ('single_image' == sonata_config.getOption('title_mode') or 'both' == sonata_config.getOption('title_mode'))
+                    %}
                         <div>
-                            <img style="width:64px;" src="{{ asset(admin_pool.titlelogo) }}" alt="{{ admin_pool.title }}">
+                            <img style="width:64px;" src="{{ asset(sonata_config.logo) }}" alt="{{ sonata_config.title }}">
                         </div>
                     {% endif %}
-                    {% if admin_pool.getOption('title_mode') in ['single_text', 'both'] %}
-                        <span>{{ admin_pool.title }}</span>
+                    {% if 'text' == sonata_config.getOption('logo_content')
+                        or 'all' == sonata_config.getOption('logo_content')
+                        and ('single_text' == sonata_config.getOption('title_mode') or 'both' == sonata_config.getOption('title_mode'))
+                    %}
+                        <span>{{ sonata_config.title }}</span>
                     {% endif %}
                 </a>
             </div>

--- a/src/Resources/views/Admin/Security/login.html.twig
+++ b/src/Resources/views/Admin/Security/login.html.twig
@@ -33,14 +33,14 @@ file that was distributed with this source code.
                         and ('single_image' == sonata_config.getOption('title_mode') or 'both' == sonata_config.getOption('title_mode'))
                     %}
                         <div>
-                            <img style="width:64px;" src="{{ asset(sonata_admin.adminPool.titlelogo) }}" alt="{{ sonata_admin.adminPool.title }}">
+                            <img style="width:64px;" src="{{ asset(sonata_config.titlelogo) }}" alt="{{ sonata_config.title }}">
                         </div>
                     {% endif %}
                     {% if 'text' == sonata_config.getOption('logo_content')
                         or 'all' == sonata_config.getOption('logo_content')
                         and ('single_text' == sonata_config.getOption('title_mode') or 'both' == sonata_config.getOption('title_mode'))
                     %}
-                        <span>{{ sonata_admin.adminPool.title }}</span>
+                        <span>{{ sonata_config.title }}</span>
                     {% endif %}
                 </a>
             </div>

--- a/src/Resources/views/Admin/Security/login.html.twig
+++ b/src/Resources/views/Admin/Security/login.html.twig
@@ -33,7 +33,7 @@ file that was distributed with this source code.
                         and ('single_image' == sonata_config.getOption('title_mode') or 'both' == sonata_config.getOption('title_mode'))
                     %}
                         <div>
-                            <img style="width:64px;" src="{{ asset(sonata_config.titlelogo) }}" alt="{{ sonata_config.title }}">
+                            <img style="width:64px;" src="{{ asset(sonata_config.logo) }}" alt="{{ sonata_config.title }}">
                         </div>
                     {% endif %}
                     {% if 'text' == sonata_config.getOption('logo_content')

--- a/src/Resources/views/Admin/Security/login.html.twig
+++ b/src/Resources/views/Admin/Security/login.html.twig
@@ -28,12 +28,18 @@ file that was distributed with this source code.
         {% block login_box_header %}
             <div class="login-logo">
                 <a href="{{ path('sonata_admin_dashboard') }}">
-                    {% if sonata_admin.adminPool.getOption('title_mode') in ['single_image', 'both'] or sonata_admin.adminPool.getOption('logo_content') in ['icon', 'all'] %}
+                    {% if 'icon' == sonata_config.getOption('logo_content')
+                        or 'all' == sonata_config.getOption('logo_content')
+                        and ('single_image' == sonata_config.getOption('title_mode') or 'both' == sonata_config.getOption('title_mode'))
+                    %}
                         <div>
                             <img style="width:64px;" src="{{ asset(sonata_admin.adminPool.titlelogo) }}" alt="{{ sonata_admin.adminPool.title }}">
                         </div>
                     {% endif %}
-                    {% if sonata_admin.adminPool.getOption('title_mode') in ['single_text', 'both'] or sonata_admin.adminPool.getOption('logo_content') in ['text', 'all'] %}
+                    {% if 'text' == sonata_config.getOption('logo_content')
+                        or 'all' == sonata_config.getOption('logo_content')
+                        and ('single_text' == sonata_config.getOption('title_mode') or 'both' == sonata_config.getOption('title_mode'))
+                    %}
                         <span>{{ sonata_admin.adminPool.title }}</span>
                     {% endif %}
                 </a>

--- a/src/Resources/views/Admin/Security/login.html.twig
+++ b/src/Resources/views/Admin/Security/login.html.twig
@@ -28,12 +28,12 @@ file that was distributed with this source code.
         {% block login_box_header %}
             <div class="login-logo">
                 <a href="{{ path('sonata_admin_dashboard') }}">
-                    {% if sonata_admin.adminPool.getOption('title_mode') in ['single_image', 'both'] %}
+                    {% if sonata_admin.adminPool.getOption('title_mode') in ['single_image', 'both'] or sonata_admin.adminPool.getOption('logo_content') in ['icon', 'all'] %}
                         <div>
                             <img style="width:64px;" src="{{ asset(sonata_admin.adminPool.titlelogo) }}" alt="{{ sonata_admin.adminPool.title }}">
                         </div>
                     {% endif %}
-                    {% if sonata_admin.adminPool.getOption('title_mode') in ['single_text', 'both'] %}
+                    {% if sonata_admin.adminPool.getOption('title_mode') in ['single_text', 'both'] or sonata_admin.adminPool.getOption('logo_content') in ['text', 'all'] %}
                         <span>{{ sonata_admin.adminPool.title }}</span>
                     {% endif %}
                 </a>


### PR DESCRIPTION
## Subject

Taking into account the following change : "title_mode" (with values "single_image", "single_text", "both") is deprecated since sonata-project/admin-bundle 3.104 and replaced by "logo_content" (with values "icon", "text", "all").

I'm not sure if I should've added a comment "{# NEXT_MAJOR: Remove the title_mode check #}" because it is for the next major of SonataAdminBundle.

## Changelog
```markdown
### Fixed
- Taking into account sonata_admin.options.logo_content configuration value
```