### PR TITLE
Check if user has access to its profile before generating link

### DIFF
--- a/src/Resources/views/Admin/Core/user_block.html.twig
+++ b/src/Resources/views/Admin/Core/user_block.html.twig
@@ -27,9 +27,10 @@ file that was distributed with this source code.
         </li>
 
         <li class="user-footer">
+            {% if sonata_user.userAdmin.hasAccess('edit', app.user) or sonata_user.userAdmin.hasAccess('show', app.user) %}
             <div class="pull-left">
                 <a href="{{
-                    sonata_user.userAdmin.isGranted('EDIT', app.user) ?
+                    sonata_user.userAdmin.hasAccess('edit', app.user) ?
                         sonata_user.userAdmin.generateUrl('edit', {id: app.user.id}) :
                         sonata_user.userAdmin.generateUrl('show', {id: app.user.id})
                 }}" class="btn btn-default btn-flat">
@@ -37,6 +38,7 @@ file that was distributed with this source code.
                     {{ 'user_block_profile'|trans({}, 'SonataUserBundle') }}
                 </a>
             </div>
+            {% endif %}
 
             <div class="pull-right">
                 <a href="{{ _logout_uri }}" class="btn btn-default btn-flat">


### PR DESCRIPTION

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 5.x is for everything backwards compatible, like patches, features and deprecation notices
    - 6.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/5.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is bc.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1591.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataUserBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Fixed
- Generate the profile link only if the logged user has access to it (edit or show permissions)
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
