### PR TITLE
Fix #1731 Using User Bundle without Admin

### DIFF
--- a/src/DependencyInjection/SonataUserExtension.php
+++ b/src/DependencyInjection/SonataUserExtension.php
@@ -29,7 +29,14 @@ final class SonataUserExtension extends Extension implements PrependExtensionInt
 {
     public function prepend(ContainerBuilder $container): void
     {
-        if ($container->hasExtension('twig')) {
+        if (!$container->hasExtension('twig')) {
+            return;
+        }
+
+        $bundles = $container->getParameter('kernel.bundles');
+        \assert(\is_array($bundles));
+
+        if (isset($bundles['SonataAdminBundle'])) {
             // add custom form widgets
             $container->prependExtensionConfig('twig', ['form_themes' => ['@SonataUser/Form/form_admin_fields.html.twig']]);
         }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 5.x is for everything backwards compatible, like patches, features and deprecation notices
    - 6.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataUserBundle/blob/5.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is a patch, should also be applied to 4.x & 6.x.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #1731.

## Changelog

#1731 Fixed blocking admin twig extension dependency.

```markdown
### Added
- isset($bundles['SonataAdminBundle'] to load forme_theme only if needed.

### Changed
- updated SonataUserExtension.php 

### Deprecated
N/A

### Removed
N/A

### Fixed

Unknown "renderMatrix" function in "@SonataUser/Form/form_admin_fields.html.twig" at line 30.

### Security
N/A
```

## To do
- [ ] Patch v4.x & v6.x if merged;
