### PR TITLE
fix: add UniqueEntity constraint to email field.

### DIFF
--- a/src/Resources/config/validation.xml
+++ b/src/Resources/config/validation.xml
@@ -3,7 +3,7 @@
     <class name="Sonata\UserBundle\Model\User">
         <constraint name="Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity">
             <option name="fields">email</option>
-	    <option name="groups">
+            <option name="groups">
                 <value>Registration</value>
                 <value>Profile</value>
             </option>

--- a/src/Resources/config/validation.xml
+++ b/src/Resources/config/validation.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping http://symfony.com/schema/dic/constraint-mapping/constraint-mapping-1.0.xsd">
     <class name="Sonata\UserBundle\Model\User">
+        <constraint name="Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity">
+            <option name="fields">email</option>
+        </constraint>
         <property name="username">
             <constraint name="NotBlank">
                 <option name="groups">
@@ -18,6 +21,7 @@
             </constraint>
         </property>
         <property name="email">
+	    <constraint name="Email"/>
             <constraint name="NotBlank">
                 <option name="groups">
                     <value>Registration</value>

--- a/src/Resources/config/validation.xml
+++ b/src/Resources/config/validation.xml
@@ -21,7 +21,6 @@
             </constraint>
         </property>
         <property name="email">
-	    <constraint name="Email"/>
             <constraint name="NotBlank">
                 <option name="groups">
                     <value>Registration</value>

--- a/src/Resources/config/validation.xml
+++ b/src/Resources/config/validation.xml
@@ -3,6 +3,10 @@
     <class name="Sonata\UserBundle\Model\User">
         <constraint name="Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity">
             <option name="fields">email</option>
+	    <option name="groups">
+                <value>Registration</value>
+                <value>Profile</value>
+            </option>
         </constraint>
         <property name="username">
             <constraint name="NotBlank">


### PR DESCRIPTION
## Subject

This PR add `UniqueEntity` constraint to email field in [validation.xml](https://github.com/sonata-project/SonataUserBundle/blob/5.x/src/Resources/config/validation.xml).

Why :
The email property is defined as unique in the DB, so we need to
constraint the field to unique in the form in order to prevent a
`UniqueConstraintViolationException` exception.

I am targeting this branch, because it is BC.

## Changelog
```markdown
### Fixed
- Add UniqueEntity constraint to email field in order to prevent UniqueConstraintViolationException exception.
```


