### PR TITLE
[POC] Add symfonycasts/reset-password-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
         "symfony/security-acl": "^3.0",
         "symfony/security-core": "^4.4.23",
         "symfony/translation": "^4.4",
+        "symfonycasts/reset-password-bundle": "^1.11",
         "twig/twig": "^2.9 || ^3.0"
     },
     "require-dev": {

--- a/src/Action/CheckEmailAction.php
+++ b/src/Action/CheckEmailAction.php
@@ -21,6 +21,12 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Twig\Environment;
 
+/**
+ * NEXT_MAJOR: remove this class.
+ *
+ * @deprecated since version 4.x, to be removed in 5.0.
+ * Use Sonata\UserBundle\Action\Resetting\CheckEmailAction and install `symfonycasts/reset-password-bundle` instead
+ */
 final class CheckEmailAction
 {
     /**

--- a/src/Action/PasswordResetting/CheckEmailAction.php
+++ b/src/Action/PasswordResetting/CheckEmailAction.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Sonata\UserBundle\Action\PasswordResetting;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use SymfonyCasts\Bundle\ResetPassword\Controller\ResetPasswordControllerTrait;
+
+class CheckEmailAction extends AbstractController
+{
+    use ResetPasswordControllerTrait;
+
+    public function __invoke(Request $request): Response
+    {
+        // Generate a fake token if the user does not exist or someone hit this page directly .
+        // This prevents exposing whether or not a user was found with the given email address or not
+        if (null === ($resetToken = $this->getTokenObjectFromSession())) {
+            $resetToken = $this->resetPasswordHelper->generateFakeResetToken();
+        }
+
+        return $this->render('security/reset_password/check_email.html.twig', [
+            'resetToken' => $resetToken,
+        ]);
+    }
+}

--- a/src/Action/PasswordResetting/RequestAction.php
+++ b/src/Action/PasswordResetting/RequestAction.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Sonata\UserBundle\Action\PasswordResetting;
+
+use App\Form\ResetPasswordRequestFormType;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use SymfonyCasts\Bundle\ResetPassword\Controller\ResetPasswordControllerTrait;
+
+class RequestAction extends AbstractController
+{
+    use ResetPasswordControllerTrait;
+
+    public function __invoke(Request $request): Response
+    {
+        $form = $this->createForm(ResetPasswordRequestFormType::class);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            return $this->processSendingPasswordResetEmail(
+                $form->get('email')->getData(),
+                $mailer
+            );
+        }
+
+        return $this->render('security/reset_password/request.html.twig', [
+            'requestForm' => $form->createView(),
+        ]);
+    }
+}

--- a/src/Action/PasswordResetting/ResetAction.php
+++ b/src/Action/PasswordResetting/ResetAction.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Sonata\UserBundle\Action\PasswordResetting;
+
+use App\Form\ChangePasswordFormType;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use SymfonyCasts\Bundle\ResetPassword\Controller\ResetPasswordControllerTrait;
+use SymfonyCasts\Bundle\ResetPassword\Exception\ResetPasswordExceptionInterface;
+use SymfonyCasts\Bundle\ResetPassword\ResetPasswordHelperInterface;
+
+class ResetAction extends AbstractController
+{
+    use ResetPasswordControllerTrait;
+
+    private ResetPasswordHelperInterface $resetPasswordHelper;
+
+    public function __construct(ResetPasswordHelperInterface $resetPasswordHelper)
+    {
+        $this->resetPasswordHelper = $resetPasswordHelper;
+    }
+
+    public function __invoke(Request $request, UserPasswordHasherInterface $userPasswordHasherInterface, string $token = null): Response
+    {
+        if ($token) {
+            // We store the token in session and remove it from the URL, to avoid the URL being
+            // loaded in a browser and potentially leaking the token to 3rd party JavaScript.
+            $this->storeTokenInSession($token);
+
+            return $this->redirectToRoute('app_reset_password');
+        }
+
+        $token = $this->getTokenFromSession();
+        if (null === $token) {
+            throw $this->createNotFoundException('No reset password token found in the URL or in the session.');
+        }
+
+        try {
+            $user = $this->resetPasswordHelper->validateTokenAndFetchUser($token);
+        } catch (ResetPasswordExceptionInterface $e) {
+            $this->addFlash('reset_password_error', sprintf(
+                'There was a problem validating your reset request - %s',
+                $e->getReason()
+            ));
+
+            return $this->redirectToRoute('app_forgot_password_request');
+        }
+
+        // The token is valid; allow the user to change their password.
+        $form = $this->createForm(ChangePasswordFormType::class);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            // A password reset token should be used only once, remove it.
+            $this->resetPasswordHelper->removeResetRequest($token);
+
+            // Encode(hash) the plain password, and set it.
+            $encodedPassword = $userPasswordHasherInterface->hashPassword(
+                $user,
+                $form->get('plainPassword')->getData()
+            );
+
+            $user->setPassword($encodedPassword);
+            $this->getDoctrine()->getManager()->flush();
+
+            // The session is cleaned up after the password has been changed.
+            $this->cleanSessionAfterReset();
+
+            return $this->redirectToRoute('cargo_index');
+        }
+
+        return $this->render('security/reset_password/reset.html.twig', [
+            'resetForm' => $form->createView(),
+        ]);
+    }
+}

--- a/src/Action/RequestAction.php
+++ b/src/Action/RequestAction.php
@@ -22,6 +22,12 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Twig\Environment;
 
+/**
+ * NEXT_MAJOR: remove this class.
+ *
+ * @deprecated since version 4.x, to be removed in 5.0.
+ * Use Sonata\UserBundle\Action\Resetting\RequestAction and install `symfonycasts/reset-password-bundle` instead
+ */
 final class RequestAction
 {
     /**

--- a/src/Action/ResetAction.php
+++ b/src/Action/ResetAction.php
@@ -31,6 +31,12 @@ use Symfony\Component\Security\Core\Exception\AccountStatusException;
 use Symfony\Component\Translation\TranslatorInterface;
 use Twig\Environment;
 
+/**
+ * NEXT_MAJOR: remove this class.
+ *
+ * @deprecated since version 4.x, to be removed in 5.0.
+ * Use Sonata\UserBundle\Action\Resetting\ResetAction and install `symfonycasts/reset-password-bundle` instead
+ */
 final class ResetAction
 {
     use LoggerAwareTrait;


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

POC for replace FOSUser resetting password into symfonycasts resetting password.

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because {reason}.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #{put_issue_number_here}.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataUserBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added some `Class::newMethod()` to do great stuff.

### Changed

### Deprecated

### Removed

### Fixed

### Security
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
