### PR TITLE
Roles matrix group by admin and admin group

### DIFF
--- a/src/Resources/views/Form/roles_matrix.html.twig
+++ b/src/Resources/views/Form/roles_matrix.html.twig
@@ -12,16 +12,25 @@ file that was distributed with this source code.
     <thead>
     <tr>
         <th></th>
+        <th></th>
         {% for label in permission_labels|sort %}
             <th> {{ label }} </th>
         {% endfor %}
     </tr>
     </thead>
     <tbody>
-    {% for admin_label, roles in grouped_roles %}
-        <tr>
-            <th>{{ admin_label }}</th>
+    {% for group_code, admin_roles in grouped_roles %}
+        {% set new_group = true %}
+        {% for admin_code, roles in admin_roles %}
+            <tr>
             {% for role, attributes in roles|sort %}
+                {% if loop.first %}
+                    {% if new_group %}
+                        {% set new_group = false %}
+                        <th rowspan="{{ admin_roles|length }}" scope="rowgroup">{{ attributes.group_label|default('') }}</th>
+                    {% endif %}
+                    <th>{{ attributes.admin_label|default('') }}</th>
+                {% endif %}
                 <td>
                     {{ form_widget(attributes.form, { label: false }) }}
                     {% if not attributes.is_granted %}
@@ -34,7 +43,8 @@ file that was distributed with this source code.
                     {% endif %}
                 </td>
             {% endfor %}
-        </tr>
+            </tr>
+        {% endfor %}
     {% endfor %}
     </tbody>
 </table>

--- a/src/Security/RolesBuilder/AdminRolesBuilder.php
+++ b/src/Security/RolesBuilder/AdminRolesBuilder.php
@@ -21,6 +21,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * @author Silas Joisten <silasjoisten@hotmail.de>
+ *
+ * @phpstan-import-type Role from RolesBuilderInterface
  */
 final class AdminRolesBuilder implements AdminRolesBuilderInterface
 {
@@ -76,25 +78,63 @@ final class AdminRolesBuilder implements AdminRolesBuilderInterface
 
     public function getRoles(?string $domain = null): array
     {
-        $adminRoles = [];
-        foreach ($this->pool->getAdminServiceCodes() as $code) {
-            if (\in_array($code, $this->excludeAdmins, true)) {
-                continue;
-            }
+        $adminServiceCodes = array_diff($this->pool->getAdminServiceCodes(), $this->excludeAdmins);
 
-            $admin = $this->pool->getInstance($code);
-            $securityHandler = $admin->getSecurityHandler();
-            $baseRole = $securityHandler->getBaseRole($admin);
-            foreach (array_keys($admin->getSecurityInformation()) as $key) {
-                $role = sprintf($baseRole, $key);
-                $adminRoles[$role] = [
-                    'role' => $role,
-                    'label' => $key,
-                    'role_translated' => $this->translateRole($role, $domain),
-                    'is_granted' => $this->isMaster($admin) || $this->authorizationChecker->isGranted($role),
-                    'admin_label' => $admin->getTranslator()->trans($admin->getLabel() ?? ''),
-                ];
+        // get groups and admins sort by config
+        $adminRoles = [];
+        foreach ($this->pool->getAdminGroups() as $groupCode => $group) {
+            foreach ($group['items'] as $item) {
+                if (!isset($item['admin'])) {
+                    continue;
+                }
+
+                $key = array_search($item['admin'], $adminServiceCodes, true);
+                if (false === $key) {
+                    continue;
+                }
+                unset($adminServiceCodes[$key]);
+
+                $groupLabelTranslated = $this->translator->trans($group['label'], [], $group['translation_domain']);
+
+                $adminRoles = array_merge($adminRoles, $this->getAdminRolesByAdminCode($item['admin'], $domain, $groupLabelTranslated, $groupCode));
             }
+        }
+
+        // admin with config "show_in_dashboard" set "false" does not have group
+        $defaultGroupLabelTranslated = $this->translator->trans('_', [], $domain);
+        $defaultGroupCode = '_';
+        foreach ($adminServiceCodes as $code) {
+            $adminRoles = array_merge($adminRoles, $this->getAdminRolesByAdminCode($code, $domain, $defaultGroupLabelTranslated, $defaultGroupCode));
+        }
+
+        return $adminRoles;
+    }
+
+    /**
+     * @return array<string, array<string, string|bool>>
+     *
+     * @phpstan-return array<string, Role>
+     */
+    private function getAdminRolesByAdminCode(string $code, ?string $domain = null, string $groupLabelTranslated = '_', string $groupCode = '_'): array
+    {
+        $adminRoles = [];
+        $admin = $this->pool->getInstance($code);
+        $securityHandler = $admin->getSecurityHandler();
+        $baseRole = $securityHandler->getBaseRole($admin);
+        $adminLabelTranslated = $admin->getTranslator()->trans($admin->getLabel() ?? '', [], $admin->getTranslationDomain());
+        $isMasterAdmin = $this->isMaster($admin);
+        foreach (array_keys($admin->getSecurityInformation()) as $key) {
+            $role = sprintf($baseRole, $key);
+            $adminRoles[$role] = [
+                'role' => $role,
+                'label' => $key,
+                'role_translated' => $this->translateRole($role, $domain),
+                'is_granted' => $isMasterAdmin || $this->authorizationChecker->isGranted($role),
+                'admin_label' => $adminLabelTranslated,
+                'admin_code' => $code,
+                'group_label' => $groupLabelTranslated,
+                'group_code' => $groupCode,
+            ];
         }
 
         return $adminRoles;

--- a/src/Security/RolesBuilder/AdminRolesBuilder.php
+++ b/src/Security/RolesBuilder/AdminRolesBuilder.php
@@ -100,11 +100,9 @@ final class AdminRolesBuilder implements AdminRolesBuilderInterface
             }
         }
 
-        // admin with config "show_in_dashboard" set "false" does not have group
-        $defaultGroupLabelTranslated = $this->translator->trans('_', [], $domain);
-        $defaultGroupCode = '_';
+        // admin with config "show_in_dashboard" set "false" or group not set, does not have group
         foreach ($adminServiceCodes as $code) {
-            $adminRoles = array_merge($adminRoles, $this->getAdminRolesByAdminCode($code, $domain, $defaultGroupLabelTranslated, $defaultGroupCode));
+            $adminRoles = array_merge($adminRoles, $this->getAdminRolesByAdminCode($code, $domain));
         }
 
         return $adminRoles;
@@ -115,7 +113,7 @@ final class AdminRolesBuilder implements AdminRolesBuilderInterface
      *
      * @phpstan-return array<string, Role>
      */
-    private function getAdminRolesByAdminCode(string $code, ?string $domain = null, string $groupLabelTranslated = '_', string $groupCode = '_'): array
+    private function getAdminRolesByAdminCode(string $code, ?string $domain = null, string $groupLabelTranslated = '', string $groupCode = ''): array
     {
         $adminRoles = [];
         $admin = $this->pool->getInstance($code);

--- a/src/Security/RolesBuilder/RolesBuilderInterface.php
+++ b/src/Security/RolesBuilder/RolesBuilderInterface.php
@@ -21,7 +21,10 @@ namespace Sonata\UserBundle\Security\RolesBuilder;
  *     role_translated: string,
  *     is_granted: boolean,
  *     label?: string,
- *     admin_label?: string
+ *     admin_label?: string,
+ *     admin_code?: string,
+ *     group_label?: string,
+ *     group_code?: string
  * }
  */
 interface RolesBuilderInterface

--- a/src/Twig/RolesMatrixExtension.php
+++ b/src/Twig/RolesMatrixExtension.php
@@ -71,14 +71,15 @@ final class RolesMatrixExtension extends AbstractExtension
     {
         $groupedRoles = [];
         foreach ($this->rolesBuilder->getRoles() as $role => $attributes) {
-            if (!isset($attributes['admin_label'])) {
+            if (!isset($attributes['admin_code'])) {
                 continue;
             }
 
-            $groupedRoles[$attributes['admin_label']][$role] = $attributes;
+            $groupCode = $attributes['group_code'] ?? '_';
+            $groupedRoles[$groupCode][$attributes['admin_code']][$role] = $attributes;
             foreach ($form->getIterator() as $child) {
                 if ($child->vars['value'] === $role) {
-                    $groupedRoles[$attributes['admin_label']][$role]['form'] = $child;
+                    $groupedRoles[$groupCode][$attributes['admin_code']][$role]['form'] = $child;
                 }
             }
         }

--- a/src/Twig/RolesMatrixExtension.php
+++ b/src/Twig/RolesMatrixExtension.php
@@ -72,7 +72,19 @@ final class RolesMatrixExtension extends AbstractExtension
         $groupedRoles = [];
         foreach ($this->rolesBuilder->getRoles() as $role => $attributes) {
             if (!isset($attributes['admin_code'])) {
-                continue;
+                // NEXT_MAJOR: Remove those lines and uncomment the last one.
+                @trigger_error(
+                    'Not setting the "admin_code" attribute to admin role is deprecated since sonata-project/user-bundle 5.5'
+                    .' and without it admin role will be skipped in version 6.0.',
+                    \E_USER_DEPRECATED
+                );
+
+                if (!isset($attributes['admin_label'])) {
+                    continue;
+                }
+
+                $attributes['admin_code'] = $attributes['admin_label'];
+                // continue;
             }
 
             $groupCode = $attributes['group_code'] ?? '';

--- a/src/Twig/RolesMatrixExtension.php
+++ b/src/Twig/RolesMatrixExtension.php
@@ -75,7 +75,7 @@ final class RolesMatrixExtension extends AbstractExtension
                 continue;
             }
 
-            $groupCode = $attributes['group_code'] ?? '_';
+            $groupCode = $attributes['group_code'] ?? '';
             $groupedRoles[$groupCode][$attributes['admin_code']][$role] = $attributes;
             foreach ($form->getIterator() as $child) {
                 if ($child->vars['value'] === $role) {

--- a/src/Twig/RolesMatrixExtension.php
+++ b/src/Twig/RolesMatrixExtension.php
@@ -73,15 +73,15 @@ final class RolesMatrixExtension extends AbstractExtension
         foreach ($this->rolesBuilder->getRoles() as $role => $attributes) {
             if (!isset($attributes['admin_code'])) {
                 // NEXT_MAJOR: Remove those lines and uncomment the last one.
+                if (!isset($attributes['admin_label'])) {
+                    continue;
+                }
+
                 @trigger_error(
                     'Not setting the "admin_code" attribute to admin role is deprecated since sonata-project/user-bundle 5.5'
                     .' and without it admin role will be skipped in version 6.0.',
                     \E_USER_DEPRECATED
                 );
-
-                if (!isset($attributes['admin_label'])) {
-                    continue;
-                }
 
                 $attributes['admin_code'] = $attributes['admin_label'];
                 // continue;

--- a/tests/Security/RolesBuilder/AdminRolesBuilderTest.php
+++ b/tests/Security/RolesBuilder/AdminRolesBuilderTest.php
@@ -72,7 +72,19 @@ final class AdminRolesBuilderTest extends TestCase
         $container = new Container();
         $container->set('sonata.admin.bar', $this->admin);
 
-        $this->pool = new Pool($container, ['sonata.admin.bar']);
+        $adminGroups = [
+            'bar' => [
+                'label' => 'Bar',
+                'translation_domain' => '',
+                'icon' => '<i class="fas fa-edit"></i>',
+                'items' => [['admin' => 'sonata.admin.bar', 'roles' => [], 'route_absolute' => false, 'route_params' => []]],
+                'keep_open' => false,
+                'on_top' => false,
+                'roles' => [],
+            ],
+        ];
+
+        $this->pool = new Pool($container, ['sonata.admin.bar'], $adminGroups);
         $this->configuration = new SonataConfiguration('title', 'logo', [
             'confirm_exit' => true,
             'default_admin_route' => 'show',
@@ -170,6 +182,9 @@ final class AdminRolesBuilderTest extends TestCase
                 'role_translated' => 'ROLE_SONATA_FOO_GUEST',
                 'is_granted' => false,
                 'admin_label' => 'Foo',
+                'admin_code' => 'sonata.admin.bar',
+                'group_label' => 'Foo',
+                'group_code' => 'bar',
             ],
             'ROLE_SONATA_FOO_STAFF' => [
                 'role' => 'ROLE_SONATA_FOO_STAFF',
@@ -177,6 +192,9 @@ final class AdminRolesBuilderTest extends TestCase
                 'role_translated' => 'ROLE_SONATA_FOO_STAFF',
                 'is_granted' => false,
                 'admin_label' => 'Foo',
+                'admin_code' => 'sonata.admin.bar',
+                'group_label' => 'Foo',
+                'group_code' => 'bar',
             ],
             'ROLE_SONATA_FOO_EDITOR' => [
                 'role' => 'ROLE_SONATA_FOO_EDITOR',
@@ -184,6 +202,9 @@ final class AdminRolesBuilderTest extends TestCase
                 'role_translated' => 'ROLE_SONATA_FOO_EDITOR',
                 'is_granted' => false,
                 'admin_label' => 'Foo',
+                'admin_code' => 'sonata.admin.bar',
+                'group_label' => 'Foo',
+                'group_code' => 'bar',
             ],
             'ROLE_SONATA_FOO_ADMIN' => [
                 'role' => 'ROLE_SONATA_FOO_ADMIN',
@@ -191,6 +212,9 @@ final class AdminRolesBuilderTest extends TestCase
                 'role_translated' => 'ROLE_SONATA_FOO_ADMIN',
                 'is_granted' => false,
                 'admin_label' => 'Foo',
+                'admin_code' => 'sonata.admin.bar',
+                'group_label' => 'Foo',
+                'group_code' => 'bar',
             ],
         ];
 

--- a/tests/Security/RolesBuilder/AdminRolesBuilderTest.php
+++ b/tests/Security/RolesBuilder/AdminRolesBuilderTest.php
@@ -117,7 +117,9 @@ final class AdminRolesBuilderTest extends TestCase
 
     public function testGetPermissionLabels(): void
     {
-        $this->translator->method('trans');
+        $this->translator->method('trans')->willReturnCallback(
+            static fn (string $key): string => $key
+        );
 
         $this->securityHandler->method('getBaseRole')
             ->willReturn('ROLE_SONATA_FOO_%s');

--- a/tests/Twig/RolesMatrixExtensionTest.php
+++ b/tests/Twig/RolesMatrixExtensionTest.php
@@ -253,6 +253,67 @@ final class RolesMatrixExtensionTest extends TestCase
         $rolesMatrixExtension->renderMatrix($this->environment, $this->formView);
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
+    public function testRenderMatrixWithoutAdminCode(): void
+    {
+        $roles = [
+            'BASE_ROLE_FOO_EDIT' => [
+                'role' => 'BASE_ROLE_FOO_EDIT',
+                'label' => 'EDIT',
+                'role_translated' => 'ROLE FOO TRANSLATED',
+                'admin_label' => 'fooadmin',
+                'is_granted' => true,
+            ],
+        ];
+        $this->rolesBuilder
+            ->expects(static::once())
+            ->method('getRoles')
+            ->willReturn($roles);
+
+        $this->rolesBuilder
+            ->expects(static::once())
+            ->method('getPermissionLabels')
+            ->willReturn(['EDIT', 'CREATE']);
+
+        $form = new FormView();
+        $form->vars['value'] = 'BASE_ROLE_FOO_EDIT';
+
+        $this->formView
+            ->expects(static::once())
+            ->method('getIterator')
+            ->willReturn(new \ArrayIterator([$form]));
+
+        $this->environment
+            ->expects(static::once())
+            ->method('render')
+            ->with('@SonataUser/Form/roles_matrix.html.twig', [
+                'grouped_roles' => [
+                    '' => [
+                        'fooadmin' => [
+                            'BASE_ROLE_FOO_EDIT' => [
+                                'role' => 'BASE_ROLE_FOO_EDIT',
+                                'label' => 'EDIT',
+                                'role_translated' => 'ROLE FOO TRANSLATED',
+                                'admin_label' => 'fooadmin',
+                                'is_granted' => true,
+                                'admin_code' => 'fooadmin',
+                                'form' => $form,
+                            ],
+                        ],
+                    ],
+                ],
+                'permission_labels' => ['EDIT', 'CREATE'],
+            ])
+            ->willReturn('');
+
+        $rolesMatrixExtension = new RolesMatrixExtension($this->rolesBuilder);
+        $rolesMatrixExtension->renderMatrix($this->environment, $this->formView);
+    }
+
     public function testRenderMatrixFormVarsNotSet(): void
     {
         $roles = [

--- a/tests/Twig/RolesMatrixExtensionTest.php
+++ b/tests/Twig/RolesMatrixExtensionTest.php
@@ -201,6 +201,9 @@ final class RolesMatrixExtensionTest extends TestCase
                 'role_translated' => 'ROLE FOO TRANSLATED',
                 'admin_label' => 'fooadmin',
                 'is_granted' => true,
+                'admin_code' => 'fooadmin',
+                'group_label' => 'BarGroup',
+                'group_code' => 'bargroup',
             ],
         ];
         $this->rolesBuilder
@@ -226,14 +229,19 @@ final class RolesMatrixExtensionTest extends TestCase
             ->method('render')
             ->with('@SonataUser/Form/roles_matrix.html.twig', [
                 'grouped_roles' => [
-                    'fooadmin' => [
-                        'BASE_ROLE_FOO_EDIT' => [
-                            'role' => 'BASE_ROLE_FOO_EDIT',
-                            'label' => 'EDIT',
-                            'role_translated' => 'ROLE FOO TRANSLATED',
-                            'admin_label' => 'fooadmin',
-                            'is_granted' => true,
-                            'form' => $form,
+                    'bargroup' => [
+                        'fooadmin' => [
+                            'BASE_ROLE_FOO_EDIT' => [
+                                'role' => 'BASE_ROLE_FOO_EDIT',
+                                'label' => 'EDIT',
+                                'role_translated' => 'ROLE FOO TRANSLATED',
+                                'admin_label' => 'fooadmin',
+                                'is_granted' => true,
+                                'admin_code' => 'fooadmin',
+                                'group_label' => 'BarGroup',
+                                'group_code' => 'bargroup',
+                                'form' => $form,
+                            ],
                         ],
                     ],
                 ],
@@ -254,6 +262,9 @@ final class RolesMatrixExtensionTest extends TestCase
                 'role_translated' => 'ROLE FOO TRANSLATED',
                 'admin_label' => 'fooadmin',
                 'is_granted' => true,
+                'admin_code' => 'fooadmin',
+                'group_label' => 'BarGroup',
+                'group_code' => 'bargroup',
             ],
         ];
         $this->rolesBuilder
@@ -279,13 +290,18 @@ final class RolesMatrixExtensionTest extends TestCase
             ->method('render')
             ->with('@SonataUser/Form/roles_matrix.html.twig', [
                 'grouped_roles' => [
-                    'fooadmin' => [
-                        'BASE_ROLE_FOO_%s' => [
-                            'role' => 'BASE_ROLE_FOO_EDIT',
-                            'label' => 'EDIT',
-                            'role_translated' => 'ROLE FOO TRANSLATED',
-                            'admin_label' => 'fooadmin',
-                            'is_granted' => true,
+                    'bargroup' => [
+                        'fooadmin' => [
+                            'BASE_ROLE_FOO_%s' => [
+                                'role' => 'BASE_ROLE_FOO_EDIT',
+                                'label' => 'EDIT',
+                                'role_translated' => 'ROLE FOO TRANSLATED',
+                                'admin_label' => 'fooadmin',
+                                'is_granted' => true,
+                                'admin_code' => 'fooadmin',
+                                'group_label' => 'BarGroup',
+                                'group_code' => 'bargroup',
+                            ],
                         ],
                     ],
                 ],


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Admin roles attribute "admin_label" set admin translation domain
Roles matrix group by admin and admin group
Admin roles sort by admin config and group config
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 5.x is for everything backwards compatible, like patches, features and deprecation notices
    - 6.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/5.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1583.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataUserBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- RolesBuilder: add attributes "admin_code", "group_label", "group_code".
### Fixed
- Fix RolesBuilder attribute "admin_label" set admin translation domain
- Fix roles matrix attribute "admin_label" can repeat not even in different groups but also in the same group
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
