### PR TITLE
Compatibility with doctrine dbal 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         "dama/doctrine-test-bundle": "^7.0",
         "doctrine/doctrine-bundle": "^2.7",
         "doctrine/mongodb-odm": "^2.3",
-        "doctrine/orm": "^2.14",
+        "doctrine/orm": "^2.13 || ^3.0",
         "egulias/email-validator": "^3.1 || ^4.0",
         "friendsofphp/php-cs-fixer": "^3.4",
         "matthiasnoback/symfony-config-test": "^4.2",

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         "dama/doctrine-test-bundle": "^7.0",
         "doctrine/doctrine-bundle": "^2.7",
         "doctrine/mongodb-odm": "^2.3",
-        "doctrine/orm": "^2.13 || ^3.0",
+        "doctrine/orm": "^2.14 || ^3.0",
         "egulias/email-validator": "^3.1 || ^4.0",
         "friendsofphp/php-cs-fixer": "^3.4",
         "matthiasnoback/symfony-config-test": "^4.2",

--- a/docs/reference/installation.rst
+++ b/docs/reference/installation.rst
@@ -82,6 +82,7 @@ And then create the corresponding entity, ``src/Entity/SonataUserUser``::
     use Doctrine\DBAL\Types\Types;
     use Doctrine\ORM\Mapping as ORM;
     use Sonata\UserBundle\Entity\BaseUser;
+    // or `Sonata\UserBundle\Entity\BaseUser3` as BaseUser if you upgrade to doctrine/orm ^3
 
     #[ORM\Entity]
     #[ORM\Table(name: 'user__user')]

--- a/src/Entity/BaseUser3.php
+++ b/src/Entity/BaseUser3.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\UserBundle\Entity;
+
+use Sonata\UserBundle\Model\User as AbstractedUser;
+
+class BaseUser3 extends AbstractedUser
+{
+    public function prePersist(): void
+    {
+        $this->createdAt = new \DateTime();
+        $this->updatedAt = new \DateTime();
+    }
+
+    public function preUpdate(): void
+    {
+        $this->updatedAt = new \DateTime();
+    }
+}

--- a/src/Resources/config/doctrine/BaseUser.orm.xml
+++ b/src/Resources/config/doctrine/BaseUser.orm.xml
@@ -11,7 +11,7 @@
         <field name="lastLogin" column="last_login" type="datetime" nullable="true"/>
         <field name="confirmationToken" column="confirmation_token" type="string" length="180" unique="true" nullable="true"/>
         <field name="passwordRequestedAt" column="password_requested_at" type="datetime" nullable="true"/>
-        <field name="roles" column="roles" type="array"/>
+        <field name="roles" column="roles" type="json"/>
         <field name="createdAt" type="datetime" column="created_at"/>
         <field name="updatedAt" type="datetime" column="updated_at"/>
         <lifecycle-callbacks>

--- a/src/Resources/config/doctrine/BaseUser3.orm.xml
+++ b/src/Resources/config/doctrine/BaseUser3.orm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://doctrine-project.org/schemas/orm/doctrine-mapping https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
-    <mapped-superclass name="Sonata\UserBundle\Entity\BaseUser">
+    <mapped-superclass name="Sonata\UserBundle\Entity\BaseUser3">
         <field name="username" column="username" type="string" length="180"/>
         <field name="usernameCanonical" column="username_canonical" type="string" length="180" unique="true"/>
         <field name="email" column="email" type="string" length="180"/>
@@ -11,7 +11,7 @@
         <field name="lastLogin" column="last_login" type="datetime" nullable="true"/>
         <field name="confirmationToken" column="confirmation_token" type="string" length="180" unique="true" nullable="true"/>
         <field name="passwordRequestedAt" column="password_requested_at" type="datetime" nullable="true"/>
-        <field name="roles" column="roles" type="array"/>
+        <field name="roles" column="roles" type="json"/>
         <field name="createdAt" type="datetime" column="created_at"/>
         <field name="updatedAt" type="datetime" column="updated_at"/>
         <lifecycle-callbacks>


### PR DESCRIPTION
## Compatibility with doctrine dbal 4

Just switching the deprecated array type to json - cf [Upgrade Guide](https://github.com/doctrine/dbal/blob/4.0.x/UPGRADE.md#bc-break-removed-array-and-object-column-types) 
 
I am targeting this branch, because it's a patch wich is not introducing bc break.

About BC Break, i am not sure, because it's required to update from unserialized to json encoded.
  
## Changelog
 
```markdown 
### Added
- BaseUser3 with roles mapped type as `json` to be compatible with ORM 3
``` 