### PR TITLE
UserListener: use event_listener instead of subscriber

### DIFF
--- a/src/Listener/UserListener.php
+++ b/src/Listener/UserListener.php
@@ -27,6 +27,8 @@ use Sonata\UserBundle\Util\CanonicalFieldsUpdaterInterface;
 
 /**
  * @internal
+ *
+ * NEXT_MAJOR: do not implement EventSubscriber interface anymore
  */
 final class UserListener implements EventSubscriber
 {
@@ -36,6 +38,9 @@ final class UserListener implements EventSubscriber
     ) {
     }
 
+    /**
+     * NEXT_MAJOR: remove this method.
+     */
     public function getSubscribedEvents(): array
     {
         return [

--- a/src/Resources/config/mongodb.php
+++ b/src/Resources/config/mongodb.php
@@ -28,7 +28,12 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ])
 
         ->set('sonata.user.listener.user', UserListener::class)
-            ->tag('doctrine_mongodb.odm.event_subscriber')
+            ->tag('doctrine.event_listener', [
+                'event' => 'prePersist'
+            ])
+            ->tag('doctrine.event_listener', [
+                'event' => 'preUpdate'
+            ])
             ->args([
                 service('sonata.user.util.canonical_fields_updater'),
                 service('sonata.user.manager.user'),

--- a/src/Resources/config/mongodb.php
+++ b/src/Resources/config/mongodb.php
@@ -28,11 +28,11 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ])
 
         ->set('sonata.user.listener.user', UserListener::class)
-            ->tag('doctrine.event_listener', [
-                'event' => 'prePersist'
+            ->tag('doctrine_mongodb.odm.event_listener', [
+                'event' => 'prePersist',
             ])
-            ->tag('doctrine.event_listener', [
-                'event' => 'preUpdate'
+            ->tag('doctrine_mongodb.odm.event_listener', [
+                'event' => 'preUpdate',
             ])
             ->args([
                 service('sonata.user.util.canonical_fields_updater'),

--- a/src/Resources/config/orm.php
+++ b/src/Resources/config/orm.php
@@ -28,7 +28,12 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ])
 
         ->set('sonata.user.listener.user', UserListener::class)
-           ->tag('doctrine.event_subscriber')
+            ->tag('doctrine.event_listener', [
+                'event' => 'prePersist'
+            ])
+            ->tag('doctrine.event_listener', [
+                'event' => 'preUpdate'
+            ])
             ->args([
                 service('sonata.user.util.canonical_fields_updater'),
                 service('sonata.user.manager.user'),

--- a/src/Resources/config/orm.php
+++ b/src/Resources/config/orm.php
@@ -29,10 +29,10 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
         ->set('sonata.user.listener.user', UserListener::class)
             ->tag('doctrine.event_listener', [
-                'event' => 'prePersist'
+                'event' => 'prePersist',
             ])
             ->tag('doctrine.event_listener', [
-                'event' => 'preUpdate'
+                'event' => 'preUpdate',
             ])
             ->args([
                 service('sonata.user.util.canonical_fields_updater'),


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 5.x is for everything backwards compatible, like patches, features and deprecation notices
    - 6.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/5.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because it should be without BC break?

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1650.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataUserBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Fixed
- Deprecation of Event Subscribers on Symfony 6.3. The UserListener now uses Event Listeners
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->


From Coverage testing, it seems that current phpunit test doesn't check the same for ODM too.
Do we need more Unit tests, that explicit test ODM?

* `doctrine.orm.entity_listener` would be more specific for ORM, but it seems something like that doesn't exist for ODM.