### PR TITLE
Use multiple options by default for `RolesMatrixType` form

### DIFF
--- a/src/Form/Type/RolesMatrixType.php
+++ b/src/Form/Type/RolesMatrixType.php
@@ -35,6 +35,7 @@ final class RolesMatrixType extends AbstractType
     {
         $resolver->setDefaults([
             'expanded' => true,
+            'multiple' => true,
             'choices' => function (Options $options, ?array $parentChoices): array {
                 if (null !== $parentChoices && [] !== $parentChoices) {
                     return [];

--- a/tests/Form/Type/RolesMatrixTypeTest.php
+++ b/tests/Form/Type/RolesMatrixTypeTest.php
@@ -58,6 +58,8 @@ final class RolesMatrixTypeTest extends TypeTestCase
         $choices = $options['choices'];
         static::assertCount(2, $choices);
         static::assertNotContains(UserInterface::ROLE_DEFAULT, $choices);
+        static::assertTrue($options['expanded']);
+        static::assertTrue($options['multiple']);
     }
 
     public function testDifferentExcludedRoles(): void


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Use multiple options by default for `RolesMatrixType` form

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 5.x is for everything backwards compatible, like patches, features and deprecation notices
    - 6.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/5.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this change seems to follow the natural use case for this form, where multiple options for the role matrix are allowed (rendered as checkboxes instead of radio buttons):
![Roles Matrix](https://raw.githubusercontent.com/sonata-project/SonataUserBundle/f97f6810017b6a3eb1d268c9b022f069aa8d33f4/docs/images/roles_matrix.png)

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataUserBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Added
- Default value `true` for the "multiple" option at `RolesMatrixType` form type

### Changed
- `RolesMatrixType` form type allows multiple values by default
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
