### PR TITLE
Avoid Username/Email is passed as clear GET Parameter to CheckEmailAction on password reset process

### DIFF
--- a/src/Action/CheckEmailAction.php
+++ b/src/Action/CheckEmailAction.php
@@ -16,16 +16,102 @@ namespace Sonata\UserBundle\Action;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Twig\Environment;
+use TypeError;
 
 final class CheckEmailAction
 {
+
+    private Pool $adminPool;
+    private TemplateRegistryInterface $templateRegistry;
+    private int $tokenTtl;
+
+    /**
+     *  NEXT_MAJOR: Remove `$tokenTtlDeprecated` argument and only allow first types of arguments.
+     *
+     * @param Environment $twig
+     * @param Pool $adminPool
+     * @param TemplateRegistryInterface $templateRegistry
+     * @param int $tokenTtl
+     * @param null $tokenTtlDeprecated
+     */
     public function __construct(
         private Environment $twig,
-        private Pool $adminPool,
-        private TemplateRegistryInterface $templateRegistry,
-        private int $tokenTtl
+        Pool|UrlGeneratorInterface $adminPool,
+        TemplateRegistryInterface|Pool $templateRegistry,
+        int|TemplateRegistryInterface $tokenTtl,
+        ?int $tokenTtlDeprecated = null,
     ) {
+        // NEXT_MAJOR: Remove all checks and use constructor property promotion instead
+        if ($adminPool instanceof UrlGeneratorInterface) {
+            if (!$templateRegistry instanceof Pool) {
+                throw new \TypeError(sprintf(
+                    'Argument 3 passed to %s() must be an instance of %s, %s given.',
+                    __METHOD__,
+                    Pool::class,
+                    \get_class($templateRegistry)
+                ));
+            }
+            $this->adminPool = $templateRegistry;
+
+            if (!$tokenTtl instanceof TemplateRegistryInterface) {
+                throw new \TypeError(sprintf(
+                    'Argument 4 passed to %s() must be an instance of %s, %s given.',
+                    __METHOD__,
+                    TemplateRegistryInterface::class,
+                    \get_class($tokenTtl)
+                ));
+            }
+            $this->templateRegistry = $tokenTtl;
+
+            if (!is_int($tokenTtlDeprecated)) {
+                throw new \TypeError(sprintf(
+                    'Argument 5 passed to %s() must be type of %s, %s given.',
+                    __METHOD__,
+                    'integer',
+                    \gettype($tokenTtlDeprecated)
+                ));
+            }
+            $this->tokenTtl = $tokenTtlDeprecated;
+
+            @trigger_error(sprintf(
+                'Passing an instance of %s as argument 2 to "%s()" is deprecated since sonata-project/user-bundle 5.x and will only accept an instance of %s in version 6.0.',
+                UrlGeneratorInterface::class,
+                __METHOD__,
+                Pool::class
+            ), \E_USER_DEPRECATED);
+        } else {
+            $this->adminPool = $adminPool;
+            if (!$templateRegistry instanceof TemplateRegistryInterface) {
+                throw new \TypeError(sprintf(
+                    'Argument 3 passed to %s() must be an instance of %s, %s given.',
+                    __METHOD__,
+                    TemplateRegistryInterface::class,
+                    \get_class($templateRegistry)
+                ));
+            }
+            $this->templateRegistry = $templateRegistry;
+
+            if (!is_int($tokenTtl)) {
+                throw new \TypeError(sprintf(
+                    'Argument 4 passed to %s() must be type of %s, %s given.',
+                    __METHOD__,
+                    'integer',
+                    \gettype($tokenTtl)
+                ));
+            }
+            $this->tokenTtl = $tokenTtl;
+
+            if (null !== $tokenTtlDeprecated) {
+                throw new \TypeError(sprintf(
+                    'Argument 5 passed to %s() must be %s, %s given.',
+                    __METHOD__,
+                    'NULL',
+                    \gettype($tokenTtlDeprecated)
+                ));
+            }
+        }
     }
 
     public function __invoke(): Response

--- a/src/Action/CheckEmailAction.php
+++ b/src/Action/CheckEmailAction.php
@@ -15,32 +15,21 @@ namespace Sonata\UserBundle\Action;
 
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
-use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Twig\Environment;
 
 final class CheckEmailAction
 {
     public function __construct(
         private Environment $twig,
-        private UrlGeneratorInterface $urlGenerator,
         private Pool $adminPool,
         private TemplateRegistryInterface $templateRegistry,
         private int $tokenTtl
     ) {
     }
 
-    public function __invoke(Request $request): Response
+    public function __invoke(): Response
     {
-        $username = $request->query->get('username');
-
-        if (null === $username) {
-            // the user does not come from the sendEmail action
-            return new RedirectResponse($this->urlGenerator->generate('sonata_user_admin_resetting_request'));
-        }
-
         return new Response($this->twig->render('@SonataUser/Admin/Security/Resetting/checkEmail.html.twig', [
             'base_template' => $this->templateRegistry->getTemplate('layout'),
             'admin_pool' => $this->adminPool,

--- a/src/Action/RequestAction.php
+++ b/src/Action/RequestAction.php
@@ -66,9 +66,7 @@ final class RequestAction
                 $this->userManager->save($user);
             }
 
-            return new RedirectResponse($this->urlGenerator->generate('sonata_user_admin_resetting_check_email', [
-                'username' => $username,
-            ]));
+            return new RedirectResponse($this->urlGenerator->generate('sonata_user_admin_resetting_check_email'));
         }
 
         return new Response($this->twig->render('@SonataUser/Admin/Security/Resetting/request.html.twig', [

--- a/src/DependencyInjection/SonataUserExtension.php
+++ b/src/DependencyInjection/SonataUserExtension.php
@@ -121,7 +121,7 @@ final class SonataUserExtension extends Extension implements PrependExtensionInt
             ->replaceArgument(9, $config['retry_ttl']);
 
         $container->getDefinition('sonata.user.action.check_email')
-            ->replaceArgument(4, $config['token_ttl']);
+            ->replaceArgument(3, $config['token_ttl']);
 
         $container->getDefinition('sonata.user.action.reset')
             ->replaceArgument(8, $config['token_ttl']);

--- a/src/Resources/config/actions_resetting.php
+++ b/src/Resources/config/actions_resetting.php
@@ -39,7 +39,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->public()
         ->args([
             service('twig'),
-            service('router'),
             service('sonata.admin.pool'),
             service('sonata.admin.global_template_registry'),
             abstract_arg('token ttl'),


### PR DESCRIPTION
## Subject

Avoid Username/Email is passed as clear GET Parameter to CheckEmailAction on password reset process as discussed in https://github.com/sonata-project/SonataUserBundle/issues/1692

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 5.x is for everything backwards compatible, like patches, features and deprecation notices
    - 6.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/5.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this fixes an privacy issue and doesn't break anything.

Closes #1692.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataUserBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

### Removed
- After requesting new passwort the username isn't passed to CheckEmailAction anymode



