### PR TITLE
Ensure emails are sent to correct address with html

### DIFF
--- a/tests/Functional/Action/RequestActionTest.php
+++ b/tests/Functional/Action/RequestActionTest.php
@@ -55,6 +55,13 @@ final class RequestActionTest extends WebTestCase
         ]);
 
         static::assertEmailCount(1);
+
+        $mail = static::getMailerMessage();
+
+        static::assertNotNull($mail);
+        static::assertEmailHtmlBodyContains($mail, 'To reset your password - please visit');
+        static::assertEmailAddressContains($mail, 'to', 'email@localhost.com');
+
         static::assertRouteSame('sonata_user_admin_resetting_send_email');
 
         $client->followRedirect();


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this add tests for html emails.

This is pedantic since it only checks that emails are sent with html, not plain text.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1094 .
Part of #1465 
