### PR TITLE
Exclude ROLE_DEFAULT from RoleMatrixType

### DIFF
--- a/docs/reference/roles_matrix.rst
+++ b/docs/reference/roles_matrix.rst
@@ -52,3 +52,9 @@ You can set the ``show_in_roles_matrix`` option to ``false``, like this:
                         manager_type: orm
                         label: 'Post'
                         show_in_roles_matrix: false
+
+How to exclude roles
+--------------------
+
+When using the Form Type, you can use ``excluded_roles`` to not show them in the matrix.
+By default, only ``UserInterface::ROLE_DEFAULT`` aka ``ROLE_USER`` is not shown.

--- a/src/Form/Type/RolesMatrixType.php
+++ b/src/Form/Type/RolesMatrixType.php
@@ -34,8 +34,6 @@ final class RolesMatrixType extends AbstractType
 
     public function configureOptions(OptionsResolver $resolver): void
     {
-        $resolver->addAllowedTypes('excluded_roles', 'string[]');
-
         $resolver->setDefaults([
             'expanded' => true,
             'choices' => function (Options $options, ?array $parentChoices): array {
@@ -80,6 +78,8 @@ final class RolesMatrixType extends AbstractType
             'excluded_roles' => [UserInterface::ROLE_DEFAULT],
             'data_class' => null,
         ]);
+
+        $resolver->addAllowedTypes('excluded_roles', 'string[]');
     }
 
     public function getParent(): string

--- a/src/Form/Type/RolesMatrixType.php
+++ b/src/Form/Type/RolesMatrixType.php
@@ -43,7 +43,7 @@ final class RolesMatrixType extends AbstractType
 
                 $roles = $this->rolesBuilder->getRoles($options['choice_translation_domain']);
                 $roles = array_keys($roles);
-                $roles = array_diff($roles, $options['exclude']);
+                $roles = array_diff($roles, $options['excluded_roles']);
 
                 return array_combine($roles, $roles);
             },
@@ -75,7 +75,7 @@ final class RolesMatrixType extends AbstractType
 
                     return $value;
                 },
-            'exclude' => [UserInterface::ROLE_DEFAULT],
+            'excluded_roles' => [UserInterface::ROLE_DEFAULT],
             'data_class' => null,
         ]);
     }

--- a/src/Form/Type/RolesMatrixType.php
+++ b/src/Form/Type/RolesMatrixType.php
@@ -43,7 +43,7 @@ final class RolesMatrixType extends AbstractType
 
                 $roles = $this->rolesBuilder->getRoles($options['choice_translation_domain']);
                 $roles = array_keys($roles);
-                $roles = array_diff($roles, $options["exclude"]);
+                $roles = array_diff($roles, $options['exclude']);
 
                 return array_combine($roles, $roles);
             },

--- a/src/Form/Type/RolesMatrixType.php
+++ b/src/Form/Type/RolesMatrixType.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\UserBundle\Form\Type;
 
+use Sonata\UserBundle\Model\UserInterface;
 use Sonata\UserBundle\Security\RolesBuilder\ExpandableRolesBuilderInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -42,6 +43,7 @@ final class RolesMatrixType extends AbstractType
 
                 $roles = $this->rolesBuilder->getRoles($options['choice_translation_domain']);
                 $roles = array_keys($roles);
+                $roles = array_diff($roles, $options["exclude"]);
 
                 return array_combine($roles, $roles);
             },
@@ -73,6 +75,7 @@ final class RolesMatrixType extends AbstractType
 
                     return $value;
                 },
+            'exclude' => [UserInterface::ROLE_DEFAULT],
             'data_class' => null,
         ]);
     }

--- a/src/Form/Type/RolesMatrixType.php
+++ b/src/Form/Type/RolesMatrixType.php
@@ -34,6 +34,8 @@ final class RolesMatrixType extends AbstractType
 
     public function configureOptions(OptionsResolver $resolver): void
     {
+        $resolver->addAllowedTypes('excluded_roles', 'string[]');
+
         $resolver->setDefaults([
             'expanded' => true,
             'choices' => function (Options $options, ?array $parentChoices): array {

--- a/tests/Form/Type/RolesMatrixTypeTest.php
+++ b/tests/Form/Type/RolesMatrixTypeTest.php
@@ -15,6 +15,7 @@ namespace Sonata\UserBundle\Tests\Form\Type;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use Sonata\UserBundle\Form\Type\RolesMatrixType;
+use Sonata\UserBundle\Model\UserInterface;
 use Sonata\UserBundle\Security\RolesBuilder\ExpandableRolesBuilderInterface;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormExtensionInterface;
@@ -38,7 +39,8 @@ final class RolesMatrixTypeTest extends TypeTestCase
 
         $this->roleBuilder->method('getRoles')->willReturn([
             'ROLE_FOO' => 'ROLE_FOO',
-            'ROLE_USER' => 'ROLE_USER',
+            # Not returned by the RolesMatrix because it can't be changed
+            UserInterface::ROLE_DEFAULT => UserInterface::ROLE_DEFAULT,
             'ROLE_ADMIN' => 'ROLE_ADMIN: ROLE_USER',
         ]);
 
@@ -53,7 +55,9 @@ final class RolesMatrixTypeTest extends TypeTestCase
         $type->configureOptions($optionResolver);
 
         $options = $optionResolver->resolve();
-        static::assertCount(3, $options['choices']);
+        $choices = $options['choices'];
+        static::assertCount(2, $choices);
+        static::assertNotContains(UserInterface::ROLE_DEFAULT, $choices);
     }
 
     public function testGetParent(): void

--- a/tests/Form/Type/RolesMatrixTypeTest.php
+++ b/tests/Form/Type/RolesMatrixTypeTest.php
@@ -68,7 +68,7 @@ final class RolesMatrixTypeTest extends TypeTestCase
         $type->configureOptions($optionResolver);
 
         $options = $optionResolver->resolve([
-            'excluded_roles' => ['ROLE_FOO']
+            'excluded_roles' => ['ROLE_FOO'],
         ]);
         $choices = $options['choices'];
         static::assertCount(2, $choices);
@@ -84,7 +84,7 @@ final class RolesMatrixTypeTest extends TypeTestCase
         $type->configureOptions($optionResolver);
 
         $options = $optionResolver->resolve([
-            'excluded_roles' => ['ROLE_BAR']
+            'excluded_roles' => ['ROLE_BAR'],
         ]);
         $choices = $options['choices'];
         static::assertCount(3, $choices);
@@ -135,7 +135,7 @@ final class RolesMatrixTypeTest extends TypeTestCase
             'multiple' => true,
             'expanded' => true,
             'required' => false,
-            'excluded_roles' => ['ROLE_FOO']
+            'excluded_roles' => ['ROLE_FOO'],
         ]);
 
         $form->submit([0 => 'ROLE_FOO']);

--- a/tests/Form/Type/RolesMatrixTypeTest.php
+++ b/tests/Form/Type/RolesMatrixTypeTest.php
@@ -39,7 +39,7 @@ final class RolesMatrixTypeTest extends TypeTestCase
 
         $this->roleBuilder->method('getRoles')->willReturn([
             'ROLE_FOO' => 'ROLE_FOO',
-            # Not returned by the RolesMatrix because it can't be changed
+            // Not returned by the RolesMatrix because it can't be changed
             UserInterface::ROLE_DEFAULT => UserInterface::ROLE_DEFAULT,
             'ROLE_ADMIN' => 'ROLE_ADMIN: ROLE_USER',
         ]);

--- a/tests/Form/Type/RolesMatrixTypeTest.php
+++ b/tests/Form/Type/RolesMatrixTypeTest.php
@@ -60,6 +60,39 @@ final class RolesMatrixTypeTest extends TypeTestCase
         static::assertNotContains(UserInterface::ROLE_DEFAULT, $choices);
     }
 
+    public function testDifferentExcludedRoles(): void
+    {
+        $type = new RolesMatrixType($this->roleBuilder);
+
+        $optionResolver = new OptionsResolver();
+        $type->configureOptions($optionResolver);
+
+        $options = $optionResolver->resolve([
+            'excluded_roles' => ['ROLE_FOO']
+        ]);
+        $choices = $options['choices'];
+        static::assertCount(2, $choices);
+        static::assertNotContains('ROLE_FOO', $choices);
+        static::assertContains(UserInterface::ROLE_DEFAULT, $choices);
+    }
+
+    public function testNotExistExcludedRoles(): void
+    {
+        $type = new RolesMatrixType($this->roleBuilder);
+
+        $optionResolver = new OptionsResolver();
+        $type->configureOptions($optionResolver);
+
+        $options = $optionResolver->resolve([
+            'excluded_roles' => ['ROLE_BAR']
+        ]);
+        $choices = $options['choices'];
+        static::assertCount(3, $choices);
+        static::assertContains('ROLE_FOO', $choices);
+        static::assertNotContains('ROLE_BAR', $choices);
+        static::assertContains(UserInterface::ROLE_DEFAULT, $choices);
+    }
+
     public function testGetParent(): void
     {
         $type = new RolesMatrixType($this->roleBuilder);
@@ -91,6 +124,21 @@ final class RolesMatrixTypeTest extends TypeTestCase
         ]);
 
         $form->submit([0 => 'ROLE_NOT_EXISTS']);
+
+        static::assertFalse($form->isValid());
+        static::assertSame([], $form->getData());
+    }
+
+    public function testSubmitExcludedData(): void
+    {
+        $form = $this->factory->create(RolesMatrixType::class, null, [
+            'multiple' => true,
+            'expanded' => true,
+            'required' => false,
+            'excluded_roles' => ['ROLE_FOO']
+        ]);
+
+        $form->submit([0 => 'ROLE_FOO']);
 
         static::assertFalse($form->isValid());
         static::assertSame([], $form->getData());


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 5.x is for everything backwards compatible, like patches, features and deprecation notices
    - 6.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/5.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because it should be BC.

Per default only `UserInterface::ROLE_DEFAULT` aka `ROLE_USER` is excluded, but users can still use it.

If this Component would be moved outside of UserBundle that might be changed.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1535.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataUserBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `RoleMatrixType:exclude` Option to hide choices.

```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [x] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
