### PR TITLE
Avoid deprecations for console commands

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": "^7.4 || ^8.0",
         "doctrine/collections": "^1.6",
         "doctrine/common": "^3.1",
-        "doctrine/persistence": "^2.1",
+        "doctrine/persistence": "^2.1 || ^3.0",
         "sonata-project/doctrine-extensions": "^1.13",
         "sonata-project/form-extensions": "^1.4",
         "sonata-project/twig-extensions": "^1.3",

--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,7 @@
         "psalm/plugin-phpunit": "^0.16",
         "psalm/plugin-symfony": "^3.0",
         "sonata-project/admin-bundle": "^4.9",
-        "sonata-project/block-bundle": "^4.0",
+        "sonata-project/block-bundle": "^4.11",
         "sonata-project/doctrine-orm-admin-bundle": "^4.0",
         "symfony/browser-kit": "^4.4 || ^5.4 || ^6.0",
         "symfony/console": "^4.4 || ^5.4 || ^6.0",
@@ -76,7 +76,7 @@
     },
     "conflict": {
         "sonata-project/admin-bundle": "<4.9",
-        "sonata-project/block-bundle": "<4.0",
+        "sonata-project/block-bundle": "<4.11",
         "sonata-project/doctrine-orm-admin-bundle": "<4.0"
     },
     "suggest": {

--- a/src/Command/ActivateUserCommand.php
+++ b/src/Command/ActivateUserCommand.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\UserBundle\Command;
 
 use Sonata\UserBundle\Model\UserManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -22,8 +23,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * @internal
  */
+#[AsCommand(name: 'sonata:user:activate', description: 'Activate a user')]
 final class ActivateUserCommand extends Command
 {
+    // TODO: Remove static properties when support for Symfony < 6.0 is dropped.
     protected static $defaultName = 'sonata:user:activate';
     protected static $defaultDescription = 'Activate a user';
 
@@ -41,6 +44,7 @@ final class ActivateUserCommand extends Command
         \assert(null !== static::$defaultDescription);
 
         $this
+            // TODO: Remove setDescription when support for Symfony < 5.4 is dropped.
             ->setDescription(static::$defaultDescription)
             ->setDefinition([
                 new InputArgument('username', InputArgument::REQUIRED, 'The username'),

--- a/src/Command/ChangePasswordCommand.php
+++ b/src/Command/ChangePasswordCommand.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\UserBundle\Command;
 
 use Sonata\UserBundle\Model\UserManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -22,8 +23,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * @internal
  */
+#[AsCommand(name: 'sonata:user:change-password', description: 'Change the password of a user')]
 final class ChangePasswordCommand extends Command
 {
+    // TODO: Remove static properties when support for Symfony < 6.0 is dropped.
     protected static $defaultName = 'sonata:user:change-password';
     protected static $defaultDescription = 'Change the password of a user';
 
@@ -41,6 +44,7 @@ final class ChangePasswordCommand extends Command
         \assert(null !== static::$defaultDescription);
 
         $this
+            // TODO: Remove setDescription when support for Symfony < 5.4 is dropped.
             ->setDescription(static::$defaultDescription)
             ->setDefinition([
                 new InputArgument('username', InputArgument::REQUIRED, 'The username'),

--- a/src/Command/CreateUserCommand.php
+++ b/src/Command/CreateUserCommand.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\UserBundle\Command;
 
 use Sonata\UserBundle\Model\UserManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -23,8 +24,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * @internal
  */
+#[AsCommand(name: 'sonata:user:create', description: 'Create a user')]
 final class CreateUserCommand extends Command
 {
+    // TODO: Remove static properties when support for Symfony < 6.0 is dropped.
     protected static $defaultName = 'sonata:user:create';
     protected static $defaultDescription = 'Create a user';
 
@@ -42,6 +45,7 @@ final class CreateUserCommand extends Command
         \assert(null !== static::$defaultDescription);
 
         $this
+            // TODO: Remove setDescription when support for Symfony < 5.4 is dropped.
             ->setDescription(static::$defaultDescription)
             ->setDefinition([
                 new InputArgument('username', InputArgument::REQUIRED, 'The username'),

--- a/src/Command/DeactivateUserCommand.php
+++ b/src/Command/DeactivateUserCommand.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\UserBundle\Command;
 
 use Sonata\UserBundle\Model\UserManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -22,8 +23,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * @internal
  */
+#[AsCommand(name: 'sonata:user:deactivate', description: 'Deactivate a user')]
 final class DeactivateUserCommand extends Command
 {
+    // TODO: Remove static properties when support for Symfony < 6.0 is dropped.
     protected static $defaultName = 'sonata:user:deactivate';
     protected static $defaultDescription = 'Deactivate a user';
 
@@ -41,6 +44,7 @@ final class DeactivateUserCommand extends Command
         \assert(null !== static::$defaultDescription);
 
         $this
+            // TODO: Remove setDescription when support for Symfony < 5.4 is dropped.
             ->setDescription(static::$defaultDescription)
             ->setDefinition([
                 new InputArgument('username', InputArgument::REQUIRED, 'The username'),

--- a/src/Command/DemoteUserCommand.php
+++ b/src/Command/DemoteUserCommand.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\UserBundle\Command;
 
 use Sonata\UserBundle\Model\UserManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -23,8 +24,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * @internal
  */
+#[AsCommand(name: 'sonata:user:demote', description: 'Demotes a user by removing a role')]
 final class DemoteUserCommand extends Command
 {
+    // TODO: Remove static properties when support for Symfony < 6.0 is dropped.
     protected static $defaultName = 'sonata:user:demote';
     protected static $defaultDescription = 'Demotes a user by removing a role';
 
@@ -42,6 +45,7 @@ final class DemoteUserCommand extends Command
         \assert(null !== static::$defaultDescription);
 
         $this
+            // TODO: Remove setDescription when support for Symfony < 5.4 is dropped.
             ->setDescription(static::$defaultDescription)
             ->setDefinition([
                 new InputArgument('username', InputArgument::REQUIRED, 'The username'),

--- a/src/Command/PromoteUserCommand.php
+++ b/src/Command/PromoteUserCommand.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\UserBundle\Command;
 
 use Sonata\UserBundle\Model\UserManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -23,8 +24,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * @internal
  */
+#[AsCommand(name: 'sonata:user:promote', description: 'Promotes a user by adding a role')]
 final class PromoteUserCommand extends Command
 {
+    // TODO: Remove static properties when support for Symfony < 6.0 is dropped.
     protected static $defaultName = 'sonata:user:promote';
     protected static $defaultDescription = 'Promotes a user by adding a role';
 
@@ -42,6 +45,7 @@ final class PromoteUserCommand extends Command
         \assert(null !== static::$defaultDescription);
 
         $this
+            // TODO: Remove setDescription when support for Symfony < 5.4 is dropped.
             ->setDescription(static::$defaultDescription)
             ->setDefinition([
                 new InputArgument('username', InputArgument::REQUIRED, 'The username'),

--- a/tests/App/AppKernel.php
+++ b/tests/App/AppKernel.php
@@ -94,6 +94,9 @@ final class AppKernel extends Kernel
         $routes->import(__DIR__.'/Resources/config/routing/routes.yaml');
     }
 
+    /**
+     * @psalm-suppress DeprecatedClass
+     */
     protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader): void
     {
         $loader->load(__DIR__.'/Resources/config/config.yaml');

--- a/tests/App/AppKernel.php
+++ b/tests/App/AppKernel.php
@@ -17,6 +17,7 @@ use DAMA\DoctrineTestBundle\DAMADoctrineTestBundle;
 use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
 use Knp\Bundle\MenuBundle\KnpMenuBundle;
 use Sonata\AdminBundle\SonataAdminBundle;
+use Sonata\BlockBundle\Cache\HttpCacheHandler;
 use Sonata\BlockBundle\SonataBlockBundle;
 use Sonata\Doctrine\Bridge\Symfony\SonataDoctrineBundle;
 use Sonata\DoctrineORMAdminBundle\SonataDoctrineORMAdminBundle;
@@ -101,6 +102,10 @@ final class AppKernel extends Kernel
             $loader->load(__DIR__.'/Resources/config/config_sf5.yaml');
         } else {
             $loader->load(__DIR__.'/Resources/config/config_sf4.yaml');
+        }
+
+        if (class_exists(HttpCacheHandler::class)) {
+            $loader->load(__DIR__.'/Resources/config/config_sonata_block_v4.yaml');
         }
 
         $container->setParameter('app.base_dir', $this->getBaseDir());

--- a/tests/App/Resources/config/config.yaml
+++ b/tests/App/Resources/config/config.yaml
@@ -8,6 +8,7 @@ framework:
         enabled: true
     translator:
         enabled: true
+    http_method_override: false
 
 security:
     role_hierarchy: null

--- a/tests/App/Resources/config/config_sonata_block_v4.yaml
+++ b/tests/App/Resources/config/config_sonata_block_v4.yaml
@@ -1,0 +1,2 @@
+sonata_block:
+    http_cache: false


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 5.x is for everything backwards compatible, like patches, features and deprecation notices
    - 6.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/5.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataUserBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Add compatibility with `doctrine/persistence` ^3.0.

### Removed
- Avoid deprecations with lazy commands on Symfony 6.1.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
