### PR TITLE
fix: add UniqueEntity constraint to username field.

### DIFF
--- a/src/Resources/config/validation.xml
+++ b/src/Resources/config/validation.xml
@@ -8,6 +8,13 @@
                 <value>Profile</value>
             </option>
         </constraint>
+        <constraint name="Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity">
+            <option name="fields">username</option>
+            <option name="groups">
+                <value>Registration</value>
+                <value>Profile</value>
+            </option>
+        </constraint>
         <property name="username">
             <constraint name="NotBlank">
                 <option name="groups">


### PR DESCRIPTION
## Subject

This PR add `UniqueEntity` constraint to username field in [validation.xml](https://github.com/sonata-project/SonataUserBundle/blob/5.x/src/Resources/config/validation.xml).

Why :
The username property is defined as unique in the DB ( in [BaseUser.orm.xml](https://github.com/sonata-project/SonataUserBundle/blob/5.x/src/Resources/config/doctrine/BaseUser.orm.xml) ) so we need to
constraint the field to unique in the form in order to prevent a
`UniqueConstraintViolationException` exception.

I am targeting this branch, because it is BC.

## Changelog
```markdown
### Fixed
- Add UniqueEntity constraint to username field in order to prevent UniqueConstraintViolationException exception.
```
