### PR TITLE
Deprecate Google Authenticator integration

### DIFF
--- a/src/Command/TwoStepVerificationCommand.php
+++ b/src/Command/TwoStepVerificationCommand.php
@@ -23,7 +23,9 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * NEXT_MAJOR: stop extending ContainerAwareCommand.
+ * NEXT_MAJOR: Remove this command.
+ *
+ * @deprecated since sonata-project/user-bundle 4.x, it will be removed on 5.0.
  */
 class TwoStepVerificationCommand extends ContainerAwareCommand
 {

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -61,6 +61,7 @@ class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
                 ->arrayNode('google_authenticator')
+                    ->setDeprecated('The "%node%" option is deprecated.')
                     ->addDefaultsIfNotSet()
                     ->children()
                         ->scalarNode('server')->cannotBeEmpty()->end()

--- a/src/DependencyInjection/SonataUserExtension.php
+++ b/src/DependencyInjection/SonataUserExtension.php
@@ -64,6 +64,7 @@ class SonataUserExtension extends Extension implements PrependExtensionInterface
 
         $loader->load('form.xml');
 
+        // NEXT_MAJOR: Remove this condition.
         if (class_exists('Google\Authenticator\GoogleAuthenticator')) {
             @trigger_error(
                 'The \'Google\Authenticator\' namespace is deprecated in sonata-project/GoogleAuthenticator since version 2.1 and will be removed in 3.0.',
@@ -71,6 +72,7 @@ class SonataUserExtension extends Extension implements PrependExtensionInterface
             );
         }
 
+        // NEXT_MAJOR: Remove this condition and all the configuration related to this.
         if (class_exists('Google\Authenticator\GoogleAuthenticator') ||
             class_exists('Sonata\GoogleAuthenticator\GoogleAuthenticator')) {
             $loader->load('google_authenticator.xml');
@@ -157,6 +159,8 @@ class SonataUserExtension extends Extension implements PrependExtensionInterface
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
      * @param array $config
      *
      * @throws \RuntimeException
@@ -176,10 +180,17 @@ class SonataUserExtension extends Extension implements PrependExtensionInterface
             return;
         }
 
-        if (!class_exists('Google\Authenticator\GoogleAuthenticator')
-            && !class_exists('Sonata\GoogleAuthenticator\GoogleAuthenticator')) {
+        if (
+            !class_exists('Google\Authenticator\GoogleAuthenticator')
+            && !class_exists('Sonata\GoogleAuthenticator\GoogleAuthenticator')
+        ) {
             throw new \RuntimeException('Please add "sonata-project/google-authenticator" package');
         }
+
+        @trigger_error(
+            'The Google Authenticator integration is deprecated since sonata-project/user-bundle 4.x and will be removed in 5.0.',
+            \E_USER_DEPRECATED
+        );
 
         $container->setParameter('sonata.user.google.authenticator.forced_for_role', $config['google_authenticator']['forced_for_role']);
 

--- a/src/GoogleAuthenticator/Helper.php
+++ b/src/GoogleAuthenticator/Helper.php
@@ -19,6 +19,11 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
+/**
+ * NEXT_MAJOR: Remove this class.
+ *
+ * @deprecated since sonata-project/user-bundle 4.x, it will be removed on 5.0.
+ */
 class Helper
 {
     /**

--- a/src/GoogleAuthenticator/InteractiveLoginListener.php
+++ b/src/GoogleAuthenticator/InteractiveLoginListener.php
@@ -17,6 +17,11 @@ use Sonata\UserBundle\Model\UserInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
 
+/**
+ * NEXT_MAJOR: Remove this class.
+ *
+ * @deprecated since sonata-project/user-bundle 4.x, it will be removed on 5.0.
+ */
 class InteractiveLoginListener
 {
     /**

--- a/src/GoogleAuthenticator/RequestListener.php
+++ b/src/GoogleAuthenticator/RequestListener.php
@@ -21,6 +21,11 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Twig\Environment;
 
+/**
+ * NEXT_MAJOR: Remove this class.
+ *
+ * @deprecated since sonata-project/user-bundle 4.x, it will be removed on 5.0.
+ */
 class RequestListener
 {
     /**


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

This integration is deprecated in preparation for 5.0. On Next major we will propose something with https://github.com/scheb/2fa Probably some docs about how to integrate the two bundles.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataUserBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecated the integration with `sonata-project/GoogleAuthenticator`
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
