### PR TITLE
Check for form attribute before rendering role matrix

### DIFF
--- a/src/Resources/views/Form/roles_matrix_list.html.twig
+++ b/src/Resources/views/Form/roles_matrix_list.html.twig
@@ -9,6 +9,7 @@ file that was distributed with this source code.
 
 #}
 {% for role, attributes in roles|sort %}
+{% if attributes.form is defined %}
     <li>{{ form_widget(attributes.form, {label: attributes.role_translated, value: attributes.role}) }}</li>
     {% if not attributes.is_granted %}
         <script>
@@ -18,4 +19,5 @@ file that was distributed with this source code.
             });
         </script>
     {% endif %}
+{% endif %}
 {% endfor %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 5.x is for everything backwards compatible, like patches, features and deprecation notices
    - 6.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/5.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because it appears that a recent change in the same branch might need additional logic.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1552.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataUserBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Fixed
- Fix user edit page to check for a form attribute before rendering the role matrix.

```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
