### PR TITLE
Change password field to PasswordType.

### DIFF
--- a/src/Admin/Model/UserAdmin.php
+++ b/src/Admin/Model/UserAdmin.php
@@ -22,7 +22,7 @@ use Sonata\AdminBundle\Show\ShowMapper;
 use Sonata\UserBundle\Form\Type\RolesMatrixType;
 use Sonata\UserBundle\Model\UserInterface;
 use Sonata\UserBundle\Model\UserManagerInterface;
-use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 
 /**
  * @phpstan-extends AbstractAdmin<UserInterface>
@@ -92,7 +92,7 @@ class UserAdmin extends AbstractAdmin
             ->with('general', ['class' => 'col-md-4'])
                 ->add('username')
                 ->add('email')
-                ->add('plainPassword', TextType::class, [
+                ->add('plainPassword', PasswordType::class, [
                     'required' => (!$this->hasSubject() || null === $this->getSubject()->getId()),
                 ])
                 ->add('enabled', null)


### PR DESCRIPTION
## Subject

 The password field was of type `TextType`, hence it did not behave as a password field for the user (input not hidden, browser did not ask to save credentials, etc). This PR change the field to `PasswordType`.

    I choose 5.x because the change is BC.

## Changelog

```markdown
### Changed
Password field is now of type PasswordType (was TextType).
```
