### PR TITLE
fix(#1623): fix xmlns and xmlns:xsi values in BaseUser.mongodb.xml

### DIFF
--- a/src/Resources/config/doctrine/BaseUser.mongodb.xml
+++ b/src/Resources/config/doctrine/BaseUser.mongodb.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<doctrine-mongo-mapping xmlns="https://doctrine-project.org/schemas/odm/doctrine-mongo-mapping" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping https://www.doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
+<doctrine-mongo-mapping xmlns="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/odm/doctrine-mongo-mapping https://www.doctrine-project.org/schemas/odm/doctrine-mongo-mapping.xsd">
     <mapped-superclass name="Sonata\UserBundle\Document\BaseUser">
         <field name="username" type="string"/>
         <field name="usernameCanonical" type="string"/>


### PR DESCRIPTION
## Subject

Replace `https` by `http` in  `xmlns` and `xmlns:xsi` attribute values in `src/Resources/config/doctrine/BaseUser.mongodb.xml to fix XML validation errors.

I am targeting this branch, because the issue this pull request fixes appeared in 5.6.0 and is not fixed by 5.6.1. This should be the correct XML for passing validation.

Closes #1623.
Closes #1612.

## Changelog

```markdown
### Fixed
- XML validation of MongoDB ODM mapping.
```