### PR TITLE
Allow doctrine annotations 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
         "phpstan/phpstan-symfony": "^1.0",
         "phpunit/phpunit": "^9.5",
         "psalm/plugin-phpunit": "^0.17",
-        "psalm/plugin-symfony": "^3.0",
+        "psalm/plugin-symfony": "^4.0",
         "rector/rector": "^0.15",
         "sonata-project/admin-bundle": "^4.20",
         "sonata-project/block-bundle": "^4.11",

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
     },
     "require-dev": {
         "dama/doctrine-test-bundle": "^6.7",
-        "doctrine/annotations": "^1.13.2",
+        "doctrine/annotations": "^1.13.2 || ^2.0",
         "doctrine/doctrine-bundle": "^2.3.2",
         "doctrine/mongodb-odm": "^2.2",
         "doctrine/orm": "^2.9",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 5.x is for everything backwards compatible, like patches, features and deprecation notices
    - 6.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/5.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this only affects php-cs-fixer.