### PR TITLE
Allow getUsername to return null

### DIFF
--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -55,7 +55,7 @@ abstract class User implements UserInterface
 
     public function __toString(): string
     {
-        return $this->getUsername();
+        return $this->getUserIdentifier();
     }
 
     /**

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -115,14 +115,14 @@ abstract class User implements UserInterface
         return $this->id;
     }
 
-    public function getUsername(): string
+    public function getUsername(): ?string
     {
-        return $this->getUserIdentifier();
+        return $this->username;
     }
 
     public function getUserIdentifier(): string
     {
-        return $this->username ?? '-';
+        return $this->getUsername() ?? '-';
     }
 
     public function getUsernameCanonical(): ?string


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 5.x is for everything backwards compatible, like patches, features and deprecation notices
    - 6.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/5.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because {reason}.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Solve
<img width="520" alt="image" src="https://user-images.githubusercontent.com/9052536/181090513-2166d392-4d57-4ec3-bb34-43b0f3a762ef.png">


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataUserBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- `User::getUsername` return the real value in database (and can return null).
```