### PR TITLE
Fix functional tests in v5

### DIFF
--- a/tests/App/Resources/config/config_sf5.yaml
+++ b/tests/App/Resources/config/config_sf5.yaml
@@ -1,6 +1,7 @@
 framework:
     session:
         storage_factory_id: session.storage.factory.mock_file
+    assets:
 
 security:
     enable_authenticator_manager: true


### PR DESCRIPTION
## Subject

I am targeting this branch, because it fixes failing tests on this branch.

Twig AssetExtension doesn't get registered when there's no `assets` entry in the `framework` config, which results in functional tests failing. Looks like older CI pipelines are green, so it must be related to some recent change in on of the dependencies.

## Changelog

```markdown
### Fixed
- Functional tests
```