### PR TITLE
Make SonataAdminBundle dependency optional

### DIFF
--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -24,6 +24,12 @@ FOSUserBundle dependency was removed. Main features of that bundle were migrated
 inside SonataUserBundle. Make sure you run your migrations and remove FOSUserBundle
 from your code and dependencies, unless you need it for other purposes.
 
+## SonataAdminBundle is optional
+
+SonataAdminBundle (sonata-project/admin-bundle) dependency has become optional. If you're using
+that bundle, we recommend requiring it explicitly in your composer.json. Note that attempt to use
+`sonata_user.userAdmin` Twig variable will throw a `\LogicException` if SonataAdminBundle is not installed.
+
 ## Deprecations
 
 All the deprecated code introduced on 4.x is removed on 5.0.

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,6 @@
         "doctrine/collections": "^1.6",
         "doctrine/common": "^3.1",
         "doctrine/persistence": "^2.1",
-        "sonata-project/admin-bundle": "^4.8",
         "sonata-project/doctrine-extensions": "^1.13",
         "sonata-project/form-extensions": "^1.4",
         "sonata-project/twig-extensions": "^1.3",
@@ -65,6 +64,7 @@
         "phpunit/phpunit": "^9.5",
         "psalm/plugin-phpunit": "^0.16",
         "psalm/plugin-symfony": "^3.0",
+        "sonata-project/admin-bundle": "^4.8",
         "sonata-project/block-bundle": "^4.0",
         "sonata-project/doctrine-orm-admin-bundle": "^4.0",
         "symfony/browser-kit": "^4.4 || ^5.3 || ^6.0",
@@ -78,7 +78,8 @@
         "sonata-project/doctrine-orm-admin-bundle": "<4.0"
     },
     "suggest": {
-        "sonata-project/doctrine-orm-admin-bundle": "For persisting entities"
+        "sonata-project/doctrine-orm-admin-bundle": "For persisting entities",
+        "sonata-project/admin-bundle": "For admin dashboard to manage users and other entities"
     },
     "autoload": {
         "psr-4": {
@@ -91,6 +92,9 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "phpstan/extension-installer": true
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -78,8 +78,8 @@
         "sonata-project/doctrine-orm-admin-bundle": "<4.0"
     },
     "suggest": {
-        "sonata-project/doctrine-orm-admin-bundle": "For persisting entities",
-        "sonata-project/admin-bundle": "For admin dashboard to manage users and other entities"
+        "sonata-project/admin-bundle": "For admin dashboard to manage users and other entities",
+        "sonata-project/doctrine-orm-admin-bundle": "For persisting entities"
     },
     "autoload": {
         "psr-4": {
@@ -92,9 +92,6 @@
         }
     },
     "config": {
-        "sort-packages": true,
-        "allow-plugins": {
-            "phpstan/extension-installer": true
-        }
+        "sort-packages": true
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -74,6 +74,7 @@
         "vimeo/psalm": "^4.9.2"
     },
     "conflict": {
+        "sonata-project/admin-bundle": "<4.8",
         "sonata-project/block-bundle": "<4.0",
         "sonata-project/doctrine-orm-admin-bundle": "<4.0"
     },

--- a/docs/reference/installation.rst
+++ b/docs/reference/installation.rst
@@ -8,13 +8,12 @@ Installation
 Prerequisites
 -------------
 
-There are some Sonata dependencies that need to be installed and configured beforehand.
-
-Required dependencies:
+If you're planning on using this bundle with SonataAdminBundle, you may want to install
+and configure that bundle first.
 
 * `SonataAdminBundle <https://docs.sonata-project.org/projects/SonataAdminBundle/en/4.x/>`_
 
-And the persistence bundle (choose one):
+and the persistence bundle (choose one):
 
 * `SonataDoctrineORMAdminBundle <https://docs.sonata-project.org/projects/SonataDoctrineORMAdminBundle/en/4.x/>`_
 * `SonataDoctrineMongoDBAdminBundle <https://docs.sonata-project.org/projects/SonataDoctrineMongoDBAdminBundle/en/4.x/>`_
@@ -167,6 +166,11 @@ Your mailer will have to implement ``Sonata\UserBundle\Mailer\MailerInterface``.
 
 Integrating the bundle into the Sonata Admin Bundle
 ---------------------------------------------------
+
+.. note::
+
+    If you're using this bundle without the optional Sonata Admin Bundle,
+    please, ignore this section.
 
 Add the related security routing information:
 

--- a/src/DependencyInjection/SonataUserExtension.php
+++ b/src/DependencyInjection/SonataUserExtension.php
@@ -49,9 +49,7 @@ final class SonataUserExtension extends Extension implements PrependExtensionInt
         if (isset($bundles['SonataAdminBundle'])) {
             $loader->load('admin.php');
             $loader->load(sprintf('admin_%s.php', $config['manager_type']));
-            $this->configureAdmin($config['admin'], $container);
             $loader->load('actions.php');
-            $this->configureResetting($config['resetting'], $container);
         }
 
         $loader->load(sprintf('%s.php', $config['manager_type']));
@@ -74,6 +72,10 @@ final class SonataUserExtension extends Extension implements PrependExtensionInt
         $this->configureClass($config, $container);
         $this->configureMailer($config, $container);
         $this->configureDefaultAvatar($config['profile'], $container);
+        if (isset($bundles['SonataAdminBundle'])) {
+            $this->configureAdmin($config['admin'], $container);
+            $this->configureResetting($config['resetting'], $container);
+        }
 
         if ($this->isConfigEnabled($container, $config['impersonating'])) {
             $this->configureImpersonation($config['impersonating'], $container);

--- a/src/DependencyInjection/SonataUserExtension.php
+++ b/src/DependencyInjection/SonataUserExtension.php
@@ -49,12 +49,14 @@ final class SonataUserExtension extends Extension implements PrependExtensionInt
         if (isset($bundles['SonataAdminBundle'])) {
             $loader->load('admin.php');
             $loader->load(sprintf('admin_%s.php', $config['manager_type']));
+            $this->configureAdmin($config['admin'], $container);
+            $loader->load('actions.php');
+            $this->configureResetting($config['resetting'], $container);
         }
 
         $loader->load(sprintf('%s.php', $config['manager_type']));
 
         $loader->load('twig.php');
-        $loader->load('actions.php');
         $loader->load('commands.php');
         $loader->load('listener.php');
         $loader->load('mailer.php');
@@ -70,9 +72,7 @@ final class SonataUserExtension extends Extension implements PrependExtensionInt
         $this->checkManagerTypeToModelTypesMapping($config);
 
         $this->configureClass($config, $container);
-        $this->configureAdmin($config['admin'], $container);
         $this->configureMailer($config, $container);
-        $this->configureResetting($config['resetting'], $container);
         $this->configureDefaultAvatar($config['profile'], $container);
 
         if ($this->isConfigEnabled($container, $config['impersonating'])) {

--- a/src/Resources/config/twig.php
+++ b/src/Resources/config/twig.php
@@ -21,7 +21,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
         ->set('sonata.user.twig.global', GlobalVariables::class)
             ->args([
-                new ReferenceConfigurator('sonata.admin.pool'),
+                (new ReferenceConfigurator('sonata.admin.pool'))->nullOnInvalid(),
                 '',
                 false,
                 '',

--- a/src/Twig/GlobalVariables.php
+++ b/src/Twig/GlobalVariables.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sonata\UserBundle\Twig;
 
-use LogicException;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool;
 
@@ -58,8 +57,9 @@ final class GlobalVariables
     public function getUserAdmin(): AdminInterface
     {
         if (null === $this->pool) {
-            throw new LogicException('Unable to get the UserAdmin, admin pool is not configured. You should install SonataAdminBundle in order to use admin-related features.');
+            throw new \LogicException('Unable to get the UserAdmin, admin pool is not configured. You should install SonataAdminBundle in order to use admin-related features.');
         }
+
         return $this->pool->getAdminByAdminCode('sonata.user.admin.user');
     }
 

--- a/src/Twig/GlobalVariables.php
+++ b/src/Twig/GlobalVariables.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\UserBundle\Twig;
 
+use LogicException;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool;
 
@@ -21,7 +22,7 @@ use Sonata\AdminBundle\Admin\Pool;
  */
 final class GlobalVariables
 {
-    private Pool $pool;
+    private ?Pool $pool;
 
     private string $defaultAvatar;
 
@@ -38,7 +39,7 @@ final class GlobalVariables
      * @param array<string, mixed> $impersonatingRouteParameters
      */
     public function __construct(
-        Pool $pool,
+        ?Pool $pool,
         string $defaultAvatar,
         bool $impersonatingEnabled,
         string $impersonatingRoute,
@@ -56,6 +57,9 @@ final class GlobalVariables
      */
     public function getUserAdmin(): AdminInterface
     {
+        if (null === $this->pool) {
+            throw new LogicException('Unable to get the UserAdmin, admin pool is not configured. You should install SonataAdminBundle in order to use admin-related features.');
+        }
         return $this->pool->getAdminByAdminCode('sonata.user.admin.user');
     }
 

--- a/tests/App/Resources/config/config_sf5.yaml
+++ b/tests/App/Resources/config/config_sf5.yaml
@@ -1,6 +1,7 @@
 framework:
     session:
         storage_factory_id: session.storage.factory.mock_file
+    assets:
 
 security:
     enable_authenticator_manager: true

--- a/tests/DependencyInjection/SonataUserExtensionNoAdminTest.php
+++ b/tests/DependencyInjection/SonataUserExtensionNoAdminTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Tests\DependencyInjection;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+use Sonata\UserBundle\DependencyInjection\SonataUserExtension;
+use Sonata\UserBundle\Twig\GlobalVariables;
+
+/**
+ * @author Alexandr Zolotukhin <alex@alexandrz.com>
+ */
+final class SonataUserExtensionNoAdminTest extends AbstractExtensionTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setParameter('kernel.bundles', [
+            'SonataDoctrineBundle' => true,
+        ]);
+    }
+
+    /**
+     * @doesNotPerformAssertions
+     */
+    public function testLoadDefault(): void
+    {
+        $this->load();
+    }
+
+    public function testGetGlobalVariablesService(): void
+    {
+        $this->load();
+        // Prevent unused service from being removed by making it public
+        $this->container->getDefinition('sonata.user.twig.global')->setPublic(true);
+        $this->compile();
+
+        // Make sure there's no exceptions thrown, as the service has a dependency on Admin
+        // which must be optional
+        $globals = $this->container->get('sonata.user.twig.global');
+        $this->assertInstanceOf(GlobalVariables::class, $globals);
+    }
+
+    /**
+     * @return mixed[]
+     */
+    protected function getMinimalConfiguration(): array
+    {
+        return [
+            'resetting' => [
+                'email' => [
+                    'address' => 'sonata@localhost.com',
+                    'sender_name' => 'Sonata',
+                ],
+            ],
+        ];
+    }
+
+    protected function getContainerExtensions(): array
+    {
+        return [
+            new SonataUserExtension(),
+        ];
+    }
+}

--- a/tests/DependencyInjection/SonataUserExtensionNoAdminTest.php
+++ b/tests/DependencyInjection/SonataUserExtensionNoAdminTest.php
@@ -49,7 +49,7 @@ final class SonataUserExtensionNoAdminTest extends AbstractExtensionTestCase
         // Make sure there's no exceptions thrown, as the service has a dependency on Admin
         // which must be optional
         $globals = $this->container->get('sonata.user.twig.global');
-        $this->assertInstanceOf(GlobalVariables::class, $globals);
+        static::assertInstanceOf(GlobalVariables::class, $globals);
     }
 
     /**

--- a/tests/DependencyInjection/SonataUserExtensionNoAdminTest.php
+++ b/tests/DependencyInjection/SonataUserExtensionNoAdminTest.php
@@ -15,7 +15,8 @@ namespace Sonata\UserBundle\Tests\DependencyInjection;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
 use Sonata\UserBundle\DependencyInjection\SonataUserExtension;
-use Sonata\UserBundle\Twig\GlobalVariables;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * @author Alexandr Zolotukhin <alex@alexandrz.com>
@@ -42,14 +43,12 @@ final class SonataUserExtensionNoAdminTest extends AbstractExtensionTestCase
     public function testGetGlobalVariablesService(): void
     {
         $this->load();
-        // Prevent unused service from being removed by making it public
-        $this->container->getDefinition('sonata.user.twig.global')->setPublic(true);
-        $this->compile();
 
-        // Make sure there's no exceptions thrown, as the service has a dependency on Admin
-        // which must be optional
-        $globals = $this->container->get('sonata.user.twig.global');
-        static::assertInstanceOf(GlobalVariables::class, $globals);
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            'sonata.user.twig.global',
+            0,
+            new Reference('sonata.admin.pool', ContainerInterface::NULL_ON_INVALID_REFERENCE)
+        );
     }
 
     /**


### PR DESCRIPTION
## Subject

This PR makes SonataAdminBundle dependency optional.

I am targeting 5.x branch, because v5 hasn't got to a final release yet and BC breaks can potentially be still accepted and there were no objections to that in the referenced issue.

Closes #1499

## Changelog

```markdown
### Changed
- SonataAdminBundle dependency is now optional. Trying to access `sonata_user.userAdmin` variable in Twig templates will throw a `\LogicException` if SonataAdminBundle is not installed.
```

## To do

- [x] Update the documentation;
- [x] Update the tests;
- [x] Add an upgrade note.

## Notes:
1. Do you think nullable admin Pool in `GlobalVariables` is OK or it would be better to conditionally register pool as another Twig variable (e. g. `sonata_user_admin`)?
2. I've checked the Media and Classification bundles (referenced in the linked issue as bundles with optional Admin dependency) and there seems to be no full-blown integration tests with running separate test-suits with and without Admin. So I took a modest approach with simply unit-testing the extension with a different config.