### PR TITLE
Fix UserAdmin breadcrumb name

### DIFF
--- a/src/Admin/Model/UserAdmin.php
+++ b/src/Admin/Model/UserAdmin.php
@@ -29,6 +29,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 class UserAdmin extends AbstractAdmin
 {
     protected UserManagerInterface $userManager;
+    protected $classnameLabel = 'user';
 
     public function __construct(UserManagerInterface $userManager)
     {

--- a/src/Listener/UserListener.php
+++ b/src/Listener/UserListener.php
@@ -17,6 +17,7 @@ use Doctrine\Common\EventSubscriber;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ODM\MongoDB\Mapping\ClassMetadata as ODMClassMetadata;
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata as ORMClassMetadata;
 use Doctrine\Persistence\Event\LifecycleEventArgs;
 use Doctrine\Persistence\ObjectManager;
@@ -49,6 +50,9 @@ final class UserListener implements EventSubscriber
         ];
     }
 
+    /**
+     * @param LifecycleEventArgs<EntityManagerInterface|DocumentManager> $args
+     */
     public function prePersist(LifecycleEventArgs $args): void
     {
         $object = $args->getObject();
@@ -60,6 +64,9 @@ final class UserListener implements EventSubscriber
         $this->updateUser($object);
     }
 
+    /**
+     * @param LifecycleEventArgs<EntityManagerInterface|DocumentManager> $args
+     */
     public function preUpdate(LifecycleEventArgs $args): void
     {
         $object = $args->getObject();


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
The breadcrumb builder is using a classnameLabel that doesn't match the translation`breadcrumb.link_user_list`.

**Before**
![image](https://user-images.githubusercontent.com/8824375/165924796-f084dbbf-22df-423a-a262-baa999954c7f.png)

**After**
![image](https://user-images.githubusercontent.com/8824375/165924657-6f9a5945-cd8c-4d67-8415-672d2bdbf0b2.png)

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 5.x is for everything backwards compatible, like patches, features and deprecation notices
    - 6.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/5.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because the error is in the 5.x branch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataUserBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Changed
- Changed UserAdmin classnameLabel. This affects the breadcrumb translation generation. With this change Sonata will always pick the SonataUserBundle breadcrumbs translations by default.
```

