### PR TITLE
Include how to override Sonata User admin service in Documentation

### DIFF
--- a/docs/reference/advanced_configuration.rst
+++ b/docs/reference/advanced_configuration.rst
@@ -1,6 +1,7 @@
 .. index::
     single: Advanced configuration
     single: Options
+    single: Override Service
 
 Advanced Configuration
 ======================
@@ -38,3 +39,30 @@ Full configuration options:
                 template: '@SonataUser/Admin/Security/Resetting/email.html.twig'
                 address: ~
                 sender_name: ~
+
+Override Service
+======================
+
+If you need to override the service of Sonata User admin, you can do it during the service declaration:
+
+.. code-block:: yaml
+
+    # config/services.yaml
+
+    services:
+        sonata.user.admin.user:
+            class: Sonata\UserBundle\Admin\Entity\UserAdmin
+            tags:
+                - name: sonata.admin
+                  model_class: '%sonata.user.user.class%'
+                  controller: '%sonata.user.admin.user.controller%'
+                  manager_type: orm
+                  group: sonata_user
+                  label: users
+                  translation_domain: SonataUserBundle
+                  label_translator_strategy: sonata.admin.label.strategy.underscore
+                  icon: '<i class=\'fa fa-users\'></i>'
+            arguments:
+                - '@sonata.user.manager.user'
+
+Please note that parameter ``%sonata.user.user.class%`` and ``%sonata.user.admin.user.controller`` refers to configuration options.

--- a/docs/reference/advanced_configuration.rst
+++ b/docs/reference/advanced_configuration.rst
@@ -61,7 +61,7 @@ If you need to override the service of Sonata User admin, you can do it during t
                   label: users
                   translation_domain: SonataUserBundle
                   label_translator_strategy: sonata.admin.label.strategy.underscore
-                  icon: '<i class=\'fa fa-users\'></i>'
+                  icon: "<i class='fa fa-users'></i>"
             arguments:
                 - '@sonata.user.manager.user'
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 5.x is for everything backwards compatible, like patches, features and deprecation notices
    - 6.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/5.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because Sonata User documentation is missing a passage on how to override service just like Sonata Admin documentation,

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataUserBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added example of overriding service in documentation
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
